### PR TITLE
Fix issue407: default values for repeat parameters

### DIFF
--- a/src/sardana/macroserver/msparameter.py
+++ b/src/sardana/macroserver/msparameter.py
@@ -444,8 +444,11 @@ class ParamDecoder:
         for raw_repeat in raw_param_repeat:
             if len(param_type) > 1:
                 repeat = []
-                for i, member_raw in enumerate(raw_repeat):
-                    member_type = param_type[i]
+                for i, member_type in enumerate(param_type):
+                    try:
+                        member_raw = raw_repeat[i]
+                    except IndexError:
+                        member_raw = None
                     member = self.decodeNormal(member_raw, member_type)
                     repeat.append(member)
             else:


### PR DESCRIPTION
Fix bug 407.

When using execMacro with repeat parameters, the default values
are not taken into account correctly.

This commit fixes the bug.