### PR TITLE
HklController: Forcing read position from hardware

### DIFF
--- a/src/sardana/pool/poolcontrollers/HklPseudoMotorController.py
+++ b/src/sardana/pool/poolcontrollers/HklPseudoMotorController.py
@@ -763,7 +763,7 @@ class DiffracBasis(PseudoMotorController):
         motor_position = []
         for i in range(0, self.nb_ph_axes):
             motor = self.GetMotor(i)
-            motor_position.append(motor.position.value)
+            motor_position.append(motor.get_position(cache=False).value)
         self.geometry.axis_values_set(motor_position, USER)
             
         curr_physical_pos = self.geometry.axis_values_get(USER)
@@ -823,7 +823,7 @@ class DiffracBasis(PseudoMotorController):
         motor_position = []
         for i in range(0, self.nb_ph_axes):
             motor = self.GetMotor(i)
-            motor_position.append(motor.position.value)
+            motor_position.append(motor.get_position(cache=False).value)
         self.geometry.axis_values_set(motor_position, USER)
         newref = self.sample.add_reflection(
             self.geometry, self.detector, value[0], value[1], value[2])


### PR DESCRIPTION
The physical positions used for updating the hkl geometry were taking from cache, this could be
a problem if  the physical motors are moved outside from sardana. This PR forces the readout to
be done always from the hardware.