### PR TITLE
Pip install requirements

### DIFF
--- a/doc/source/users/getting_started/installing.rst
+++ b/doc/source/users/getting_started/installing.rst
@@ -5,14 +5,14 @@
 Installing
 ==========
 
-Installing with easy_install [1]_ (platform-independent)
+Installing with pip [1]_ (platform-independent)
 --------------------------------------------------------
 
-Sardana can be installed using easy_install. The following command will
+Sardana can be installed using pip. The following command will
 automatically download and install the latest release of Sardana (see
-easy_install --help for options)::
+pip --help for options)::
 
-       easy_install -U sardana
+       pip install sardana
 
 You can test the installation by running::
 
@@ -125,9 +125,9 @@ Sardana has dependencies on some python libraries:
 
 .. [1] This command requires super user previledges on linux systems. If your
        user has them you can usually prefix the command with *sudo*:
-       ``sudo easy_install -U sardana``. Alternatively, if you don't have
+       ``sudo pip -U sardana``. Alternatively, if you don't have
        administrator previledges, you can install locally in your user
-       directory with: ``easy_install --user sardana``
+       directory with: ``pip --user sardana``
        In this case the executables are located at <HOME_DIR>/.local/bin. Make
        sure the PATH is pointing there or you execute from there.
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,15 @@ requires = [
     'ordereddict'
 ]
 
+install_requires = [
+    'PyTango (>=7.2.3)',
+    'itango (>=0.0.1)',
+    'taurus (>= 3.6.0)',
+    'lxml (>=2.1)',
+    'ordereddict;python_version<"2.7"'
+]
+
+
 console_scripts = [
     "MacroServer = sardana.tango.macroserver:main",
     "Pool = sardana.tango.pool:main",
@@ -118,5 +127,6 @@ setup(name='sardana',
       entry_points=entry_points,
       provides=provides,
       requires=requires,
+      install_requires=install_requires,
       test_suite='sardana.test.testsuite.get_sardana_unitsuite',
       )

--- a/setup.py
+++ b/setup.py
@@ -62,11 +62,10 @@ requires = [
 ]
 
 install_requires = [
-    'PyTango (>=7.2.3)',
-    'itango (>=0.0.1)',
-    'taurus (>= 3.6.0)',
-    'lxml (>=2.1)',
-    'ordereddict;python_version<"2.7"'
+    'PyTango>=7.2.3',
+    'itango>=0.0.1',
+    'taurus>=3.6.0',
+    'lxml>=2.1'
 ]
 
 


### PR DESCRIPTION
Handle install requirements when using `pip`, ~~also conditionally install `ordereddict` when using Python < 2.6~~. 
Apart of that update the documentation to install with `pip` instead of `easy_install`.