### PR TITLE
Add bumpversion support (and bump version to 2.1.2-dev)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 2.1.2-dev
+current_version = 2.1.2-alpha
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,5 +16,5 @@ replace = version = '{new_version}'
 [bumpversion:part:release]
 optional_value = gamma
 values = 
-	dev
+	alpha
 	gamma

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+commit = True
+message = Bump version {current_version} to {new_version}
+tag = False
+tag_name = {new_version}
+current_version = 2.1.2-dev
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
+serialize = 
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:src/sardana/release.py]
+search = version = '{current_version}'
+replace = version = '{new_version}'
+
+[bumpversion:part:release]
+optional_value = gamma
+values = 
+	dev
+	gamma

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -45,13 +45,19 @@ Release data for the taurus project. It contains the following members:
 #: the tarballs and RPMs made by distutils, so it's best to lowercase it.
 name = 'sardana'
 
-#: For versions with substrings (like 0.6.16.svn), use an extra . to separate
-#: the new substring. We have to avoid using either dashes or underscores,
-#: because bdist_rpm does not accept dashes (an RPM) convention, and
-#: bdist_deb does not accept underscores (a Debian convention).
-version_info = (2, 1, 1, 'rc', 0)
-version = '.'.join(map(str, version_info[:3]))
-revision = str(version_info[4])
+# we use semantic versioning (http://semver.org/) and we update it using the
+# bumpversion script (https://github.com/peritus/bumpversion)
+version = '2.1.2-dev'
+
+# generate version_info and revision (**deprecated** since version 2.1.2-dev).
+if '-' in version:
+    _v, _rel = version.split('-')
+else:
+    _v, _rel = version, ''
+
+_v = tuple([int(n) for n in _v.split('.')])
+version_info = _v + (_rel, 0)   # deprecated, do not use
+revision = str(version_info[4]) # deprecated, do not use
 
 description = "instrument control and data acquisition system"
 

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,9 +47,9 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '2.1.2-dev'
+version = '2.1.2-alpha'
 
-# generate version_info and revision (**deprecated** since version 2.1.2-dev).
+# generate version_info and revision (**deprecated** since v 2.1.2--alpha).
 if '-' in version:
     _v, _rel = version.split('-')
 else:

--- a/src/sardana/spock/ipython_00_10/genutils.py
+++ b/src/sardana/spock/ipython_00_10/genutils.py
@@ -713,7 +713,7 @@ def check_for_upgrade(ipy_profile_file, ipythondir, session, profile):
     spock_profile_ver = translate_version_str2int(spock_profile_ver_str)
     
     if spocklib_ver == spock_profile_ver and \
-            spock_profile_ver_str.find("-dev") == -1:
+            spock_profile_ver_str.find("-alpha") == -1:
         return
     if spocklib_ver < spock_profile_ver:
         print '%sYour spock profile (%s) is newer than your spock version ' \

--- a/src/sardana/spock/ipython_00_10/genutils.py
+++ b/src/sardana/spock/ipython_00_10/genutils.py
@@ -133,7 +133,9 @@ def spock_input(prompt='',  ps2='... '):
 def translate_version_str2int(version_str):
     """Translates a version string in format x[.y[.z[...]]] into a 000000 number"""
     import math
-    parts = version_str.split('.')
+    # Get the current version number ignoring the release part ("-dev")
+    num_version_str = version_str.split('-')[0]
+    parts = num_version_str.split('.')
     i, v, l = 0, 0, len(parts)
     if not l: return v
     while i<3:
@@ -710,7 +712,8 @@ def check_for_upgrade(ipy_profile_file, ipythondir, session, profile):
     spocklib_ver = translate_version_str2int(release.version)
     spock_profile_ver = translate_version_str2int(spock_profile_ver_str)
     
-    if spocklib_ver == spock_profile_ver:
+    if spocklib_ver == spock_profile_ver and \
+            spock_profile_ver_str.find("-dev") == -1:
         return
     if spocklib_ver < spock_profile_ver:
         print '%sYour spock profile (%s) is newer than your spock version ' \

--- a/src/sardana/spock/ipython_00_10/genutils.py
+++ b/src/sardana/spock/ipython_00_10/genutils.py
@@ -66,7 +66,7 @@ from taurus.core.util.codecs import CodecFactory
 
 from sardana.spock import exception
 from sardana.spock import colors
-from sardana.spock import release
+from sardana import release
 
 arg_split = IPython.iplib.arg_split
 page = IPython.genutils.page

--- a/src/sardana/spock/ipython_00_10/genutils.py
+++ b/src/sardana/spock/ipython_00_10/genutils.py
@@ -133,7 +133,7 @@ def spock_input(prompt='',  ps2='... '):
 def translate_version_str2int(version_str):
     """Translates a version string in format x[.y[.z[...]]] into a 000000 number"""
     import math
-    # Get the current version number ignoring the release part ("-dev")
+    # Get the current version number ignoring the release part ("-alpha")
     num_version_str = version_str.split('-')[0]
     parts = num_version_str.split('.')
     i, v, l = 0, 0, len(parts)

--- a/src/sardana/spock/ipython_00_11/genutils.py
+++ b/src/sardana/spock/ipython_00_11/genutils.py
@@ -149,7 +149,9 @@ def spock_input(prompt='',  ps2='... '):
 def translate_version_str2int(version_str):
     """Translates a version string in format x[.y[.z[...]]] into a 000000 number"""
     import math
-    parts = version_str.split('.')
+    # Get the current version number ignoring the release part ("-dev")
+    num_version_str = version_str.split('-')[0]
+    parts = num_version_str.split('.')
     i, v, l = 0, 0, len(parts)
     if not l: return v
     while i<3:
@@ -709,7 +711,8 @@ def check_for_upgrade(ipy_profile_dir):
     spocklib_ver = translate_version_str2int(release.version)
     spock_profile_ver = translate_version_str2int(spock_profile_ver_str)
 
-    if spocklib_ver == spock_profile_ver:
+    if spocklib_ver == spock_profile_ver and \
+            spock_profile_ver_str.find("-dev") == -1:
         return
     if spocklib_ver < spock_profile_ver:
         print '%sYour spock profile (%s) is newer than your spock version ' \

--- a/src/sardana/spock/ipython_00_11/genutils.py
+++ b/src/sardana/spock/ipython_00_11/genutils.py
@@ -712,7 +712,7 @@ def check_for_upgrade(ipy_profile_dir):
     spock_profile_ver = translate_version_str2int(spock_profile_ver_str)
 
     if spocklib_ver == spock_profile_ver and \
-            spock_profile_ver_str.find("-dev") == -1:
+            spock_profile_ver_str.find("-alpha") == -1:
         return
     if spocklib_ver < spock_profile_ver:
         print '%sYour spock profile (%s) is newer than your spock version ' \

--- a/src/sardana/spock/ipython_00_11/genutils.py
+++ b/src/sardana/spock/ipython_00_11/genutils.py
@@ -149,7 +149,7 @@ def spock_input(prompt='',  ps2='... '):
 def translate_version_str2int(version_str):
     """Translates a version string in format x[.y[.z[...]]] into a 000000 number"""
     import math
-    # Get the current version number ignoring the release part ("-dev")
+    # Get the current version number ignoring the release part ("-alpha")
     num_version_str = version_str.split('-')[0]
     parts = num_version_str.split('.')
     i, v, l = 0, 0, len(parts)

--- a/src/sardana/spock/ipython_00_11/genutils.py
+++ b/src/sardana/spock/ipython_00_11/genutils.py
@@ -79,7 +79,7 @@ from taurus.external.qt import Qt
 
 from sardana.spock import exception
 from sardana.spock import colors
-from sardana.spock import release
+from sardana import release
 
 SpockTermColors = colors.TermColors
 

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -86,7 +86,7 @@ from taurus.external.qt import Qt
 
 from sardana.spock import exception
 from sardana.spock import colors
-from sardana.spock import release
+from sardana import release
 
 SpockTermColors = colors.TermColors
 

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -733,7 +733,7 @@ def check_for_upgrade(ipy_profile_dir):
     spock_profile_ver = translate_version_str2int(spock_profile_ver_str)
 
     if spocklib_ver == spock_profile_ver and \
-            spock_profile_ver_str.find("-dev") == -1:
+            spock_profile_ver_str.find("-alpha") == -1:
         return
     if spocklib_ver < spock_profile_ver:
         print '%sYour spock profile (%s) is newer than your spock version ' \

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -156,7 +156,9 @@ def spock_input(prompt='',  ps2='... '):
 def translate_version_str2int(version_str):
     """Translates a version string in format x[.y[.z[...]]] into a 000000 number"""
     import math
-    parts = version_str.split('.')
+    # Get the current version number ignoring the release part ("-dev")
+    num_version_str = version_str.split('-')[0]
+    parts = num_version_str.split('.')
     i, v, l = 0, 0, len(parts)
     if not l: return v
     while i<3:
@@ -730,7 +732,8 @@ def check_for_upgrade(ipy_profile_dir):
     spocklib_ver = translate_version_str2int(release.version)
     spock_profile_ver = translate_version_str2int(spock_profile_ver_str)
 
-    if spocklib_ver == spock_profile_ver:
+    if spocklib_ver == spock_profile_ver and \
+            spock_profile_ver_str.find("-dev") == -1:
         return
     if spocklib_ver < spock_profile_ver:
         print '%sYour spock profile (%s) is newer than your spock version ' \

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -156,7 +156,7 @@ def spock_input(prompt='',  ps2='... '):
 def translate_version_str2int(version_str):
     """Translates a version string in format x[.y[.z[...]]] into a 000000 number"""
     import math
-    # Get the current version number ignoring the release part ("-dev")
+    # Get the current version number ignoring the release part ("-alpha")
     num_version_str = version_str.split('-')[0]
     parts = num_version_str.split('.')
     i, v, l = 0, 0, len(parts)

--- a/src/sardana/spock/release.py
+++ b/src/sardana/spock/release.py
@@ -24,6 +24,11 @@
 ##
 ##############################################################################
 
+#### DEPRECATED MODULE!!!!
+# This module is deprecated avoid to use anything from it.
+# Use sardana.release module instead
+####
+
 """Release data for the Spock project.
 """
 


### PR DESCRIPTION
Add bumpversion configuration to update the version using the
bumpversion script from https://github.com/peritus/bumpversion

Deprecate the version_info and revision variables from the
sardana.release module.