### PR TITLE
Accepting brackets for single paramrepeat and default values

### DIFF
--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -141,6 +141,14 @@ def recur_map(fun, data, keep_none=False):
         else:
             return fun(data)
 
+def is_flat_list(obj):
+    """Check if a given object is a flat list."""
+    if not isinstance(obj, list):
+        return False
+    for item in obj:
+        if isinstance(item, list):
+            return False
+    return True
 
 class MacroManager(MacroServerManager):
 
@@ -688,10 +696,7 @@ class MacroManager(MacroServerManager):
             # only if raw params are passed as a list e.g. using macro API
             # execMacro("mv", mot01, 0.0) and parameters definition allows to
             # decode it from a flat list we give it a try
-            for param in raw_params:
-                if (isinstance(param, list)):
-                    raise out_e
-            if (isinstance(raw_params, list) and
+            if (is_flat_list(raw_params) and
                 FlatParamDecoder.isPossible(params_def)):
                 self.debug("Trying flat parameter decoder due to: %s" % out_e)
                 try:

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -688,6 +688,9 @@ class MacroManager(MacroServerManager):
             # only if raw params are passed as a list e.g. using macro API
             # execMacro("mv", mot01, 0.0) and parameters definition allows to
             # decode it from a flat list we give it a try
+            for param in raw_params:
+                if (isinstance(param, list)):
+                    raise out_e
             if (isinstance(raw_params, list) and
                 FlatParamDecoder.isPossible(params_def)):
                 self.debug("Trying flat parameter decoder due to: %s" % out_e)

--- a/src/sardana/macroserver/msparameter.py
+++ b/src/sardana/macroserver/msparameter.py
@@ -399,7 +399,8 @@ class ParamDecoder:
                     if len(value) == 0:
                         value = param_def['default_value']
                     else:
-                        value = value[0]
+                        msg = 'API not allowed'
+                        raise WrongParam, msg
                 if value is None:
                     value = param_def['default_value']
                 if value is None:

--- a/src/sardana/macroserver/msparameter.py
+++ b/src/sardana/macroserver/msparameter.py
@@ -395,13 +395,8 @@ class ParamDecoder:
                     value = raw_param.get("value")
                 else:
                     value = raw_param
-                if type(value) == list:
-                    if len(value) == 0:
-                        value = param_def['default_value']
-                    else:
-                        msg = 'Brackets not allowed for single element repetitions'
-                        raise WrongParam, msg
-                if value is None:
+                # None or [] indicates default value
+                if value is None or (type(value) == list and len(value) == 0):
                     value = param_def['default_value']
                 if value is None:
                     raise MissingParam, "'%s' not specified" % name
@@ -462,6 +457,12 @@ class ParamDecoder:
                 # do not encapsulate it in list and pass directly the item
                 if isinstance(raw_repeat, etree._Element):
                     raw_repeat = raw_repeat[0]
+                # check if one tries to decode repeat parameter of just one
+                # member encapsulated in a list, empty lists are still allowed
+                # to indicate default value
+                elif isinstance(raw_repeat , list) and len(raw_repeat) > 0:
+                    msg = 'Repetitions of just one member must not be lists'
+                    raise WrongParam, msg
                 repeat = self.decodeNormal(raw_repeat, param_type[0])
             param_repeat.append(repeat)
         return param_repeat

--- a/src/sardana/macroserver/msparameter.py
+++ b/src/sardana/macroserver/msparameter.py
@@ -395,6 +395,11 @@ class ParamDecoder:
                     value = raw_param.get("value")
                 else:
                     value = raw_param
+                if type(value) == list:
+                    if len(value) == 0:
+                        value = param_def['default_value']
+                    else:
+                        value = value[0]
                 if value is None:
                     value = param_def['default_value']
                 if value is None:

--- a/src/sardana/macroserver/msparameter.py
+++ b/src/sardana/macroserver/msparameter.py
@@ -399,7 +399,7 @@ class ParamDecoder:
                     if len(value) == 0:
                         value = param_def['default_value']
                     else:
-                        msg = 'API not allowed'
+                        msg = 'Brackets not allowed for single element repetitions'
                         raise WrongParam, msg
                 if value is None:
                     value = param_def['default_value']


### PR DESCRIPTION
Hi, this PR should solve the issue #408, allowing to use brackets for the single element paramrepeat
arguments. 
For example a macro like:

 
```
class pt20_default(Macro):
    """Macro with a list of numbers as parameter."""

    param_def = [
       [ 'numb_list', [ [ 'pos', Type.Float, 3.0, 'value'] ], None, 'List of values'],
    ]

    def run(self, *args, **kwargs):
        self.output(args)
        pass

```
Could be called like:
```
        params = ('pt20_default', [1, 2, 3])
        self.execMacro(params)

```
or

```
        params = ('pt20_default', [1, 2, [3]])
        self.execMacro(params)

```
Also the issue with the default values should be solved, so one could use:

```
        params = ('pt20_default', [1, 2, []])
        self.execMacro(params)
```

The issue with the default values should be solved in general, also for ParamRepeat with several elements. For example:
```

class pt1_default(Macro):
    """Macro with a list of  float pairs"""

    param_def = [
       [ 'p_p_pair', [ [ 'pos', Type.Float, 21, 'Position1'],
                       [ 'pos',   Type.Float, 22, 'Position2'] ],
         None, 'List of position/position pairs']
    ]

    def run(self, *args, **kwargs):
        self.output(args)
        pass
```
 
could be called:

 
```
        params = ('pt1_default', [[2], []])
        self.execMacro(params)
```

and the default values should be correctly taken.

 


