### PR TITLE
Issue 403: upgrade spock if versions are not equal

### DIFF
--- a/src/sardana/spock/ipython_00_10/genutils.py
+++ b/src/sardana/spock/ipython_00_10/genutils.py
@@ -714,15 +714,18 @@ def check_for_upgrade(ipy_profile_file, ipythondir, session, profile):
             door_name = line[line.index('=')+1:].strip()
     
     # convert version from string to numbers
-    spocklib_ver = translate_version_str2int(release.version)
+    spock_lib_ver_str = release.version
+    spocklib_ver = translate_version_str2int(spock_lib_ver_str)
     spock_profile_ver = translate_version_str2int(spock_profile_ver_str)
     
+    alpha_in_spock_profile = "-alpha" in spock_profile_ver_str
+    alpha_in_spock_lib = "-alpha" in spock_lib_ver_str    
     if spocklib_ver == spock_profile_ver and \
-            spock_profile_ver_str.find("-alpha") == -1:
+       alpha_in_spock_profile == alpha_in_spock_lib:       
         return
     if spocklib_ver < spock_profile_ver:
         print '%sYour spock profile (%s) is newer than your spock version ' \
-              '(%s)!' % (TermColors.Brown, spock_profile_ver_str, release.version)
+              '(%s)!' % (TermColors.Brown, spock_profile_ver_str, spock_lib_ver_str)
         print 'Please upgrade spock or delete the current profile %s' % TermColors.Normal
         sys.exit(1)
         
@@ -732,7 +735,7 @@ def check_for_upgrade(ipy_profile_file, ipythondir, session, profile):
         spock_profile_ver_str = '<= 0.2.0'
     msg = 'Your current spock door extension profile has been created with spock %s.\n' \
           'Your current spock door extension version is %s, therefore a profile upgrade is needed.\n' \
-          % (spock_profile_ver_str, release.version)
+          % (spock_profile_ver_str, spock_lib_ver_str)
     print msg
     prompt = 'Do you wish to upgrade now (warn: this will shutdown the current spock session) ([y]/n)? '
     r = raw_input(prompt) or 'y'

--- a/src/sardana/spock/ipython_00_11/genutils.py
+++ b/src/sardana/spock/ipython_00_11/genutils.py
@@ -708,15 +708,18 @@ def check_for_upgrade(ipy_profile_dir):
                 door_name = line[line.index('=')+1:].strip()
 
     # convert version from string to numbers
-    spocklib_ver = translate_version_str2int(release.version)
+    spock_lib_ver_str = release.version
+    spocklib_ver = translate_version_str2int(spock_lib_ver_str)
     spock_profile_ver = translate_version_str2int(spock_profile_ver_str)
 
+    alpha_in_spock_profile = "-alpha" in spock_profile_ver_str
+    alpha_in_spock_lib = "-alpha" in spock_lib_ver_str 
     if spocklib_ver == spock_profile_ver and \
-            spock_profile_ver_str.find("-alpha") == -1:
+       alpha_in_spock_profile == alpha_in_spock_lib:
         return
     if spocklib_ver < spock_profile_ver:
         print '%sYour spock profile (%s) is newer than your spock version ' \
-              '(%s)!' % (SpockTermColors.Brown, spock_profile_ver_str, release.version)
+              '(%s)!' % (SpockTermColors.Brown, spock_profile_ver_str, spock_lib_ver_str)
         print 'Please upgrade spock or delete the current profile %s' % SpockTermColors.Normal
         sys.exit(1)
 
@@ -726,7 +729,7 @@ def check_for_upgrade(ipy_profile_dir):
         spock_profile_ver_str = '<= 0.2.0'
     msg = 'Your current spock door extension profile has been created with spock %s.\n' \
           'Your current spock door extension version is %s, therefore a profile upgrade is needed.\n' \
-          % (spock_profile_ver_str, release.version)
+          % (spock_profile_ver_str, spock_lib_ver_str)
     print msg
     prompt = 'Do you wish to upgrade now (warn: this will shutdown the current spock session) ([y]/n)? '
     r = raw_input(prompt) or 'y'

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -729,15 +729,18 @@ def check_for_upgrade(ipy_profile_dir):
                 door_name = line[line.index('=')+1:].strip()
 
     # convert version from string to numbers
-    spocklib_ver = translate_version_str2int(release.version)
+    spock_lib_ver_str = release.version
+    spocklib_ver = translate_version_str2int(spock_lib_ver_str)
     spock_profile_ver = translate_version_str2int(spock_profile_ver_str)
 
+    alpha_in_spock_profile = "-alpha" in spock_profile_ver_str
+    alpha_in_spock_lib = "-alpha" in spock_lib_ver_str  
     if spocklib_ver == spock_profile_ver and \
-            spock_profile_ver_str.find("-alpha") == -1:
+       alpha_in_spock_profile == alpha_in_spock_lib: 
         return
     if spocklib_ver < spock_profile_ver:
         print '%sYour spock profile (%s) is newer than your spock version ' \
-              '(%s)!' % (SpockTermColors.Brown, spock_profile_ver_str, release.version)
+              '(%s)!' % (SpockTermColors.Brown, spock_profile_ver_str, spock_lib_ver_str)
         print 'Please upgrade spock or delete the current profile %s' % SpockTermColors.Normal
         sys.exit(1)
 
@@ -747,7 +750,7 @@ def check_for_upgrade(ipy_profile_dir):
         spock_profile_ver_str = '<= 0.2.0'
     msg = 'Your current spock door extension profile has been created with spock %s.\n' \
           'Your current spock door extension version is %s, therefore a profile upgrade is needed.\n' \
-          % (spock_profile_ver_str, release.version)
+          % (spock_profile_ver_str, spock_lib_ver_str)
     print msg
     prompt = 'Do you wish to upgrade now (warn: this will shutdown the current spock session) ([y]/n)? '
     r = raw_input(prompt) or 'y'


### PR DESCRIPTION
Spock upgrade fails with alpha releases.
Fix it.

Spock will be upgraded if the spock profile version
and the spock library version does not correspond.

A version containing alpha and another not containing alpha
are considered different versions.