### PR TITLE
Fix #448: expconf problem with timers of 0D

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
@@ -809,9 +809,10 @@ class ChannelDelegate(Qt.QStyledItemDelegate):
                 editor.setCurrentIndex(editor.findText(current))
             else:
                 for ctrl_data in dataSource['controllers'].values():
-                    for channel in ctrl_data['channels']:
-                        editor.addItem(channel['name'], Qt.QVariant(
-                            channel['full_name']))
+                    if key in ctrl_data:
+                        channel = all_channels[ctrl_data[key]]
+                        editor.addItem(channel['name'],
+                                       Qt.QVariant(channel['full_name']))
                 current = dataSource.get(key)  # current global timer/monitor
                 editor.setCurrentIndex(editor.findData(Qt.QVariant(current)))
         elif taurus_role == ChannelView.Synchronization:


### PR DESCRIPTION
Revert implementation to what was present prior 6b5b58e (removing units).
This logic does not have too much sense - timer is not used to control the 0D
chennel but at least it does not provoke exception.