### PR TITLE
Fix  #418 TaurusSequencerWidget fails with stopped MS

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/motion.py
+++ b/src/sardana/taurus/core/tango/sardana/motion.py
@@ -70,7 +70,7 @@ class Moveable:
     def getLastMotionTime(self):
         raise NotImplementedError
 
-    def getTotalLastMotionTime():
+    def getTotalLastMotionTime(self):
         raise NotImplementedError
 
     def abort(self, wait_ready=True, timeout=None):

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/common.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/common.py
@@ -183,7 +183,8 @@ class TaurusMacroConfigurationDialog(Qt.QDialog):
             #state = Device(macroServer).getState()
             state = None
             try:
-                state = PyTango.DeviceProxy(macroServer).state()
+                ms_name = "{0}/{1}".format(db.getNormalName(), macroServer)
+                state = PyTango.DeviceProxy(ms_name).state()
             except:
                 pass
             icon = None

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -951,7 +951,9 @@ class TaurusMacroExecutorWidget(TaurusWidget):
             self.disconnect(oldModelObj, Qt.SIGNAL("macrosUpdated"), self.macroComboBox.onMacrosUpdated)
         TaurusWidget.setModel(self, model)
         newModelObj = self.getModelObj()
-        self.connect(newModelObj, Qt.SIGNAL("macrosUpdated"), self.macroComboBox.onMacrosUpdated)
+        if newModelObj is not None:
+            self.connect(newModelObj, Qt.SIGNAL("macrosUpdated"),
+                         self.macroComboBox.onMacrosUpdated)
 
     @classmethod
     def getQtDesignerPluginInfo(cls):

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -811,7 +811,9 @@ class TaurusSequencerWidget(TaurusWidget):
             self.disconnect(oldModelObj, Qt.SIGNAL("macrosUpdated"), self.macroComboBox.onMacrosUpdated)
         TaurusWidget.setModel(self, model)
         newModelObj = self.getModelObj()
-        self.connect(newModelObj, Qt.SIGNAL("macrosUpdated"), self.macroComboBox.onMacrosUpdated)
+        if newModelObj is not None:
+            self.connect(newModelObj, Qt.SIGNAL("macrosUpdated"),
+                         self.macroComboBox.onMacrosUpdated)
 
     @classmethod
     def getQtDesignerPluginInfo(cls):


### PR DESCRIPTION
TaurusSequencerWidget.SetModel raises an Type error when the
chosen MS is not connected and the door is not defined.

Fix it, checking the value of the new model obj before connect the
signal.