### PR TITLE
Provide data to 'ct' macro

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -676,7 +676,13 @@ class ct(Macro):
         for line in table.genOutput():
             self.output(line)
 
-
+        # Prepare data result to be extracted by getData()
+        self._data = {}
+        self._data['mntGrp'] = self.mnt_grp_name
+        self._data['integ_time'] = integ_time
+        self._data['data'] = zip(names, counts)
+        self.debug("Data: %r ", self._data)
+        
 class uct(Macro):
     """Count on the active measurement group and update"""
 

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -678,7 +678,7 @@ class ct(Macro):
 
         # Prepare data result to be extracted by getData()
         self._data = {}
-        self._data['mntGrp'] = self.mnt_grp.name
+        self._data['mnt_grp'] = self.mnt_grp.name
         self._data['integ_time'] = integ_time
         self._data['data'] = zip(names, counts)
         self.debug("Data: %r ", self._data)

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -678,7 +678,7 @@ class ct(Macro):
 
         # Prepare data result to be extracted by getData()
         self._data = {}
-        self._data['mntGrp'] = self.mnt_grp
+        self._data['mntGrp'] = self.mnt_grp.name
         self._data['integ_time'] = integ_time
         self._data['data'] = zip(names, counts)
         self.debug("Data: %r ", self._data)

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -682,7 +682,7 @@ class ct(Macro):
         self._data['integ_time'] = integ_time
         self._data['data'] = zip(names, counts)
         self.debug("Data: %r ", self._data)
-        
+
 class uct(Macro):
     """Count on the active measurement group and update"""
 

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -678,7 +678,7 @@ class ct(Macro):
 
         # Prepare data result to be extracted by getData()
         self._data = {}
-        self._data['mntGrp'] = self.mnt_grp_name
+        self._data['mntGrp'] = self.mnt_grp
         self._data['integ_time'] = integ_time
         self._data['data'] = zip(names, counts)
         self.debug("Data: %r ", self._data)

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -681,7 +681,6 @@ class ct(Macro):
         self._data['mnt_grp'] = self.mnt_grp.name
         self._data['integ_time'] = integ_time
         self._data['data'] = zip(names, counts)
-        self.debug("Data: %r ", self._data)
 
 class uct(Macro):
     """Count on the active measurement group and update"""


### PR DESCRIPTION
Proposal for Issue #471

'ct' macro does not allow data access.
Add access to data via getData() in 'ct' macro.