### PR TITLE
Copy-paste bug in read_Value function

### DIFF
--- a/src/sardana/tango/pool/OneDExpChannel.py
+++ b/src/sardana/tango/pool/OneDExpChannel.py
@@ -173,9 +173,9 @@ class OneDExpChannel(PoolElementDevice):
         # buffer so the cached value will be returned only at the first readout
         # after the acquisition. This is a workaround for the step scans which
         # read the value after the acquisition.
-        if not use_cache and len(ct.value.value_buffer) > 0:
+        if not use_cache and len(oned.value.value_buffer) > 0:
             use_cache = True
-            ct.value.clear_buffer()
+            oned.value.clear_buffer()
         value = oned.get_value(cache=use_cache, propagate=0)
         if value.error:
             Except.throw_python_exception(*value.exc_info)

--- a/src/sardana/tango/pool/TwoDExpChannel.py
+++ b/src/sardana/tango/pool/TwoDExpChannel.py
@@ -174,9 +174,9 @@ class TwoDExpChannel(PoolElementDevice):
         # buffer so the cached value will be returned only at the first readout
         # after the acquisition. This is a workaround for the step scans which
         # read the value after the acquisition.
-        if not use_cache and len(ct.value.value_buffer) > 0:
+        if not use_cache and len(twod.value.value_buffer) > 0:
             use_cache = True
-            ct.value.clear_buffer()
+            twod.value.clear_buffer()
         value = twod.get_value(cache=use_cache, propagate=0)
         if value.error:
             Except.throw_python_exception(*value.exc_info)


### PR DESCRIPTION
We found a, I guess, copy-paste bug in the read_Value function of the TwoD and OneD experimental channels, introduced with the sep6 implementation. This PR only correct the copy-paste error.