### PR TITLE
Fix #464: umv unsubscribe in case of exception

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -496,8 +496,10 @@ class umv(Macro):
 
     def run(self, motor_pos_list):
         self.print_pos = True
-        self.execMacro('mv', motor_pos_list)
-        self.finish()
+        try:
+            self.execMacro('mv', motor_pos_list)
+        finally:
+            self.finish()
 
     def finish(self):
         self._clean()

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -505,9 +505,6 @@ class umv(Macro):
         self._clean()
         self.printAllPos()
 
-    def on_abort(self):
-        self.finish()
-
     def _clean(self):
         for motor, pos in self.getParameters()[0]:
             posObj = motor.getPositionObj()


### PR DESCRIPTION
Motor's position attribute stays subscribed in case an exception occurs while
executing the move. Enclose the move with try/finally clause so we unsubscribe in case
of the exception as well as in case of a normal end of movement.