### PR TITLE
Fix bug when updating macro arguments

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -230,7 +230,7 @@ class MacroButton(TaurusWidget):
             self.macro_args.append('')
         # some signals may come with other than string argumenst e.g. int
         # so convert them to string
-        value = Qt.from_qvariant(value, str)
+        value = str(value)
         # string arguments may contain spaces so encapsulate them in quotes
         if re.search('\s', value):
             value = '"{0}"'.format(value)

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -228,7 +228,7 @@ class MacroButton(TaurusWidget):
         # make sure that the macro_args is at least as long as index
         while len(self.macro_args) < index + 1:
             self.macro_args.append('')
-        # some signals may come with other than string argumenst e.g. int, float
+        # some signals may come with other than string argumenst e.g. int
         # so convert them to string
         value = Qt.from_qvariant(value, str)
         # string arguments may contain spaces so encapsulate them in quotes

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -229,8 +229,7 @@ class MacroButton(TaurusWidget):
         while len(self.macro_args) < index + 1:
             self.macro_args.append('')
         # update the given argument
-        if re.search('\s', value):
-            value = '"{0}"'.format(value)
+        value = '"{0}"'.format(value)
         self.macro_args[index] = str(value)
         # update tooltip
         self.setToolTip(self.macro_name + ' ' + ' '.join(self.macro_args))

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -223,14 +223,19 @@ class MacroButton(TaurusWidget):
         '''change a given argument
 
         :param index: (int) positional index for this argument
-        :param value: (str) value for this argument
+        :param value: value for this argument
         '''
         # make sure that the macro_args is at least as long as index
         while len(self.macro_args) < index + 1:
             self.macro_args.append('')
+        # some signals may come with other than string argumenst e.g. int, float
+        # so convert them to string
+        value = Qt.from_qvariant(value, str)
+        # string arguments may contain spaces so encapsulate them in quotes
+        if re.search('\s', value):
+            value = '"{0}"'.format(value)
         # update the given argument
-        value = '"{0}"'.format(value)
-        self.macro_args[index] = str(value)
+        self.macro_args[index] = value
         # update tooltip
         self.setToolTip(self.macro_name + ' ' + ' '.join(self.macro_args))
 


### PR DESCRIPTION
A string value is expected as argument for updateMacroArgument
method. However, this value comes from any valid signal and
could be any other object.

Remove the regular expression statement before string conversion.