### PR TITLE
New ParamRepeat interface in spock

### DIFF
--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -333,8 +333,8 @@ execution time.
 The repeat parameter definition allows to:
 
     - restrict the minimum and/or maximum number of repetitions
-    - nest repeat parameters inside of another repeat parameters [#f3]_
-    - define multiple repeat parameters in the same macro [#f3]_
+    - nest repeat parameters inside of another repeat parameters
+    - define multiple repeat parameters in the same macro
 
 Repeat parameter values are passed to the macro function in the form of a list.
 If the repeat parameter definition contains just one member it is a plain list
@@ -596,12 +596,16 @@ parameters with different *flavors*:
         self.execMacro('mv', [[motor.getName(), '0']])
         self.execMacro('mv', motor.getName(), '0') # backwards compatibility - see note
 
-    * parameters as space separated string (this is not compatible with multiple
-      or nested repeat parameters, furthermore the repeat parameter must be the last one)::
+    * parameters as space separated string::
 
         self.execMacro('ascan %s 0 100 10 0.2' % motor.getName())
-        self.execMacro('mv %s 0' % motor.getName())
-
+        self.execMacro('mv [[%s 0]]' % motor.getName()) 
+        self.execMacro('mv [%s 0]' % motor.getName()) # simplified interface
+        self.execMacro('mv %s 0' % motor.getName()) # backwards compatibility - see note
+        self.execMacro('mv [[%s 0][%s 20]]' % (motor.getName(), motor2.getName()))
+        self.execMacro('mv [%s 0 %s 20]' % (motor.getName(), motor2.getName())) # simplified interface
+        self.execMacro('mv %s 0 %s 20' % (motor.getName(), motor2.getName())) # backwards compatibility - see note
+      
     * parameters as concrete types::
 
         self.execMacro(['ascan', motor, 0, 100, 10, 0.2])
@@ -613,7 +617,9 @@ parameters with different *flavors*:
     use :ref:`repeat parameters <sardana-macro-repeat-parameters>`.
     From Sardana 2.0 the repeat parameter values must be passed as lists of
     items. An item of a repeat parameter containing more than one member is a
-    list. In case when a macro defines only one repeat parameter
+    list. In order to simplify the interface the use of the brackets closing each
+    repetition of a ParamRepeat can be skipped.
+    In case when a macro defines only one repeat parameter
     and it is the last parameter, for the backwards compatibility reasons, the
     plain list of items' members is allowed.
 
@@ -1249,9 +1255,6 @@ value but also the ranges so it is safe to change them if necessary.
 
 .. [#f2] To check which version of Python_ you are using type on the command
          line ``python -c "import sys; sys.stdout.write(sys.version)"``
-
-.. [#f3] Currently only GUI macro clients (*macroexecutor* or *sequencer*)
-       are compatible with this kind of repeat parameters usage.
 
 .. |input_integer| image:: ../../_static/macro_input_integer.png
     :align: middle

--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -600,10 +600,8 @@ parameters with different *flavors*:
 
         self.execMacro('ascan %s 0 100 10 0.2' % motor.getName())
         self.execMacro('mv [[%s 0]]' % motor.getName()) 
-        self.execMacro('mv [%s 0]' % motor.getName()) # simplified interface
         self.execMacro('mv %s 0' % motor.getName()) # backwards compatibility - see note
         self.execMacro('mv [[%s 0][%s 20]]' % (motor.getName(), motor2.getName()))
-        self.execMacro('mv [%s 0 %s 20]' % (motor.getName(), motor2.getName())) # simplified interface
         self.execMacro('mv %s 0 %s 20' % (motor.getName(), motor2.getName())) # backwards compatibility - see note
       
     * parameters as concrete types::
@@ -617,8 +615,7 @@ parameters with different *flavors*:
     use :ref:`repeat parameters <sardana-macro-repeat-parameters>`.
     From Sardana 2.0 the repeat parameter values must be passed as lists of
     items. An item of a repeat parameter containing more than one member is a
-    list. In order to simplify the interface the use of the brackets closing each
-    repetition of a ParamRepeat can be skipped.
+    list.
     In case when a macro defines only one repeat parameter
     and it is the last parameter, for the backwards compatibility reasons, the
     plain list of items' members is allowed.

--- a/src/sardana/macroserver/macros/examples/parameters.py
+++ b/src/sardana/macroserver/macros/examples/parameters.py
@@ -154,7 +154,7 @@ class pt6(Macro):
 class pt7(Macro):
     """Macro with a list of pair Motor,Float.
     Usages from Spock, ex.:
-    pt7 [[mot1 1][mot2 3]]
+    pt7 [[mot1 1] [mot2 3]]
     pt7 mot1 1 mot2 3
     """
 
@@ -170,10 +170,10 @@ class pt7(Macro):
 class pt7d1(Macro):
     """Macro with a list of pair Motor,Float. Default value for last ParamRepeat element.
     Usages from Spock, ex.:
-    pt7d1 [[mot1 1][mot2 3]]
+    pt7d1 [[mot1 1] [mot2 3]]
     pt7d1 mot1 1 mot2 3
     Using default value, ex.:
-    pt7d1 [[mot1][mot2 3]] # at any repetition
+    pt7d1 [[mot1] [mot2 3]] # at any repetition
     
     """
 
@@ -190,10 +190,10 @@ class pt7d1(Macro):
 class pt7d2(Macro):
     """Macro with a list of pair Motor,Float. Default value for both ParamRepeat elements.
     Usages from Spock, ex.:
-    pt7d2 [[mot1 1][mot2 3]]
+    pt7d2 [[mot1 1] [mot2 3]]
     pt7d2 mot1 1 mot2 3
     Using both default values, ex.:
-    pt7d2 [[][mot2 3][]] # at any repetition
+    pt7d2 [[] [mot2 3] []] # at any repetition
     """
 
     param_def = [
@@ -209,7 +209,7 @@ class pt8(Macro):
     """Macro with a list of pair Motor,Float. The min and max elements have been
     explicitly stated.
     Usages from Spock, ex.:
-    pt8 [[mot1 1][mot2 3]]
+    pt8 [[mot1 1] [mot2 3]]
     pt8 mot1 1 mot2 3    
     """
     
@@ -262,7 +262,6 @@ class pt11(Macro):
     """Macro with list of numbers followed by a motor parameter. The repeat
     parameter may be defined as first one.
     Usages from Spock, ex.:
-    pt11 ct1 [[1][3]] mot1
     pt11 ct1 [1 3] mot1
     """
 
@@ -296,7 +295,7 @@ class pt13(Macro):
     """Macro with list of motors groups, where each motor group is a list of 
     motors. Repeat parameters may be defined as nested.
     Usage from Spock, ex.:
-    pt13 [[mot1 mot2][mot3 mot4]]
+    pt13 [[mot1 mot2] [mot3 mot4]]
 """
 
     param_def = [
@@ -313,7 +312,7 @@ class pt14(Macro):
     """Macro with list of motors groups, where each motor group is a list of 
     motors and a float. Repeat parameters may be defined as nested.
     Usage from Spock, ex.:
-    pt14 [[[mot61 mot62] 3] [[mot63] 5]]
+    pt14 [[[mot1 mot2] 3] [[mot3] 5]]
     """
 
     param_def = [
@@ -331,14 +330,14 @@ class pt14d(Macro):
     motors and a float. Repeat parameters may be defined as nested.
     Default values can be used.
     Usages taken default values, ex.:
-    pt14d [[[mot61 mot62] 3] [[mot63] []]]
-    pt14d [[[mot61 []] 3] [[mot63] []]]
-    pt14d [[[[]] 3] [[mot03] []]]
+    pt14d [[[mot1 mot2] 3] [[mot3] []]]
+    pt14d [[[mot1 []] 3] [[mot3] []]]
+    pt14d [[[[]] 3] [[mot3] []]]
     """
 
     param_def = [
        ['motor_group_list',
-        [['motor_list', [['motor', Type.Motor, 'exp_dmy01', 'Motor to move']], None, 'List of motors'],
+        [['motor_list', [['motor', Type.Motor, 'mot1', 'Motor to move']], None, 'List of motors'],
          ['float', Type.Float, 33, 'Number']],
         None, 'Motor groups']
     ]

--- a/src/sardana/macroserver/macros/examples/parameters.py
+++ b/src/sardana/macroserver/macros/examples/parameters.py
@@ -31,7 +31,7 @@ __all__ = ["pt0", "pt1", "pt2", "pt3", "pt3d", "pt4", "pt5", "pt6", "pt7",
 
 class pt0(Macro):
     """Macro without parameters. Pretty dull.
-       Usage, ex.:
+       Usage from Spock, ex.:
        pt0
        """
 
@@ -44,7 +44,7 @@ class pt1(Macro):
     """Macro with one float parameter: Each parameter is described in the 
     param_def sequence as being a sequence of four elements: name, type, 
     default value and description.
-    Usage, ex.:
+    Usage from Spock, ex.:
     pt1 1
     """
     
@@ -57,7 +57,7 @@ class pt2(Macro):
     """Macro with one Motor parameter: Each parameter is described in the 
     param_def sequence as being a sequence of four elements: name, type, 
     default value and description.
-    Usage, ex.
+    Usage from Spock, ex.
     pt2 mot1
     """
 
@@ -71,8 +71,7 @@ class pt3(Macro):
     parameter types which is repeated. In this case it is a repetition of a 
     float so only one parameter is defined.
     By default the repetition as a semantics of 'at least one'
-    Usages, ex.:
-    pt3 [[1][34][15]]
+    Usages from Spock, ex.:
     pt3 [1 34 15]
     pt3 1 34 15
     """
@@ -89,12 +88,10 @@ class pt3d(Macro):
     parameter types which is repeated. In this case it is a repetition of a 
     float so only one parameter is defined. The parameter has a default value.
     By default the repetition as a semantics of 'at least one'
-    Usages, ex.:
-    pt3d [[1][34][15]]
+    Usages from Spock, ex.:
     pt3d [1 34 15]
     pt3d 1 34 15
-    Usages taken the default value, ex.:
-    pt3d [[1] [] [15]]
+    Usage taken the default value, ex.:
     pt3d [1 [] 15]
     """
 
@@ -110,10 +107,9 @@ class pt4(Macro):
     parameter types which is repeated. In this case it is a repetition of a 
     motor so only one parameter is defined.
     By default the repetition as a semantics of 'at least one'.
-    Usages, ex.:
-    pt3 [[mot1][mot2][mot3]]
-    pt3 [mot1 mot2 mot3]
-    pt3 mot1 mot2 mot3
+    Usages from Spock, ex.:
+    pt4 [mot1 mot2 mot3]
+    pt4 mot1 mot2 mot3
     """
 
     param_def = [
@@ -125,8 +121,7 @@ class pt4(Macro):
 
 class pt5(Macro):
     """Macro with a motor parameter followed by a list of numbers.
-    Usages, ex.:
-    pt5 mot1 [[1][3]]
+    Usages from Spock, ex.:
     pt5 mot1 [1 3]
     pt5 mot1 1 3
     """
@@ -143,8 +138,7 @@ class pt6(Macro):
     """Macro with a motor parameter followed by a list of numbers. The list as
     explicitly stated an optional last element which is a dictionary that defines the
     min and max values for repetitions.
-    Usages, ex.:
-    pt6 mot1 [[1][34][1]]
+    Usages from Spock, ex.:
     pt6 mot1 [1 34 1]
     pt6 mot1 1 34 1
     """
@@ -159,9 +153,8 @@ class pt6(Macro):
     
 class pt7(Macro):
     """Macro with a list of pair Motor,Float.
-    Usages, ex.:
+    Usages from Spock, ex.:
     pt7 [[mot1 1][mot2 3]]
-    pt7 [mot1 1 mot2 3]
     pt7 mot1 1 mot2 3
     """
 
@@ -176,13 +169,11 @@ class pt7(Macro):
     
 class pt7d1(Macro):
     """Macro with a list of pair Motor,Float. Default value for last ParamRepeat element.
-    Usages, ex.:
+    Usages from Spock, ex.:
     pt7d1 [[mot1 1][mot2 3]]
-    pt7d1 [mot1 1 mot2 3]
     pt7d1 mot1 1 mot2 3
     Using default value, ex.:
     pt7d1 [[mot1][mot2 3]] # at any repetition
-    pt7d1 [mot1 1 [mot2]] # only at the last repetition
     
     """
 
@@ -198,13 +189,11 @@ class pt7d1(Macro):
     
 class pt7d2(Macro):
     """Macro with a list of pair Motor,Float. Default value for both ParamRepeat elements.
-    Usages, ex.:
+    Usages from Spock, ex.:
     pt7d2 [[mot1 1][mot2 3]]
-    pt7d2 [mot1 1 mot2 3]
     pt7d2 mot1 1 mot2 3
     Using both default values, ex.:
-    pt7d1 [[][mot2 3][]] # at any repetition
-    pt7d1 [mot1 1 []] # only at the last repetition
+    pt7d2 [[][mot2 3][]] # at any repetition
     """
 
     param_def = [
@@ -219,9 +208,8 @@ class pt7d2(Macro):
 class pt8(Macro):
     """Macro with a list of pair Motor,Float. The min and max elements have been
     explicitly stated.
-    Usages, ex.:
+    Usages from Spock, ex.:
     pt8 [[mot1 1][mot2 3]]
-    pt8 [mot1 1 mot2 3]
     pt8 mot1 1 mot2 3    
     """
     
@@ -239,9 +227,8 @@ class pt9(Macro):
     """Same as macro pt7 but with old style ParamRepeat. If you are writing
     a macro with variable number of parameters for the first time don't even
     bother to look at this example since it is DEPRECATED.
-    Usages, ex.:
+    Usages from Spock, ex.:
     pt9 [[mot1 1][mot2 3]]
-    pt9 [mot1 1 mot2 3]
     pt9 mot1 1 mot2 3
     """
 
@@ -258,8 +245,7 @@ class pt9(Macro):
 class pt10(Macro):
     """Macro with list of numbers followed by a motor parameter. The repeat
     parameter may be defined as first one.
-    Usages, ex.:
-    pt10 [[1][3]] mot1
+    Usage from Spock, ex.:
     pt10 [1 3] mot1
     """
 
@@ -275,7 +261,7 @@ class pt10(Macro):
 class pt11(Macro):
     """Macro with list of numbers followed by a motor parameter. The repeat
     parameter may be defined as first one.
-    Usages, ex.:
+    Usages from Spock, ex.:
     pt11 ct1 [[1][3]] mot1
     pt11 ct1 [1 3] mot1
     """
@@ -293,8 +279,7 @@ class pt11(Macro):
 class pt12(Macro):
     """Macro with list of motors followed by list of numbers. Two repeat
     parameters may defined.
-    Usages, ex.:
-    pt12 [[1][3][4]] [[mot1][mot2]]
+    Usage from Spock, ex.:
     pt12 [1 3 4] [mot1 mot2]
     """
 
@@ -310,8 +295,7 @@ class pt12(Macro):
 class pt13(Macro):
     """Macro with list of motors groups, where each motor group is a list of 
     motors. Repeat parameters may be defined as nested.
-    Usages, ex.:
-    pt13 [[[[mot1] [mot2]]][[[mot3] [mot4]]]]
+    Usage from Spock, ex.:
     pt13 [[mot1 mot2][mot3 mot4]]
 """
 
@@ -328,9 +312,8 @@ class pt13(Macro):
 class pt14(Macro):
     """Macro with list of motors groups, where each motor group is a list of 
     motors and a float. Repeat parameters may be defined as nested.
-    Usages, ex.:
-    pt14 [[[[mot61] [mot62]] 3]  [[[mot63]] 5] ]
-    pt14 [[mot61 mot62] 3  [mot63] 5]
+    Usage from Spock, ex.:
+    pt14 [[[mot61 mot62] 3] [[mot63] 5]]
     """
 
     param_def = [
@@ -347,15 +330,10 @@ class pt14d(Macro):
     """Macro with list of motors groups, where each motor group is a list of 
     motors and a float. Repeat parameters may be defined as nested.
     Default values can be used.
-    Usages, ex.:
-    pt14d [[[[mot61] [mot62]] 3]  [[[mot63]] 5] ]
-    pt14d [[mot61 mot62] 3  [mot63] 5]
     Usages taken default values, ex.:
-    pt14d [[[[mot61] [mot62]]]  [[[mot63]] 5] ]
-    pt14d [[[[mot61] []]]  [[[mot63]] 5] ]
-    pt14d [[[]]  [[[mot63]] 5] ]
-    pt14d [[mot61 mot62] 3  [] 5]
-    pt14d [[mot61 mot62] 3  []] # only at the last repetition
+    pt14d [[[mot61 mot62] 3] [[mot63] []]]
+    pt14d [[[mot61 []] 3] [[mot63] []]]
+    pt14d [[[[]] 3] [[mot03] []]]
     """
 
     param_def = [

--- a/src/sardana/macroserver/macros/examples/parameters.py
+++ b/src/sardana/macroserver/macros/examples/parameters.py
@@ -25,11 +25,15 @@
 
 from sardana.macroserver.macro import *
 
-__all__ = ["pt0", "pt1", "pt2", "pt3", "pt4", "pt5", "pt6", "pt7", "pt8",
-           "pt9"]
+__all__ = ["pt0", "pt1", "pt2", "pt3", "pt3d", "pt4", "pt5", "pt6", "pt7",
+           "pt7d1", "pt7d2", "pt8", "pt9", "pt10", "pt11", "pt12", "pt13",
+           "pt14", "pt14d", "twice"]
 
 class pt0(Macro):
-    """Macro without parameters. Pretty dull"""
+    """Macro without parameters. Pretty dull.
+       Usage, ex.:
+       pt0
+       """
 
     param_def = []
     
@@ -39,7 +43,10 @@ class pt0(Macro):
 class pt1(Macro):
     """Macro with one float parameter: Each parameter is described in the 
     param_def sequence as being a sequence of four elements: name, type, 
-    default value and description"""
+    default value and description.
+    Usage, ex.:
+    pt1 1
+    """
     
     param_def = [ [ 'value', Type.Float, None, 'some bloody float'] ]
     
@@ -49,7 +56,10 @@ class pt1(Macro):
 class pt2(Macro):
     """Macro with one Motor parameter: Each parameter is described in the 
     param_def sequence as being a sequence of four elements: name, type, 
-    default value and description"""
+    default value and description.
+    Usage, ex.
+    pt2 mot1
+    """
 
     param_def = [ [ 'motor', Type.Motor, None, 'some bloody motor'] ]
     
@@ -60,10 +70,36 @@ class pt3(Macro):
     """Macro with a list of numbers as parameter: the type is a sequence of
     parameter types which is repeated. In this case it is a repetition of a 
     float so only one parameter is defined.
-    By default the repetition as a semantics of 'at least one'"""
+    By default the repetition as a semantics of 'at least one'
+    Usages, ex.:
+    pt3 [[1][34][15]]
+    pt3 [1 34 15]
+    pt3 1 34 15
+    """
 
     param_def = [
        [ 'numb_list', [ [ 'pos', Type.Float, None, 'value'] ], None, 'List of values'],
+    ]
+    
+    def run(self, *args, **kwargs):
+        pass
+    
+class pt3d(Macro):
+    """Macro with a list of numbers as parameter: the type is a sequence of
+    parameter types which is repeated. In this case it is a repetition of a 
+    float so only one parameter is defined. The parameter has a default value.
+    By default the repetition as a semantics of 'at least one'
+    Usages, ex.:
+    pt3d [[1][34][15]]
+    pt3d [1 34 15]
+    pt3d 1 34 15
+    Usages taken the default value, ex.:
+    pt3d [[1] [] [15]]
+    pt3d [1 [] 15]
+    """
+
+    param_def = [
+       [ 'numb_list', [ [ 'pos', Type.Float, 21, 'value'] ], None, 'List of values'],
     ]
     
     def run(self, *args, **kwargs):
@@ -73,7 +109,12 @@ class pt4(Macro):
     """Macro with a list of motors as parameter: the type is a sequence of
     parameter types which is repeated. In this case it is a repetition of a 
     motor so only one parameter is defined.
-    By default the repetition as a semantics of 'at least one'"""
+    By default the repetition as a semantics of 'at least one'.
+    Usages, ex.:
+    pt3 [[mot1][mot2][mot3]]
+    pt3 [mot1 mot2 mot3]
+    pt3 mot1 mot2 mot3
+    """
 
     param_def = [
        [ 'motor_list', [ [ 'motor', Type.Motor, None, 'motor name'] ], None, 'List of motors'],
@@ -83,7 +124,12 @@ class pt4(Macro):
         pass
 
 class pt5(Macro):
-    """Macro with a motor parameter followed by a list of numbers"""
+    """Macro with a motor parameter followed by a list of numbers.
+    Usages, ex.:
+    pt5 mot1 [[1][3]]
+    pt5 mot1 [1 3]
+    pt5 mot1 1 3
+    """
 
     param_def = [
        [ 'motor', Type.Motor, None, 'Motor to move'],
@@ -92,11 +138,16 @@ class pt5(Macro):
     
     def run(self, *args, **kwargs):
         pass
-
+ 
 class pt6(Macro):
     """Macro with a motor parameter followed by a list of numbers. The list as
     explicitly stated an optional last element which is a dictionary that defines the
-    min and max values for repetitions"""
+    min and max values for repetitions.
+    Usages, ex.:
+    pt6 mot1 [[1][34][1]]
+    pt6 mot1 [1 34 1]
+    pt6 mot1 1 34 1
+    """
 
     param_def = [
        [ 'motor', Type.Motor, None, 'Motor to move'],
@@ -107,7 +158,12 @@ class pt6(Macro):
         pass
     
 class pt7(Macro):
-    """Macro with a list of pair Motor,Float"""
+    """Macro with a list of pair Motor,Float.
+    Usages, ex.:
+    pt7 [[mot1 1][mot2 3]]
+    pt7 [mot1 1 mot2 3]
+    pt7 mot1 1 mot2 3
+    """
 
     param_def = [
        [ 'm_p_pair', [ [ 'motor', Type.Motor, None, 'Motor to move'],
@@ -117,10 +173,57 @@ class pt7(Macro):
     
     def run(self, *args, **kwargs):
         pass
+    
+class pt7d1(Macro):
+    """Macro with a list of pair Motor,Float. Default value for last ParamRepeat element.
+    Usages, ex.:
+    pt7d1 [[mot1 1][mot2 3]]
+    pt7d1 [mot1 1 mot2 3]
+    pt7d1 mot1 1 mot2 3
+    Using default value, ex.:
+    pt7d1 [[mot1][mot2 3]] # at any repetition
+    pt7d1 [mot1 1 [mot2]] # only at the last repetition
+    
+    """
+
+    param_def = [
+       [ 'm_p_pair', [ [ 'motor', Type.Motor, None, 'Motor to move'],
+                       [ 'pos',   Type.Float, 2, 'Position to move to'] ],
+         None, 'List of motor/position pairs']
+    ]
+    
+    def run(self, *args, **kwargs):
+        pass
+
+    
+class pt7d2(Macro):
+    """Macro with a list of pair Motor,Float. Default value for both ParamRepeat elements.
+    Usages, ex.:
+    pt7d2 [[mot1 1][mot2 3]]
+    pt7d2 [mot1 1 mot2 3]
+    pt7d2 mot1 1 mot2 3
+    Using both default values, ex.:
+    pt7d1 [[][mot2 3][]] # at any repetition
+    pt7d1 [mot1 1 []] # only at the last repetition
+    """
+
+    param_def = [
+       [ 'm_p_pair', [ [ 'motor', Type.Motor, 'mot1', 'Motor to move'],
+                       [ 'pos',   Type.Float, 2, 'Position to move to'] ],
+         None, 'List of motor/position pairs']
+    ]
+    
+    def run(self, *args, **kwargs):
+        pass   
 
 class pt8(Macro):
     """Macro with a list of pair Motor,Float. The min and max elements have been
-    explicitly stated"""
+    explicitly stated.
+    Usages, ex.:
+    pt8 [[mot1 1][mot2 3]]
+    pt8 [mot1 1 mot2 3]
+    pt8 mot1 1 mot2 3    
+    """
     
     param_def = [
        [ 'm_p_pair', [ [ 'motor', Type.Motor, None, 'Motor to move'],
@@ -135,7 +238,12 @@ class pt8(Macro):
 class pt9(Macro):
     """Same as macro pt7 but with old style ParamRepeat. If you are writing
     a macro with variable number of parameters for the first time don't even
-    bother to look at this example since it is DEPRECATED."""
+    bother to look at this example since it is DEPRECATED.
+    Usages, ex.:
+    pt9 [[mot1 1][mot2 3]]
+    pt9 [mot1 1 mot2 3]
+    pt9 mot1 1 mot2 3
+    """
 
     param_def = [
        ['m_p_pair',
@@ -149,7 +257,11 @@ class pt9(Macro):
 
 class pt10(Macro):
     """Macro with list of numbers followed by a motor parameter. The repeat
-    parameter may be defined as first one."""
+    parameter may be defined as first one.
+    Usages, ex.:
+    pt10 [[1][3]] mot1
+    pt10 [1 3] mot1
+    """
 
     param_def = [
        ['numb_list', [['pos', Type.Float, None, 'value']], None, 'List of values'],
@@ -158,11 +270,15 @@ class pt10(Macro):
 
     def run(self, *args, **kwargs):
         pass
-
+  
 
 class pt11(Macro):
     """Macro with list of numbers followed by a motor parameter. The repeat
-    parameter may be defined as first one."""
+    parameter may be defined as first one.
+    Usages, ex.:
+    pt11 ct1 [[1][3]] mot1
+    pt11 ct1 [1 3] mot1
+    """
 
     param_def = [
        ['counter', Type.ExpChannel, None, 'Counter to count'],
@@ -176,7 +292,11 @@ class pt11(Macro):
 
 class pt12(Macro):
     """Macro with list of motors followed by list of numbers. Two repeat
-    parameters may defined."""
+    parameters may defined.
+    Usages, ex.:
+    pt12 [[1][3][4]] [[mot1][mot2]]
+    pt12 [1 3 4] [mot1 mot2]
+    """
 
     param_def = [
        ['numb_list', [['pos', Type.Float, None, 'value']], None, 'List of values'],
@@ -189,7 +309,11 @@ class pt12(Macro):
 
 class pt13(Macro):
     """Macro with list of motors groups, where each motor group is a list of 
-    motors. Repeat parameters may be defined as nested."""
+    motors. Repeat parameters may be defined as nested.
+    Usages, ex.:
+    pt13 [[[[mot1] [mot2]]][[[mot3] [mot4]]]]
+    pt13 [[mot1 mot2][mot3 mot4]]
+"""
 
     param_def = [
        ['motor_group_list',
@@ -200,7 +324,50 @@ class pt13(Macro):
     def run(self, *args, **kwargs):
         pass
 
+       
+class pt14(Macro):
+    """Macro with list of motors groups, where each motor group is a list of 
+    motors and a float. Repeat parameters may be defined as nested.
+    Usages, ex.:
+    pt14 [[[[mot61] [mot62]] 3]  [[[mot63]] 5] ]
+    pt14 [[mot61 mot62] 3  [mot63] 5]
+    """
 
+    param_def = [
+       ['motor_group_list',
+        [['motor_list', [['motor', Type.Motor, None, 'Motor to move']], None, 'List of motors'],
+         ['float', Type.Float, None, 'Number']],
+        None, 'Motor groups']
+    ]
+
+    def run(self, *args, **kwargs):
+        pass 
+       
+class pt14d(Macro):
+    """Macro with list of motors groups, where each motor group is a list of 
+    motors and a float. Repeat parameters may be defined as nested.
+    Default values can be used.
+    Usages, ex.:
+    pt14d [[[[mot61] [mot62]] 3]  [[[mot63]] 5] ]
+    pt14d [[mot61 mot62] 3  [mot63] 5]
+    Usages taken default values, ex.:
+    pt14d [[[[mot61] [mot62]]]  [[[mot63]] 5] ]
+    pt14d [[[[mot61] []]]  [[[mot63]] 5] ]
+    pt14d [[[]]  [[[mot63]] 5] ]
+    pt14d [[mot61 mot62] 3  [] 5]
+    pt14d [[mot61 mot62] 3  []] # only at the last repetition
+    """
+
+    param_def = [
+       ['motor_group_list',
+        [['motor_list', [['motor', Type.Motor, 'exp_dmy01', 'Motor to move']], None, 'List of motors'],
+         ['float', Type.Float, 33, 'Number']],
+        None, 'Motor groups']
+    ]
+
+    def run(self, *args, **kwargs):
+        pass
+    
 class twice(Macro):
     """A macro that returns a float that is twice its input. It also sets its 
     data to be a dictionary with 'in','out' as keys and value,result 

--- a/src/sardana/spock/spockms.py
+++ b/src/sardana/spock/spockms.py
@@ -608,6 +608,22 @@ class Reflector(object):
         return name
 
 def split_macro_parameters(parameters_s):
+    """Split string with macro parameters into a list with macro parameters.
+    Whitespaces are the separators between the parameters.
+    
+    When the input string contains square brackets it indicates an advanced
+    syntax for representing repeat parameters. Repeat parameters are encapsulated
+    in square brackets and its internal repetitions, if composed from more than
+    one item are also encapsulated in brackets. In this case the output list
+    contains lists internally.
+    
+    :param parameters_s (string): input string containing parameters
+    :returns (list): parameters represented as a list (may contain internal lists)
+    
+    ..todo:: This function is quite hard to understand and may be optimized by
+        implementing it in a form of parser. If it causes problems in the future
+        it is recommended to refactor it.
+    """
     macro_params = genutils.arg_split(parameters_s, posix=True)
 
     list_of_pars = 0

--- a/src/sardana/spock/spockms.py
+++ b/src/sardana/spock/spockms.py
@@ -610,8 +610,12 @@ class Reflector(object):
 def split_macro_parameters(parameters_s):
     macro_params = genutils.arg_split(parameters_s, posix=True)
 
+    list_of_pars = 0
+    if len(macro_params) == 1:
+        if  macro_params[0].find('[') > -1:
+            list_of_pars = 1
     # skip empty strings and just one parameter
-    if len(macro_params) > 1:
+    if len(macro_params) > 1 or list_of_pars:
         params_str = ''
         for par in macro_params:
             params_str = params_str + str(par) + ","

--- a/src/sardana/spock/spockms.py
+++ b/src/sardana/spock/spockms.py
@@ -609,16 +609,21 @@ class Reflector(object):
 
 def split_macro_parameters(parameters_s):
     macro_params = genutils.arg_split(parameters_s, posix=True)
-    params_str = ''
-    for par in macro_params:
-        params_str = params_str + str(par) + ","
-    params_str = params_str[:-1] 
-    params_str = params_str.replace("[,", "[").replace(",]","]").replace("][", "],[")
-    macro_params = eval(params_str, globals(), Reflector())
-    if type(macro_params) == list:
-        new_params = []
-        new_params.append(macro_params)
-        macro_params = new_params
+
+    # skip empty strings and just one parameter
+    if len(macro_params) > 1:
+        params_str = ''
+        for par in macro_params:
+            params_str = params_str + str(par) + ","
+        params_str = params_str[:-1]
+        params_str = params_str.replace("[,", "[").replace(",]", "]").replace(
+            "][", "],[")
+        macro_params = eval(params_str, globals(), Reflector())
+        if type(macro_params) == list:
+            new_params = []
+            new_params.append(macro_params)
+            macro_params = new_params
+
     # Convert tuple to list
     macro_params = list(macro_params)
     return macro_params

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -1167,7 +1167,6 @@ def ParamFactory(paramInfo):
     return param
 
 def check_member_node_simple(rest_raw, param_node, mem, rep, params_info_len):
-
     for member_raw in rest_raw:
         repeat_node = param_node.child(rep)
         if repeat_node is None:
@@ -1179,7 +1178,8 @@ def check_member_node_simple(rest_raw, param_node, mem, rep, params_info_len):
             rep_nested = 0; mem_nested = 0
             check_member_node_simple(member_raw, member_node, mem_nested, rep_nested, params_info_len_nested)
         else:
-            member_node.setValue(str(member_raw))
+            if not isinstance(member_raw, list):
+                member_node.setValue(str(member_raw))
         mem += 1
         mem %= params_info_len
         if mem == 0:

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -1177,7 +1177,6 @@ def check_member_node(macro_param, param_node):
                 check_member_node(par, member_node)
             else:
                 try: # last parameters can have default values
-                    param_raw = macro_param[j]
                     member_node.setValue(str(par))
                 except:
                     pass

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -1180,6 +1180,10 @@ def check_member_node_simple(rest_raw, param_node, mem, rep, params_info_len):
         else:
             if not isinstance(member_raw, list):
                 member_node.setValue(str(member_raw))
+            else:
+                if len(member_raw) == 1:
+                    member_raw = member_raw[0]
+                    member_node.setValue(str(member_raw))
         mem += 1
         mem %= params_info_len
         if mem == 0:

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -534,6 +534,17 @@ class SingleParamNode(ParamNode):
     def toList(self):
         return self._value
 
+    def fromList(self, v):
+        if isinstance(v, list):
+            if len(v) == 0:
+                v = self.defValue()
+            elif not isinstance(self.parent(), RepeatNode):
+                msg = "Only members of repeat parameter allow list values"
+                raise ValueError(msg)
+            else:
+                raise ValueError("Too many elements in list value")
+        self.setValue(v)
+
 class RepeatParamNode(ParamNode, BranchNode):
     """Repeat parameter class."""
 
@@ -654,6 +665,13 @@ class RepeatParamNode(ParamNode, BranchNode):
     def toList(self):
         return [child.toList() for child in self.children()]
 
+    def fromList(self, repeats):
+        for j, repeat in enumerate(repeats):
+            repeat_node = self.child(j)
+            if repeat_node is None:
+                repeat_node = self.addRepeat()
+            repeat_node.fromList(repeat)
+
 #    def isAllowedMoveUp(self):
 #        return self is not self.parent().child(0)
 #
@@ -727,11 +745,23 @@ class RepeatNode(BranchNode):
         else:
             return [child.toList() for child in self.children()]
 
+    def fromList(self, params):
+        if len(self.children()) == 1:
+            self.child(0).fromList(params)
+        else:
+            for k, member_node in enumerate(self.children()):
+                try:
+                    param = params[k]
+                except IndexError:
+                    param = []
+                member_node.fromList(param)
+
+
 class MacroNode(BranchNode):
     """Class to represent macro element."""
     count = 0
 
-    def __init__(self, parent=None, name=None):
+    def __init__(self, parent=None, name=None, params_def=None):
         BranchNode.__init__(self, parent)
         self.setId(None)
         self.setName(name)
@@ -742,6 +772,11 @@ class MacroNode(BranchNode):
         self.setHooks([])
         self.setHookPlaces([])
         self.setAllowedHookPlaces([])
+        # create parameter nodes (it is recursive for repeat parameters
+        # containing repeat parameters)
+        if params_def is not None:
+            for param_info in params_def:
+                self.addParam(ParamFactory(param_info))
 
     def id(self):
         """
@@ -1093,6 +1128,15 @@ class MacroNode(BranchNode):
         list_.insert(0, self.name())
         return list_
 
+    def fromList(self, values):
+        params = self.params()
+        for i, node in enumerate(params):
+            try:
+                raw = values[i]
+            except IndexError:
+                continue
+            node.fromList(raw)
+
 
 class SequenceNode(BranchNode):
     """Class to represent sequence element."""
@@ -1189,28 +1233,6 @@ def check_interface(param_raw, param_node):
                 if ret ==0:
                     return ret
     return 1
-            
-def check_member_node(param_raw, param_node):
-    """Fill the ParamNode checking each repetition node asuming the complete interface
-  
-    :param param_raw: element of the raw parameters list
-    :param param_node: element of the parameters node list
-
-    """
-    
-    for j, param in enumerate(param_raw):
-        repeat_node = param_node.child(j)
-        if repeat_node is None:
-            repeat_node = param_node.addRepeat()
-        for k, par in enumerate(param):
-            member_node = repeat_node.child(k)
-            if isinstance(member_node, RepeatParamNode):
-                check_member_node(par, member_node)
-            else:
-                try: # last parameters can have default values
-                    member_node.setValue(str(par))
-                except:
-                    pass
 
 def check_member_node_simple(rest_raw, param_node, mem, rep, params_info_len):
     """Fill the ParamNode checking each repetition node asuming the partial interface
@@ -1243,27 +1265,7 @@ def check_member_node_simple(rest_raw, param_node, mem, rep, params_info_len):
         mem %= params_info_len
         if mem == 0:
             rep += 1
-                
-class Reflector(object):
-    def __getitem__(self, name):
-        return name
-  
-def recur_map(fun, data, keep_none=False):
-    """Recursive map. Similar to map, but maintains the list objects structure
 
-    :param fun: <callable> the same purpose as in map function
-    :param data: <object> the same purpose as in map function
-    :param keep_none: <bool> keep None elements without applying fun
-    """
-    if hasattr(data, "__iter__"):
-        return [recur_map(fun, elem, keep_none) for elem in data]
-    else:
-        if keep_none is True and data is None:
-            return data
-        else:
-            return fun(data)
-
-                
 def createMacroNode(macro_name, params_def, macro_params):
     """The best effort creation of the macro XML object. It tries to
     convert flat list of string parameter values to the correct macro XML
@@ -1281,47 +1283,16 @@ def createMacroNode(macro_name, params_def, macro_params):
     `sardana.taurus.core.tango.sardana.macroserver.BaseDoor._createMacroXmlFromStr`
     unify them and place in some common location.
     """
-    macro_node = MacroNode(name=macro_name)
-    # create parameter nodes (it is recursive for repeat parameters containing
-    # repeat parameters)
-    for param_info in params_def:
-        macro_node.addParam(ParamFactory(param_info))
-    # obtain just the first level parameters
-    param_nodes = macro_node.params()
-    
+    macro_node = MacroNode(name=macro_name, params_def=params_def)
     # Check if ParamRepeat used in advanced interface
-    open_bracks = 0
-    close_bracks = 0
     new_interface = False
     for param in macro_params:
-        if param.find('[') > -1:
-            open_bracks = open_bracks + 1
-        if param.find(']') > -1:
-            close_bracks = close_bracks + 1
+        if isinstance(param, list):
+            new_interface = True
+            break
 
-    # open_bracks and close_bracks don't have to be equal because several closes or opens can be in the same param
-    if open_bracks and close_bracks:
-        new_interface = True
-
-    # Close the character strings into ''
-    if new_interface:       
-        # Create a string
-        params_str = ''
-        for par in macro_params:
-            params_str = params_str + str(par) + ","
-        params_str = params_str[:-1] 
-        params_str = params_str.replace("[,", "[").replace(",]","]").replace("][", "],[")
-        macro_params = eval(params_str, globals(), Reflector())
-        if type(macro_params) == list:
-            new_params = []
-            new_params.append(macro_params)
-            macro_params = new_params
-        # Convert tuple to list
-        macro_params = list(macro_params)
-        macro_params = recur_map(str, macro_params)
-
-    
     if not new_interface:
+        param_nodes = macro_node.params()
         contain_param_repeat = False
         len_param_nodes = len(param_nodes)
         for i, param_node in enumerate(param_nodes):
@@ -1361,35 +1332,6 @@ def createMacroNode(macro_name, params_def, macro_params):
                         rep += 1
                 break
     else:
-        ret = 1
-        for param_node, param_raw in zip(param_nodes, macro_params):
-            if isinstance(param_node, RepeatParamNode):
-                ret = check_interface(param_raw, param_node)
-                if ret == 0:
-                    break
-                
-        if ret:
-            for param_node, param_raw in zip(param_nodes, macro_params):
-                if isinstance(param_node, RepeatParamNode):
-                    check_member_node(param_raw, param_node)
-                else:
-                    try: # last parameters can have default values
-                        param_node.setValue(str(param_raw))
-                    except:
-                        pass
-        else:
-            for param_node, param_raw in zip(param_nodes, macro_params):
-                if isinstance(param_node, RepeatParamNode):
-                    params_info = param_node.paramsInfo()
-                    params_info_len = len(params_info)
-                    rep = 0; mem = 0
-                    check_member_node_simple(param_raw, param_node, mem, rep, params_info_len)
-                else:
-                    try: # last parameters can have default values
-                        param_node.setValue(str(param_raw))
-                    except:
-                        pass              
-            
-                        
+        macro_node.fromList(macro_params)
     return macro_node
 

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -1166,8 +1166,8 @@ def ParamFactory(paramInfo):
         param = SingleParamNode(param=paramInfo)
     return param
 
-def check_member_node(macro_param, param_node):
-    for j, param in enumerate(macro_param):
+def check_member_node(param_raw, param_node):
+    for j, param in enumerate(param_raw):
         repeat_node = param_node.child(j)
         if repeat_node is None:
             repeat_node = param_node.addRepeat()
@@ -1225,7 +1225,7 @@ def createMacroNode(macro_name, params_def, macro_params):
         macro_node.addParam(ParamFactory(param_info))
     # obtain just the first level parameters
     param_nodes = macro_node.params()
-    
+
     # Check if ParamRepeat used in advanced interface
     open_bracks = 0
     close_bracks = 0
@@ -1295,13 +1295,12 @@ def createMacroNode(macro_name, params_def, macro_params):
                     if mem == 0:
                         rep += 1
                 break
-    else:
-        for i, param_node in enumerate(param_nodes):
+    else: 
+        for param_node, param_raw in zip(param_nodes, macro_params):
             if isinstance(param_node, RepeatParamNode):
-                check_member_node(macro_params[i], param_node)
+                check_member_node(param_raw, param_node)
             else:
                 try: # last parameters can have default values
-                    param_raw = macro_params[i]
                     param_node.setValue(str(param_raw))
                 except:
                     pass

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -1169,7 +1169,14 @@ def ParamFactory(paramInfo):
 def check_interface(param_raw, param_node):
     """Check which interface is being used: complete (brackets for each
     ParamRepeat and each repetition inside) or partial (brackets only for
-    each ParamRepeat)""".
+    each ParamRepeat)
+    
+    :param param_raw: element of the raw parameters list
+    :param param_node: element of the parameters node list
+ 
+    :return: (int) 1 if complete interface, 0 if partial
+
+    """
     
     repeat_node = param_node.child(0)
     for j, param in enumerate(param_raw):
@@ -1184,7 +1191,12 @@ def check_interface(param_raw, param_node):
     return 1
             
 def check_member_node(param_raw, param_node):
-    """Fill the ParamNode checking each repetition node asuming the complete interface"""
+    """Fill the ParamNode checking each repetition node asuming the complete interface
+  
+    :param param_raw: element of the raw parameters list
+    :param param_node: element of the parameters node list
+
+    """
     
     for j, param in enumerate(param_raw):
         repeat_node = param_node.child(j)
@@ -1201,7 +1213,15 @@ def check_member_node(param_raw, param_node):
                     pass
 
 def check_member_node_simple(rest_raw, param_node, mem, rep, params_info_len):
-    """Fill the ParamNode checking each repetition node asuming the partial interface"""
+    """Fill the ParamNode checking each repetition node asuming the partial interface
+  
+    :param rest_raw: raw parameters still not included in the macro parameteres node 
+    :param param_node: element of the parameters node list
+    :param mem: iterator on repetitions inside a ParamRepeat
+    :param rep: iterator on param nodes
+    :param params_info_len: number of nodes
+
+    """
     for member_raw in rest_raw:
         repeat_node = param_node.child(rep)
         if repeat_node is None:
@@ -1268,8 +1288,7 @@ def createMacroNode(macro_name, params_def, macro_params):
         macro_node.addParam(ParamFactory(param_info))
     # obtain just the first level parameters
     param_nodes = macro_node.params()
-
-    param_nodes_copy = copy.copy(param_nodes)
+    
     # Check if ParamRepeat used in advanced interface
     open_bracks = 0
     close_bracks = 0

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -1247,7 +1247,7 @@ def createMacroNode(macro_name, params_def, macro_params):
         for par in macro_params:
             params_str = params_str + str(par) + ","
         params_str = params_str[:-1] 
-
+        params_str = params_str.replace("[,", "[").replace(",]","]").replace("][", "],[")
         macro_params = eval(params_str, globals(), Reflector())
         if type(macro_params) == list:
             new_params = []

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -1153,8 +1153,6 @@ class SequenceNode(BranchNode):
 #        return descendant
 
 
-
-
 def ParamFactory(paramInfo):
     """Factory method returning param element, depends of the paramInfo argument."""
 
@@ -1166,7 +1164,44 @@ def ParamFactory(paramInfo):
         param = SingleParamNode(param=paramInfo)
     return param
 
+  
+
+def check_interface(param_raw, param_node):
+    """Check which interface is being used: complete (brackets for each
+    ParamRepeat and each repetition inside) or partial (brackets only for
+    each ParamRepeat)""".
+    
+    repeat_node = param_node.child(0)
+    for j, param in enumerate(param_raw):
+        if(isinstance(param,str)):
+            return 0
+        for k, par in enumerate(param):
+            member_node = repeat_node.child(k)
+            if isinstance(member_node, RepeatParamNode):
+                ret = check_interface(par, member_node)
+                if ret ==0:
+                    return ret
+    return 1
+            
+def check_member_node(param_raw, param_node):
+    """Fill the ParamNode checking each repetition node asuming the complete interface"""
+    
+    for j, param in enumerate(param_raw):
+        repeat_node = param_node.child(j)
+        if repeat_node is None:
+            repeat_node = param_node.addRepeat()
+        for k, par in enumerate(param):
+            member_node = repeat_node.child(k)
+            if isinstance(member_node, RepeatParamNode):
+                check_member_node(par, member_node)
+            else:
+                try: # last parameters can have default values
+                    member_node.setValue(str(par))
+                except:
+                    pass
+
 def check_member_node_simple(rest_raw, param_node, mem, rep, params_info_len):
+    """Fill the ParamNode checking each repetition node asuming the partial interface"""
     for member_raw in rest_raw:
         repeat_node = param_node.child(rep)
         if repeat_node is None:
@@ -1188,36 +1223,7 @@ def check_member_node_simple(rest_raw, param_node, mem, rep, params_info_len):
         mem %= params_info_len
         if mem == 0:
             rep += 1
-  
-
-def check_interface(param_raw, param_node):
-    repeat_node = param_node.child(0)
-    for j, param in enumerate(param_raw):
-        if(isinstance(param,str)):
-            return 0
-        for k, par in enumerate(param):
-            member_node = repeat_node.child(k)
-            if isinstance(member_node, RepeatParamNode):
-                ret = check_interface(par, member_node)
-                if ret ==0:
-                    return ret
-    return 1
-            
-def check_member_node(param_raw, param_node):
-    for j, param in enumerate(param_raw):
-        repeat_node = param_node.child(j)
-        if repeat_node is None:
-            repeat_node = param_node.addRepeat()
-        for k, par in enumerate(param):
-            member_node = repeat_node.child(k)
-            if isinstance(member_node, RepeatParamNode):
-                check_member_node(par, member_node)
-            else:
-                try: # last parameters can have default values
-                    member_node.setValue(str(par))
-                except:
-                    pass
-       
+                
 class Reflector(object):
     def __getitem__(self, name):
         return name

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -60,6 +60,20 @@ from .macro import createMacroNode
 
 CHANGE_EVT_TYPES = TaurusEventType.Change, TaurusEventType.Periodic
 
+def recur_map(fun, data, keep_none=False):
+    """Recursive map. Similar to map, but maintains the list objects structure
+
+    :param fun: <callable> the same purpose as in map function
+    :param data: <object> the same purpose as in map function
+    :param keep_none: <bool> keep None elements without applying fun
+    """
+    if hasattr(data, "__iter__"):
+        return [recur_map(fun, elem, keep_none) for elem in data]
+    else:
+        if keep_none is True and data is None:
+            return data
+        else:
+            return fun(data)
 
 class Attr(Logger, EventGenerator):
 
@@ -497,7 +511,7 @@ class BaseDoor(MacroServerDevice):
                         pars = m.split()
                         macros.append((pars[0], pars[1:]))
                 else:
-                    parameters = map(str, parameters)
+                    parameters = recur_map(str, parameters)
                     macros.append((obj, parameters))
                 xml_root = xml_seq = etree.Element('sequence')
                 for m in macros:

--- a/src/sardana/taurus/core/tango/sardana/test/__init__.py
+++ b/src/sardana/taurus/core/tango/sardana/test/__init__.py
@@ -22,3 +22,8 @@
 ## along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
 ##
 ##############################################################################
+
+
+from .paramdef import (pt3d_param_def, pt5d_param_def, pt7d_param_def,
+                       pt10d_param_def, pt12d_param_def, pt13d_param_def,
+                       pt14d_param_def)

--- a/src/sardana/taurus/core/tango/sardana/test/paramdef.py
+++ b/src/sardana/taurus/core/tango/sardana/test/paramdef.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+## This file is part of Sardana
+##
+## http://www.sardana-controls.org/
+##
+## Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+## Sardana is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## Sardana is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+"""Resource file containing parameter definitions, to be used in
+test_macro for testing encoding and decoding of macro parameters.
+The following parameter definitions are based in the macro examples present in
+the module sardana.macroserver.macros.examples.parameters"""
+
+
+# pt3 like parameter definition, using default values.
+pt3d_param_def = [
+    {'name': 'numb_list',
+     'default_value': 100,
+     'type': [
+         {'name': 'float',
+          'default_value': 100
+          }
+     ]}
+    ]
+
+
+# pt5 like parameter definition, using default values.
+pt5d_param_def = [
+    {'name': 'motor',
+     'default_value': "mot99"
+     },
+    {'name': 'float_list',
+     'default_value': None,
+     'type': [
+        {'name': 'float',
+         'default_value': 100
+         }
+        ]}
+    ]
+
+
+# pt7 like parameter definition, using default values.
+pt7d_param_def = [
+    {'name': 'motor_pos_list',
+     'default_value': ["mot01", 50],
+     'type': [
+        {'name': 'motor',
+         'default_value': "mot99"
+         },
+        {'name': 'pos',
+         'default_value': 100
+         }
+        ]}
+    ]
+
+
+# pt10 like parameter definition, using default values.
+pt10d_param_def = [
+    {'name': 'float_list',
+     'default_value': None,
+     'type': [
+        {'name': 'float',
+         'default_value': 100
+         }]
+     },
+    {'name': 'motor',
+     'default_value': "mot99"
+     }
+    ]
+
+
+# pt12 like parameter definition, using default values.
+pt12d_param_def = [
+    {'name': 'numb_list',
+     'default_value': None,
+     'type': [
+        {'name': 'float',
+         'default_value': 100
+         }]
+     },
+    {'name': 'motors_list',
+     'default_value': None,
+     'type': [
+        {'name': 'motor',
+         'default_value': 'mot99'
+         }]
+     }
+    ]
+
+
+# pt13 like parameter definition, using default values.
+pt13d_param_def = [
+    {'name': 'motor_group_list',
+     'default_value': None,
+     'type': [
+         {'name': 'motor_list',
+          'default_value': None,
+          'type': [{'name': 'motor',
+                   'default_value': 'mot99'}]
+          }]
+     }]
+
+
+# pt14 like parameter definition, using default values.
+pt14d_param_def = [
+    {'name': 'motor_group_list',
+     'default_value': None,
+     'type': [
+         {'name': 'motor_list',
+          'default_value': None,
+          'type': [{'name': 'motor',
+                   'default_value': 'mot99'}]
+          },
+         {'name': 'numb',
+          'default_value': 100}
+     ]
+     }]
+

--- a/src/sardana/taurus/core/tango/sardana/test/test_macro.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_macro.py
@@ -273,7 +273,6 @@ class ParamsTestCase(unittest.TestCase):
         Helper to verify the correct building of the parameters objects tree.
         Verify that the list is recreated correctly from the parameters
         objects tree.
-        :param macro_name: (str) name of the macro
         :param param_def:   (list<dict>) macro parameters definition
         :param macro_params: (list<str>) list of strings representing macro
             parameters values.

--- a/src/sardana/taurus/core/tango/sardana/test/test_macro.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_macro.py
@@ -29,9 +29,16 @@ from lxml import etree
 
 from taurus.external import unittest
 from taurus.test import insertTest
+from sardana.taurus.core.tango.sardana.macro import MacroNode
 from sardana.taurus.core.tango.sardana.macro import createMacroNode
 from sardana.macroserver.macro import Type
-
+from sardana.taurus.core.tango.sardana.test import (pt3d_param_def,
+                                                    pt5d_param_def,
+                                                    pt7d_param_def,
+                                                    pt10d_param_def,
+                                                    pt12d_param_def,
+                                                    pt13d_param_def,
+                                                    pt14d_param_def)
 # TODO: Use unittest.mock instead of this fake class.
 from sardana.macroserver.mstypemanager import TypeManager
 class FakeMacroServer(object):
@@ -40,7 +47,7 @@ class FakeMacroServer(object):
 macro_server = FakeMacroServer()
 tm = TypeManager(macro_server)
 
-
+# TODO: Move the parameter definition to res/paramdef.py module
 pt8_params_def = [
     {
         "name" : "m_p_pair",
@@ -65,7 +72,7 @@ pt8_params_def = [
 ]
 pt8_params_value = ["mot73", "5.0", "mot74", "8.0"]
 
-# 
+#
 pt8_xml = \
 '''<macro name="pt8">
   <paramrepeat name="m_p_pair">
@@ -114,3 +121,175 @@ class MacroNodeTestCase(unittest.TestCase):
         expected_xml = etree.fromstring(expected_xml_rep)
         # Validate the XML tree
         self._validateXML(macronode_xml, expected_xml)
+
+
+
+#### Testing a list of elements (floats) ####
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt3d_param_def,
+            macro_params=[["1", "3", "15"]],
+            expected_params_list=[["1", "3", "15"]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt3d_param_def,
+            macro_params=[["3", [], "4"]],
+            expected_params_list=[["3", "100", "4"]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt3d_param_def,
+            macro_params=[[[], [], []]],
+            expected_params_list=[["100", "100", "100"]]
+            )
+
+#### Testing one element (moveable) followed by a ####
+############ list of elements (floats). ##############
+
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt5d_param_def,
+            macro_params=["mot01", ["1", "3", "15"]],
+            expected_params_list=["mot01", ["1", "3", "15"]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt5d_param_def,
+            macro_params=[[], ["1", "3", "15"]],
+            expected_params_list=["mot99", ["1", "3", "15"]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt5d_param_def,
+            macro_params=["mot01", [[], "3", "15"]],
+            expected_params_list=["mot01", ["100", "3", "15"]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt5d_param_def,
+            macro_params=[[], ["1", [], "15"]],
+            expected_params_list=["mot99", ["1", "100", "15"]]
+            )
+
+#### Testing a list of pairs of elements (moveable, float). ####
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt7d_param_def,
+            macro_params=[[["mot01", "0"]]],
+            expected_params_list=[[['mot01', "0"]]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt7d_param_def,
+            macro_params=[[["mot01"]]],
+            expected_params_list=[[['mot01', "100"]]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt7d_param_def,
+            macro_params=[[[]]],
+            expected_params_list=[[['mot99', "100"]]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt7d_param_def,
+            macro_params=[[[[], "50"]]],
+            expected_params_list=[[['mot99', "50"]]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt7d_param_def,
+            macro_params=[[['mot99', []]]],
+            expected_params_list=[[['mot99', "100"]]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt7d_param_def,
+            macro_params=[[["mot01", "0"], ["mot02", "5"], ["mot03", "10"]]],
+            expected_params_list=[[["mot01", "0"], ["mot02", "5"],
+                                   ["mot03", "10"]]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt7d_param_def,
+            macro_params=[[["mot01", "0"], [], ["mot03"]]],
+            expected_params_list=[[["mot01", "0"], ["mot99", "100"],
+                                   ["mot03", "100"]]]
+            )
+## Testing the outer default parameters for the whole repetition.
+## This test is commented because this option is not functional at the moment.
+## See ticket #427 referring to this bug.
+#@insertTest(helper_name='verifyEncoding',
+#            param_def=pt7d_param_def,
+#            macro_params=[[[]]],
+#            expected_params_list=[[['mot01', "50"]]],
+#            )
+
+#### Testing list of elements (moveables) followed by a ####
+################# single parameter (float). ################
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt10d_param_def,
+            macro_params=[["1", "3", "15"], "mot01"],
+            expected_params_list=[["1", "3", "15"], "mot01"]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt10d_param_def,
+            macro_params=[["1", "3", []], "mot01"],
+            expected_params_list=[["1", "3", "100"], "mot01"]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt10d_param_def,
+            macro_params=[["1", "3", "15"], []],
+            expected_params_list=[["1", "3", "15"], "mot99"]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt10d_param_def,
+            macro_params=[["1", [], "15"], []],
+            expected_params_list=[["1", "100", "15"], "mot99"],
+            )
+
+#### Testing lists of elements (floats), followed by another list of ####
+######################### elements (moveables). #########################
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt12d_param_def,
+            macro_params=[["1", "3", "4"], ["mot1", "mot2"]],
+            expected_params_list=[["1", "3", "4"], ["mot1", "mot2"]]
+            )
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt12d_param_def,
+            macro_params=[["1", [], "4"], [[], "mot2"]],
+            expected_params_list=[["1", "100", "4"], ["mot99", "mot2"]]
+            )
+
+########################### Testing nested paramRepeats ########################
+############## Groups of motors, where each group is a motor list ##############
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt13d_param_def,
+            macro_params=[[["mot2", "mot3"], ["mot4", "mot5", "mot6"]]],
+            expected_params_list=[[["mot2", "mot3"], ["mot4", "mot5", "mot6"]]]
+            )
+
+########################### Testing nested paramRepeats ########################
+## Groups of motors, where each group is a motor list followed by a number #####
+@insertTest(helper_name='verifyEncoding',
+            param_def=pt14d_param_def,
+            macro_params=[[[["mot2", "mot3"], 4],
+                           [["mot4", "mot5", "mot6"], 5]]],
+            expected_params_list=[[[["mot2", "mot3"], 4],
+                                   [["mot4", "mot5", "mot6"], 5]]]
+            )
+
+class ParamsTestCase(unittest.TestCase):
+
+    def verifyEncoding(self, param_def, macro_params, expected_params_list):
+        """
+        Helper to verify the correct building of the parameters objects tree.
+        Verify that the list is recreated correctly from the parameters
+        objects tree.
+        :param macro_name: (str) name of the macro
+        :param param_def:   (list<dict>) macro parameters definition
+        :param macro_params: (list<str>) list of strings representing macro
+            parameters values.
+        :param expected_params_list: (list<str>) expected parameters list.
+        """
+
+        # Create the MacroNode with the inputs
+        node = MacroNode(name="macro_name", params_def=param_def)
+        node.fromList(macro_params)
+
+        output_params_list = node.toList()
+        output_params_list.pop(0)
+
+        msg = ("Parameters list is not encoded/decoded correctly. \n"
+               "expected: %s \n"
+               "received: %s" % (expected_params_list, output_params_list))
+        self.assertEqual(output_params_list, expected_params_list, msg)
+
+


### PR DESCRIPTION
Hello,
               I have done a first implementation for extending the new ParamRepeat interface to spock.
The old spock input syntax is , of course, still valid and, as before, only admit ParamRepeat parameters in the last position. With the new interface the ParamRepeat parameters can be used at any position and even recursively. I have choosen the syntax using square brackets as group characters and space as separator e.g.

mv [[mot01 5] [mot02 10]]
pt10 [0 5 10] mot01
pt11 ct01 [10 5 0] mot01
pt12 [0 5 10] [mot01 mot02 mot03]
pt13 [[mot01 mot02 mot03] [mot04 mot05]]

Everything is, of course, open to discussion, this is only a first attempt. 

                                      Regards,
                                                        Teresa