### PR TITLE
Avoid import OrderedDict from taurus

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ requires = [
     'itango (>=0.0.1)',
     'taurus (>= 3.6.0)',
     'lxml (>=2.1)',
+    # ordereddict is necessary for Python < 2.6
+    'ordereddict'
 ]
 
 console_scripts = [

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -42,7 +42,12 @@ from lxml import etree
 
 from PyTango import DevFailed
 
-from taurus.external.ordereddict import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    # For Python < 2.7
+    from ordereddict import OrderedDict
+
 from taurus.core.util.log import Logger
 from taurus.core.util.codecs import CodecFactory
 
@@ -1060,7 +1065,6 @@ class MacroExecutor(Logger):
         macro_name = meta_macro.name
         macro_id = init_opts.get("id")
         if macro_id is None:
-            macro_id = str(self.getNewMacroID())
             init_opts["id"] = macro_id
         macro_line = self._composeMacroLine(macro_name, macro_params, macro_id)
 

--- a/src/sardana/macroserver/msrecordermanager.py
+++ b/src/sardana/macroserver/msrecordermanager.py
@@ -35,7 +35,11 @@ import sys
 import copy
 import inspect
 
-from taurus.external.ordereddict import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    # For Python < 2.7
+    from ordereddict import OrderedDict
 
 from sardana import sardanacustomsettings
 from sardana.sardanaexception import format_exception_only_str

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -41,11 +41,16 @@ import numpy as np
 import PyTango
 import taurus
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    # For Python < 2.7
+    from ordereddict import OrderedDict
+
 from taurus.core import TaurusListener, TaurusEventType
 from taurus.core.util.log import Logger
 from taurus.core.util.user import USER_NAME
 from taurus.core.util.codecs import CodecFactory
-from taurus.external.ordereddict import OrderedDict
 from taurus.core.tango import FROM_TANGO_TO_STR_TYPE
 from taurus.core.util.enumeration import Enumeration
 

--- a/src/sardana/pool/poolaction.py
+++ b/src/sardana/pool/poolaction.py
@@ -36,8 +36,13 @@ import weakref
 import traceback
 import threading
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    # For Python < 2.7
+    from ordereddict import OrderedDict
+
 from taurus.core.util.log import Logger
-from taurus.external.ordereddict import OrderedDict
 
 from sardana import State
 from sardana.sardanathreadpool import get_thread_pool

--- a/src/sardana/pool/poolcontrollermanager.py
+++ b/src/sardana/pool/poolcontrollermanager.py
@@ -37,7 +37,12 @@ import copy
 import types
 import inspect
 
-from taurus.external.ordereddict import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    # For Python < 2.7
+    from ordereddict import OrderedDict
+
 from taurus.core import ManagerState
 from taurus.core.util.log import Logger
 from taurus.core.util.singleton import Singleton

--- a/src/sardana/sardanabuffer.py
+++ b/src/sardana/sardanabuffer.py
@@ -32,7 +32,11 @@ __all__ = ["SardanaBuffer", "LateValueException", "EarlyValueException"]
 
 import weakref
 
-from taurus.external.ordereddict import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    # For Python < 2.7
+    from ordereddict import OrderedDict
 
 from .sardanavalue import SardanaValue
 from .sardanaevent import EventGenerator, EventType


### PR DESCRIPTION
Sardana imports OrderedDict module from taurus.external and it will
be dropped in the next release.

Fix #481