### PR TITLE
Fix #442: allow escaped quotes in parameters (spock)

### DIFF
--- a/src/sardana/spock/test/test_parser.py
+++ b/src/sardana/spock/test/test_parser.py
@@ -29,6 +29,9 @@ from taurus.external import unittest
 from taurus.test import insertTest
 from sardana.spock.parser import ParamParser
 
+@insertTest(helper_name="parse",
+            params_str='ScanFile "[\\"file.nxs\\", \\"file.dat\\"]"',
+            params=["ScanFile", '["file.nxs", "file.dat"]'])
 @insertTest(helper_name="parse", params_str="[1 [] 3]",
             params=[["1", [], "3"]])
 @insertTest(helper_name="parse",


### PR DESCRIPTION
Use negative lookbehind assertion in the regular expression describing
quoted parameter in order to allow passing quotes escaped by backslash.

Also avoid string cutting in order to exclude quotes and single quotes
from the string parameters. Do it by explicit extraction of the given group.