### PR TITLE
Fix #467 - catching and handling exception in a motion ending in alarm

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -463,7 +463,7 @@ class mv(Macro):
         motion = self.getMotion(motors)
         state, pos = motion.move(positions)
         if state != DevState.ON:
-            self.warning("Motion ended in %s", state)
+            self.warning("Motion ended in %s", state.name)
             msg = []
             for motor in motors:
                 msg.append(motor.information())

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -47,7 +47,7 @@ import weakref
 
 from PyTango import DevState, AttrDataFormat, AttrQuality, DevFailed, \
     DeviceProxy
-from taurus import Factory, Device, Attribute, Release
+from taurus import Factory, Device, Attribute
 from taurus.core.taurusbasetypes import TaurusEventType
 
 try:
@@ -503,13 +503,12 @@ class PoolElement(BaseElement, TangoDevice):
         indent = "\n" + tab + 10 * ' '
         msg = [self.getName() + ":"]
         try:
-            if Release.version_info[0] > 3:
-                # For Taurus 4
+            # TODO: For Taurus 4 / Taurus 3 compatibility
+            if hasattr(self, "stateObj"):
                 state_value = self.stateObj.read().rvalue
-                # state is DevState enumeration (IntEnum)
+                # state_value is DevState enumeration (IntEnum)
                 state = state_value.name.capitalize()
             else:
-                # For Taurus 3
                 state = str(self.state()).capitalize()
         except DevFailed as df:
             if len(df.args):

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -124,8 +124,8 @@ class BaseElement(object):
         return self._str_tuple[:n]
 
     def __cmp__(self, o):
-        return cmp(self.getPoolData()['full_name'], o.getPoolData()[
-            'full_name'])
+        return cmp(self.getPoolData()['full_name'],
+                   o.getPoolData()['full_name'])
 
     def getName(self):
         return self.getPoolData()['name']
@@ -258,8 +258,8 @@ def reservedOperation(fn):
         try:
             return fn(*args, **kwargs)
         except:
-            print
-            "Exception occured in reserved operation: clearing events..."
+            print("Exception occurred in reserved operation:"
+                  " clearing events...")
             self._clearEventWait()
             raise
 
@@ -1110,8 +1110,8 @@ def getChannelConfigs(mgconfig, ctrls=None, sort=True):
     if sort:
         # sort the channel configs by index (primary sort) and then by channel
         # name.
-        chconfigs = sorted(chconfigs, key=lambda c: c[
-            0])  # sort by channel_name
+        # sort by channel_name
+        chconfigs = sorted(chconfigs, key=lambda c: c[0])
         # sort by index (give a very large index for those which don't have it)
         chconfigs = sorted(chconfigs, key=lambda c: c[1].get('index', 1e16))
     return chconfigs
@@ -1439,8 +1439,8 @@ class MeasurementGroup(PoolElement):
         cfg_attr.addListener(self.on_configuration_changed)
 
     def _create_str_tuple(self):
-        return self.getName(), self.getTimerName(), ", ".join(
-            self.getChannelNames())
+        return self.getName(), self.getTimerName(), \
+               ", ".join(self.getChannelNames())
 
     def getConfigurationAttrEG(self):
         return self._getAttrEG('Configuration')

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -505,7 +505,7 @@ class PoolElement(BaseElement, TangoDevice):
         try:
             if Release.version_info[0] > 3:
                 # For Taurus 4
-                state = str(self.stateObj.read().rvalue).split('.')[0]
+                state = str(self.stateObj.read().rvalue).split('.')[1]
                 state.capitalize()
             else:
                 # For Taurus 3

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -505,8 +505,9 @@ class PoolElement(BaseElement, TangoDevice):
         try:
             if Release.version_info[0] > 3:
                 # For Taurus 4
-                state = str(self.stateObj.read().rvalue).split('.')[1]
-                state.capitalize()
+                state_value = self.stateObj.read().rvalue
+                # state is DevState enumeration (IntEnum)
+                state = state_value.name.capitalize()
             else:
                 # For Taurus 3
                 state = str(self.state()).capitalize()

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -510,7 +510,10 @@ class PoolElement(BaseElement, TangoDevice):
         except:
             e_info = sys.exc_info()[:2]
             state = traceback.format_exception_only(*e_info)
-        msg.append(tab + "   State: " + state)
+        try:
+            msg.append(tab + "   State: " + state)
+        except TypeError:
+            msg.append(tab + "   State: " + state[0])
 
         try:
             e_info = sys.exc_info()[:2]

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -23,14 +23,15 @@
 ##
 ##############################################################################
 
-"""The device pool submodule. It contains specific part of sardana device pool"""
+"""The device pool submodule.
+It contains specific part of sardana device pool"""
 
 __all__ = ["InterruptException", "StopException", "AbortException",
            "BaseElement", "ControllerClass", "ControllerLibrary",
            "PoolElement", "Controller", "ComChannel", "ExpChannel",
            "CTExpChannel", "ZeroDExpChannel", "OneDExpChannel",
-           "TwoDExpChannel",
-           "PseudoCounter", "Motor", "PseudoMotor", "MotorGroup", "TriggerGate",
+           "TwoDExpChannel", "PseudoCounter", "Motor", "PseudoMotor",
+           "MotorGroup", "TriggerGate",
            "MeasurementGroup", "IORegister", "Instrument", "Pool",
            "registerExtensions", "getChannelConfigs"]
 
@@ -113,8 +114,9 @@ class BaseElement(object):
         return self.getPoolData()
 
     def str(self, n=0):
-        """Returns a sequence of strings representing the object in 'consistent'
-        way. Default is to return <name>, <controller name>, <axis>
+        """Returns a sequence of strings representing the object in
+        'consistent' way.
+        Default is to return <name>, <controller name>, <axis>
 
         :param n: the number of elements in the tuple."""
         if n == 0:
@@ -392,7 +394,8 @@ class PoolElement(BaseElement, TangoDevice):
         return self._pool_obj
 
     def waitReady(self, timeout=None):
-        return self.getStateEG().waitEvent(Moving, equal=False, timeout=timeout)
+        return self.getStateEG().waitEvent(Moving, equal=False,
+                                           timeout=timeout)
 
     def getAttrEG(self, name):
         """Returns the TangoAttributeEG object"""
@@ -734,7 +737,7 @@ class Motor(PoolElement, Moveable):
     def setSign(self, value):
         return self.getSignObj().write(value)
 
-    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
     # Moveable interface
     #
 
@@ -744,7 +747,7 @@ class Motor(PoolElement, Moveable):
             new_pos = new_pos[0]
         try:
             self.write_attribute('position', new_pos)
-        except DevFailed, df:
+        except DevFailed as df:
             for err in df:
                 if err.reason == 'API_AttrNotAllowed':
                     raise RuntimeError('%s is already moving' % self)
@@ -779,16 +782,16 @@ class Motor(PoolElement, Moveable):
             time_stamp = time.time()
             try:
                 self.getPositionObj().write(new_pos)
-            except DevFailed, err_traceback:
+            except DevFailed as err_traceback:
                 for err in err_traceback:
                     if err.reason == 'API_AttrNotAllowed':
-                        raise RuntimeError, '%s is already moving' % self
+                        raise RuntimeError('%s is already moving' % self)
                     else:
                         raise
             self.final_pos = new_pos
-            # putting timeout=0.1 and retries=1 is a patch for the case the when the initial
-            # moving event doesn't arrive do to an unknow tango/pytango error
-            # at the time
+            # putting timeout=0.1 and retries=1 is a patch for the case when
+            # the initial moving event doesn't arrive do to an unknown
+            # tango/pytango error at the time
             evt_wait.waitEvent(DevState.MOVING, time_stamp,
                                timeout=0.1, retries=1)
         finally:
@@ -823,7 +826,7 @@ class Motor(PoolElement, Moveable):
 
     #
     # End of Moveable interface
-    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 
     def _information(self, tab='    '):
         msg = PoolElement._information(self, tab=tab)
@@ -866,7 +869,7 @@ class PseudoMotor(PoolElement, Moveable):
     def getDialPositionObj(self):
         return self.getPositionObj()
 
-    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
     # Moveable interface
     #
 
@@ -913,7 +916,7 @@ class PseudoMotor(PoolElement, Moveable):
 
     #
     # End of Moveable interface
-    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 
     def _information(self, tab='    '):
         msg = PoolElement._information(self, tab=tab)
@@ -960,7 +963,7 @@ class MotorGroup(PoolElement, Moveable):
     def getPositionObj(self):
         return self._getAttrEG('position')
 
-    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
     # Moveable interface
     #
 
@@ -1007,7 +1010,7 @@ class MotorGroup(PoolElement, Moveable):
 
     #
     # End of Moveable interface
-    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 
     def _information(self, tab='    '):
         msg = PoolElement._information(self, tab=tab)
@@ -1127,7 +1130,8 @@ class MGConfiguration(object):
 
         #####################
         # @todo: the for-loops above could be replaced by something like:
-        # self.channels = channels = CaselessDict(getChannelConfigs(data,sort=False))
+        # self.channels = channels = CaselessDict(getChannelConfigs(data,
+        #                                                          sort=False))
         #####################
 
         # seq<dict> each element is the channel data in form of a dict as
@@ -1488,7 +1492,7 @@ class MeasurementGroup(PoolElement):
 
     def getCounters(self):
         cfg = self.getConfiguration()
-        return [ch for ch in self.getChannels() if ch['full_name'] != cfg.timer]
+        return [c for c in self.getChannels() if c['full_name'] != cfg.timer]
 
     def getChannelNames(self):
         return [ch['name'] for ch in self.getChannels()]
@@ -1684,10 +1688,10 @@ class IORegister(PoolElement):
         try:
             self.getValueObj().write(new_value)
             self.final_val = new_value
-        except DevFailed, err_traceback:
+        except DevFailed as err_traceback:
             for err in err_traceback:
                 if err.reason == 'API_AttrNotAllowed':
-                    raise RuntimeError, '%s is already chaging' % self
+                    raise RuntimeError('%s is already chaging' % self)
                 else:
                     raise
 
@@ -1764,9 +1768,9 @@ class Pool(TangoDevice, MoveableSource):
                 # skip configuration errors
                 if d.reason == "API_BadConfigurationProperty":
                     return
-                if d.reason in (
-                "API_DeviceNotExported", "API_CantConnectToDevice"):
-                    msg = "Pool was shutdown or is inacessible"
+                if d.reason in ("API_DeviceNotExported",
+                                "API_CantConnectToDevice"):
+                    msg = "Pool was shutdown or is inaccessible"
                 else:
                     msg = "{0}: {1}".format(d.reason, d.desc)
             self.warning("Received elements error event %s", msg)
@@ -1854,7 +1858,7 @@ class Pool(TangoDevice, MoveableSource):
     def __str__(self):
         return repr(self)
 
-    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
     # MoveableSource interface
     #
 
@@ -1908,7 +1912,7 @@ class Pool(TangoDevice, MoveableSource):
 
     #
     # End of MoveableSource interface
-    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 
     def _wait_for_element_in_container(self, container, elem_name, timeout=0.5,
                                        contains=True):

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -505,7 +505,8 @@ class PoolElement(BaseElement, TangoDevice):
         try:
             if Release.version_info[0] > 3:
                 # For Taurus 4
-                state = str(self.stateObj.read().rvalue).capitalize()
+                state = str(self.stateObj.read().rvalue).split('.')[0]
+                state.capitalize()
             else:
                 # For Taurus 3
                 state = str(self.state()).capitalize()

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -511,7 +511,7 @@ class PoolElement(BaseElement, TangoDevice):
                 e_info = sys.exc_info()[:2]
                 state = traceback.format_exception_only(*e_info)
         except TypeError:  # we assume state is a TaurusDevState
-            state = str(self.state).capitalize()
+            state = str(self.state)
         except:
             e_info = sys.exc_info()[:2]
             state = traceback.format_exception_only(*e_info)

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -47,7 +47,7 @@ import weakref
 
 from PyTango import DevState, AttrDataFormat, AttrQuality, DevFailed, \
     DeviceProxy
-from taurus import Factory, Device, Attribute
+from taurus import Factory, Device, Attribute, Release
 from taurus.core.taurusbasetypes import TaurusEventType
 
 try:
@@ -124,8 +124,8 @@ class BaseElement(object):
         return self._str_tuple[:n]
 
     def __cmp__(self, o):
-        return cmp(self.getPoolData()['full_name'],
-                   o.getPoolData()['full_name'])
+        return cmp(self.getPoolData()['full_name'], o.getPoolData()[
+            'full_name'])
 
     def getName(self):
         return self.getPoolData()['name']
@@ -503,15 +503,18 @@ class PoolElement(BaseElement, TangoDevice):
         indent = "\n" + tab + 10 * ' '
         msg = [self.getName() + ":"]
         try:
-            state = str(self.state()).capitalize()
+            if Release.version_info[0] > 3:
+                # For Taurus 4
+                state = str(self.stateObj.read().rvalue).capitalize()
+            else:
+                # For Taurus 3
+                state = str(self.state()).capitalize()
         except DevFailed as df:
             if len(df.args):
                 state = df.args[0].desc
             else:
                 e_info = sys.exc_info()[:2]
                 state = traceback.format_exception_only(*e_info)
-        except TypeError:  # we assume state is a TaurusDevState
-            state = str(self.state)
         except:
             e_info = sys.exc_info()[:2]
             state = traceback.format_exception_only(*e_info)

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1440,7 +1440,7 @@ class MeasurementGroup(PoolElement):
 
     def _create_str_tuple(self):
         return self.getName(), self.getTimerName(), \
-               ", ".join(self.getChannelNames())
+                ", ".join(self.getChannelNames())
 
     def getConfigurationAttrEG(self):
         return self._getAttrEG('Configuration')

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -510,6 +510,8 @@ class PoolElement(BaseElement, TangoDevice):
             else:
                 e_info = sys.exc_info()[:2]
                 state = traceback.format_exception_only(*e_info)
+        except TypeError:  # we assume state is a TaurusDevState
+            state = str(self.state).capitalize()
         except:
             e_info = sys.exc_info()[:2]
             state = traceback.format_exception_only(*e_info)

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1439,8 +1439,8 @@ class MeasurementGroup(PoolElement):
         cfg_attr.addListener(self.on_configuration_changed)
 
     def _create_str_tuple(self):
-        return self.getName(), self.getTimerName(), \
-                ", ".join(self.getChannelNames())
+        channel_names = ", ".join(self.getChannelNames())
+        return self.getName(), self.getTimerName(), channel_names
 
     def getConfigurationAttrEG(self):
         return self._getAttrEG('Configuration')


### PR DESCRIPTION
This is a very simple fix of #467 and a PEP8-ification of the module the error was in.
Also, when I've printed that value of `state` variable that caused the exception here, I got what I've reported in #456 , so:
```
["TypeError: 'TaurusDevState' object is not callable\n"]
```
But I guess that that is another issue. Only now have I learned why I've seen it and not the exception: it turns out that @daneos has hot-fixed it.