### PR TITLE
Add timescan

### DIFF
--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -149,7 +149,7 @@ class aNscan(Hookable):
                                      self._period_generator, moveables, env, constrains, extrainfodesc)
             elif mode == ContinuousHwTimeMode:
                 self.nr_interv = scan_length
-                self.nr_of_points = self.nr_interv + 1
+                self.nr_points = self.nr_interv + 1
                 mg_name = self.getEnv('ActiveMntGrp')
                 mg = self.getMeasurementGroup(mg_name)
                 mg_latency_time = mg.getLatencyTime()
@@ -245,8 +245,8 @@ class aNscan(Hookable):
             'post-move') + [self._fill_missing_records]
         step["post-move-hooks"] = post_move_hooks
         step["check_func"] = []
-        step["active_time"] = self.nr_of_points * (self.integ_time +
-                                                   self.latency_time)
+        step["active_time"] = self.nr_points * (self.integ_time +
+                                                self.latency_time)
         step["positions"] = []
         step["start_positions"] = []
         starts = self.starts
@@ -321,7 +321,7 @@ class aNscan(Hookable):
 
     def _fill_missing_records(self):
         # fill record list with dummy records for the final padding
-        nb_of_points = self.nr_of_points
+        nb_of_points = self.nr_points
         scan = self._gScan
         nb_of_records = len(scan.data.records)
         missing_records = nb_of_points - nb_of_records

--- a/src/sardana/macroserver/recorders/output.py
+++ b/src/sardana/macroserver/recorders/output.py
@@ -168,8 +168,7 @@ class OutputRecorder(DataRecorder):
         msg = "Scan #%d started at %s." % (serialno, starttime)
         if not estimatedtime is None:
             estimatedtime = datetime.timedelta(0, abs(estimatedtime))
-            msg += " It will take at least %s\n" % estimatedtime
-            msg += "Moving to start positions..."
+            msg += " It will take at least %s" % estimatedtime
         self._stream.info(msg)
 
         labels, col_names, col_sizes = [], [], []

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2026,7 +2026,7 @@ class CTScan(CScan):
             moveable = moveables[MASTER].full_name
             self.measurement_group.setMoveable(moveable)
             path = motion_paths[MASTER]
-            repeats = self.macro.nr_of_points
+            repeats = self.macro.nr_points
             active_time = self.macro.integ_time
             active_position = path.max_vel * active_time
             if not path.positive_displacement:

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -898,7 +898,7 @@ class GScan(Logger):
             self.end()
             self.do_restore()
             if endstatus != ScanEndStatus.Normal:
-                raise e
+                raise
 
     def scan_loop(self):
         raise NotImplementedError('Scan method cannot be called by '
@@ -1810,7 +1810,16 @@ class CAcquisition(object):
         # e.g. dict(data=seq<float>, index=seq<int>)
         if value_buffer is None:
             return
-        info = {'label': channel.getFullName()}
+        # TODO: for Taurus4 compatibility
+        # The sardana code is not fully ready to deal with Taurus4 model names
+        # strip scheme name that appeared in the full_name since Taurus4
+        # and come back to the Taurus3 style full name cause all the recording
+        # stuff and the measurement group counts is based on them
+        full_name = channel.getFullName()
+        if full_name.startswith("tango://"):
+            full_name = full_name.lstrip("tango://")
+
+        info = {'label': full_name}
         info.update(value_buffer)
         # info is a dictionary with at least keys: label, data,
         # index and its values are of type string for label and

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2400,7 +2400,7 @@ class TScan(GScan, CAcquisition):
         else:
             try:
                 active_time = getattr(self.macro, "integ_time")
-                repeats = getattr(self.macro, "nr_interv")
+                repeats = getattr(self.macro, "nr_points")
             except AttributeError:
                 msg = "Macro object is missing synchronization attributes"
                 raise ScanSetupError(msg)

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -37,6 +37,7 @@ import operator
 import time
 import threading
 import numpy as np
+import math
 
 import PyTango
 import taurus
@@ -1329,7 +1330,7 @@ class CScan(GScan):
         then use the current top velocity"""
 
         top_vel_obj = motor.getVelocityObj()
-        min_top_vel, max_top_vel = top_vel_obj.getRange()
+        _, max_top_vel = top_vel_obj.getRange()
         try:
             max_top_vel = float(max_top_vel)
         except ValueError:
@@ -1341,6 +1342,9 @@ class CScan(GScan):
                 max_top_vel = self._maxVelDict[motor]
             except AttributeError:
                 pass
+        # Taurus4 reports -inf or inf when no limits are defined (NotSpecified)
+        if math.isinf(max_top_vel):
+            max_top_vel = motor.getVelocity()
         return max_top_vel
 
     def get_min_acc_time(self, motor):
@@ -1349,10 +1353,13 @@ class CScan(GScan):
         then use the current acceleration time"""
 
         acc_time_obj = motor.getAccelerationObj()
-        min_acc_time, max_acc_time = acc_time_obj.getRange()
+        min_acc_time, _ = acc_time_obj.getRange()
         try:
             min_acc_time = float(min_acc_time)
         except ValueError:
+            min_acc_time = motor.getAcceleration()
+        # Taurus4 reports -inf or inf when no limits are defined (NotSpecified)
+        if math.isinf(min_acc_time):
             min_acc_time = motor.getAcceleration()
         return min_acc_time
 
@@ -1362,11 +1369,14 @@ class CScan(GScan):
         then use the current acceleration time"""
 
         dec_time_obj = motor.getDecelerationObj()
-        min_dec_time, max_dec_time = dec_time_obj.getRange()
+        min_dec_time, _ = dec_time_obj.getRange()
         try:
             min_dec_time = float(min_dec_time)
         except ValueError:
             min_dec_time = motor.getDeceleration()
+        # Taurus4 reports -inf or inf when no limits are defined (NotSpecified)
+        if math.isinf(min_dec_time):
+            min_dec_time = motor.getAcceleration()
         return min_dec_time
 
     def set_max_top_velocity(self, motor):

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -616,9 +616,11 @@ class GScan(Logger):
                     i += 1
                 else:
                     plotAxes.append(a)
-
+            # TODO: for Taurus4 compatibility
+            full_name = ci.full_name
+            full_name = "tango://%s" % full_name
             # create the ColumnDesc object
-            column = ColumnDesc(name=ci.full_name,
+            column = ColumnDesc(name=full_name,
                                 label=ci.label,
                                 dtype=ci.data_type,
                                 shape=ci.shape,
@@ -1805,7 +1807,11 @@ class CAcquisition(object):
         # e.g. dict(data=seq<float>, index=seq<int>)
         if value_buffer is None:
             return
-        info = {'label': channel.getFullName()}
+        full_name = channel.getFullName()
+        # TODO: for Taurus4 compatibility
+        if not full_name.startswith("tango://"):
+            full_name = "tango://%s" % full_name
+        info = {'label': full_name}
         info.update(value_buffer)
         # info is a dictionary with at least keys: label, data,
         # index and its values are of type string for label and

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -259,7 +259,10 @@ class GScan(Logger):
         # ----------------------------------------------------------------------
         # Setup motion objects
         # ----------------------------------------------------------------------
-        self._motion = macro.getMotion(moveable_names)
+        if len(moveable_names) > 0:
+            self._motion = macro.getMotion(moveable_names)
+        else:
+            self._motion = None
 
         # ----------------------------------------------------------------------
         # Find the measurement group
@@ -604,6 +607,10 @@ class GScan(Logger):
             i = 0
             for a in ci.plot_axes:
                 if a == '<mov>':
+                    # skip plots against moveables in scans that do not involve
+                    # them e.g. time scans
+                    if len(ref_moveables) == 0:
+                        continue
                     plotAxes.append(ref_moveables[i])
                     i += 1
                 else:
@@ -1100,7 +1107,11 @@ class CScan(GScan):
         # This is due to the fact that the CTScan coordinates the
         # pseudomotors' underneeth physical motors on on their constant
         # velocity in contrary to the the CScan which do not coordinate them
-        self._physical_motion = self.macro.getMotion(physical_moveables_names)
+        if len(physical_moveables_names) > 0:
+            self._physical_motion = self.macro.getMotion(
+                physical_moveables_names)
+        else:
+            self._physical_motion = None
 
     def populate_moveables_data_structures(self, moveables):
         '''Populates moveables data structures.

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -618,11 +618,9 @@ class GScan(Logger):
                     i += 1
                 else:
                     plotAxes.append(a)
-            # TODO: for Taurus4 compatibility
-            full_name = ci.full_name
-            full_name = "tango://%s" % full_name
+
             # create the ColumnDesc object
-            column = ColumnDesc(name=full_name,
+            column = ColumnDesc(name=ci.full_name,
                                 label=ci.label,
                                 dtype=ci.data_type,
                                 shape=ci.shape,
@@ -1812,11 +1810,7 @@ class CAcquisition(object):
         # e.g. dict(data=seq<float>, index=seq<int>)
         if value_buffer is None:
             return
-        full_name = channel.getFullName()
-        # TODO: for Taurus4 compatibility
-        if not full_name.startswith("tango://"):
-            full_name = "tango://%s" % full_name
-        info = {'label': full_name}
+        info = {'label': channel.getFullName()}
         info.update(value_buffer)
         # info is a dictionary with at least keys: label, data,
         # index and its values are of type string for label and

--- a/src/sardana/pool/poolbasegroup.py
+++ b/src/sardana/pool/poolbasegroup.py
@@ -175,8 +175,12 @@ class PoolBaseGroup(PoolContainer):
             # a tango channel or non internal element (ex: ioregister or motor
             # in measurement group)
             if not internal:
+                # TODO: for Taurus4 compatibility
                 validator = TangoAttributeNameValidator()
                 params = validator.getParams(user_element_id)
+                if params is None:
+                    user_element_id = "tango://%s" % user_element_id
+                    params = validator.getParams(user_element_id)
                 params['pool'] = self._get_pool()
                 user_element = PoolExternalObject(**params)
             self.add_user_element(user_element)

--- a/src/sardana/tango/pool/test/base_sartest.py
+++ b/src/sardana/tango/pool/test/base_sartest.py
@@ -118,7 +118,7 @@ class SarTestTestCase(BasePoolTestCase):
                 self.ctrl_list.append(ctrl_name)
                 for role in roles:
                     elem = role.split("=")[1]
-                    if not elem in self.elem_list:
+                    if elem not in self.elem_list:
                         self.elem_list.append(elem)
         except Exception, e:
             # force tearDown in order to eliminate the Pool

--- a/src/sardana/tango/pool/test/base_sartest.py
+++ b/src/sardana/tango/pool/test/base_sartest.py
@@ -32,7 +32,7 @@ __all__ = ['SarTestTestCase']
 
 class SarTestTestCase(BasePoolTestCase):
     """ Base class to setup sardana test environment.
-        It creates the controllers defined in cls_list
+        It creates the controllers defined in cls_list and pseudo_cls_list
         with the given 'n' elements.
 
         - cls_list is a list of tuples: (ctrl_class, prefix, subfix, num_elem)
@@ -50,10 +50,26 @@ class SarTestTestCase(BasePoolTestCase):
          'DummyCounterTimerController', '_test_ct', '1', 5),
         ('CTExpChannel', 'DummyCounterTimerController',
          'DummyCounterTimerController', '_test_ct', '2', 5),
+        ('ZeroDExpChannel', 'DummyZeroDController',
+         'DummyZeroDController', '_test_0d', '1', 5),
+        ('ZeroDExpChannel', 'DummyZeroDController',
+         'DummyZeroDController', '_test_0d', '2', 5),
+        ('OneDExpChannel', 'DummyOneDController',
+         'DummyOneDController', '_test_1d', '1', 5),
+        ('OneDExpChannel', 'DummyOneDController',
+         'DummyOneDController', '_test_1d', '2', 5),
+        ('TwoDExpChannel', 'DummyTwoDController',
+         'DummyTwoDController', '_test_2d', '1', 5),
+        ('TwoDExpChannel', 'DummyTwoDController',
+         'DummyTwoDController', '_test_2d', '2', 5),
         ('TriggerGate', 'DummyTriggerGateController',
-         'DummyTriggerGateController', '_test_tg', '1', 5),
-        ('TriggerGate', 'DummyTriggerGateController',
-         'DummyTriggerGateController', '_test_tg', '2', 5)
+         'DummyTriggerGateController', '_test_tg', '1', 5)
+    ]
+
+    pseudo_cls_list = [
+        ('PseudoCounter', 'IoverI0',
+         'IoverI0', '_test_pc', '1', "I=_test_ct_1_2", "I0=_test_ct_1_1",
+         "IoverI0=_test_pc_1_1")
     ]
 
     def setUp(self):
@@ -62,8 +78,9 @@ class SarTestTestCase(BasePoolTestCase):
         self.ctrl_list = []
         self.elem_list = []
         try:
+            # physical controllers and elements
             for sar_type, lib, cls, prefix, postfix, nelem in self.cls_list:
-                # Create controller
+                # create controller
                 ctrl_name = prefix + "_ctrl_%s" % (postfix)
                 try:
                     self.pool.CreateController([sar_type, lib, cls, ctrl_name])
@@ -72,7 +89,7 @@ class SarTestTestCase(BasePoolTestCase):
                     msg = 'Impossible to create ctrl: "%s"' % (ctrl_name)
                     raise Exception('Aborting SartestTesCase: %s' % (msg))
                 self.ctrl_list.append(ctrl_name)
-                # Create 5 elemens
+                # create elements
                 for axis in range(1, nelem + 1):
                     elem_name = prefix + "_" + postfix + '_%s' % (axis)
                     try:
@@ -84,6 +101,25 @@ class SarTestTestCase(BasePoolTestCase):
                             elem_name)
                         raise Exception('Aborting SartestTesCase: %s' % (msg))
                     self.elem_list.append(elem_name)
+            # pseudo controllers and elements
+            for pseudo in self.pseudo_cls_list:
+                sar_type, lib, cls, prefix, postfix = pseudo[0:5]
+                roles = pseudo[5:]
+                # Create controller
+                ctrl_name = prefix + "_ctrl_%s" % (postfix)
+                argin = [sar_type, lib, cls, ctrl_name]
+                argin.extend(roles)
+                try:
+                    self.pool.CreateController(argin)
+                except Exception, e:
+                    print e
+                    msg = 'Impossible to create ctrl: "%s"' % (ctrl_name)
+                    raise Exception('Aborting SartestTesCase: %s' % (msg))
+                self.ctrl_list.append(ctrl_name)
+                for role in roles:
+                    elem = role.split("=")[1]
+                    if not elem in self.elem_list:
+                        self.elem_list.append(elem)
         except Exception, e:
             # force tearDown in order to eliminate the Pool
             BasePoolTestCase.tearDown(self)

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1646,10 +1646,7 @@ class MeasurementGroup(PoolElement):
         :type cb: callable
         """
         for channel_info in self.getChannels():
-            full_name = channel_info["full_name"]
-            # TODO: For Taurus 4 compatibility
-            full_name = "tango://%s" % full_name
-            channel = Device(full_name)
+            channel = Device(channel_info["full_name"])
             value_buffer_obj = channel.getValueBufferObj()
             if cb is not None:
                 self._value_buffer_cb = cb
@@ -1668,10 +1665,7 @@ class MeasurementGroup(PoolElement):
         :type cb: callable
         """
         for channel_info in self.getChannels():
-            full_name = channel_info["full_name"]
-            # TODO: For Taurus 4 compatibility
-            full_name = "tango://%s" % full_name
-            channel = Device(full_name)
+            channel = Device(channel_info["full_name"])
             value_buffer_obj = channel.getValueBufferObj()
             if cb is not None:
                 value_buffer_obj.unsubscribeEvent(self.valueBufferChanged,

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1646,7 +1646,10 @@ class MeasurementGroup(PoolElement):
         :type cb: callable
         """
         for channel_info in self.getChannels():
-            channel = Device(channel_info["full_name"])
+            full_name = channel_info["full_name"]
+            # TODO: For Taurus 4 compatibility
+            full_name = "tango://%s" % full_name
+            channel = Device(full_name)
             value_buffer_obj = channel.getValueBufferObj()
             if cb is not None:
                 self._value_buffer_cb = cb
@@ -1665,7 +1668,10 @@ class MeasurementGroup(PoolElement):
         :type cb: callable
         """
         for channel_info in self.getChannels():
-            channel = Device(channel_info["full_name"])
+            full_name = channel_info["full_name"]
+            # TODO: For Taurus 4 compatibility
+            full_name = "tango://%s" % full_name
+            channel = Device(full_name)
             value_buffer_obj = channel.getValueBufferObj()
             if cb is not None:
                 value_buffer_obj.unsubscribeEvent(self.valueBufferChanged,

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -44,8 +44,8 @@ import sys
 import time
 import traceback
 import weakref
-
 import numpy
+
 from PyTango import DevState, AttrDataFormat, AttrQuality, DevFailed, \
     DeviceProxy
 from taurus import Factory, Device, Attribute

--- a/src/sardana/taurus/core/tango/sardana/test/test_pool.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_pool.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+
+import uuid
+import numpy
+
+from taurus import Device
+from taurus.external.unittest import TestCase
+from taurus.test.base import insertTest
+from sardana.sardanautils import is_number, is_non_str_seq
+from sardana.taurus.core.tango.sardana.pool import registerExtensions
+from sardana.tango.pool.test.base_sartest import SarTestTestCase
+
+
+def is_numerical(obj):
+    if is_number(obj):
+        return True
+    if is_non_str_seq(obj) or isinstance(obj, numpy.ndarray):
+        if is_number(obj[0]):
+            return True
+        elif is_non_str_seq(obj[0]) or isinstance(obj, numpy.ndarray):
+            if is_number(obj[0][0]):
+                return True
+    return False
+
+@insertTest(helper_name="count", test_method_doc="count with PC",
+            elements=["_test_ct_1_1", "_test_ct_1_2", "_test_pc_1_1"])
+@insertTest(helper_name="count", test_method_doc="count with Tango attribute",
+            elements=["_test_ct_1_1", "_test_mt_1_1/position"])
+@insertTest(helper_name="count", test_method_doc="count with 2D",
+            elements=["_test_ct_1_1", "_test_2d_1_1"])
+@insertTest(helper_name="count", test_method_doc="count with 1D",
+            elements=["_test_ct_1_1", "_test_1d_1_1"])
+@insertTest(helper_name="count", test_method_doc="count with 0D",
+            elements=["_test_ct_1_1", "_test_0d_1_1"])
+@insertTest(helper_name="count", test_method_doc="count with CT",
+            elements=["_test_ct_1_1"])
+class TestMeasurementGroup(SarTestTestCase, TestCase):
+
+    def setUp(self):
+        SarTestTestCase.setUp(self)
+        self.mg_name = str(uuid.uuid1())
+        registerExtensions()
+
+    def count(self, elements):
+        argin = [self.mg_name] + elements
+        self.pool.CreateMeasurementGroup(argin)
+        try:
+            self.mg = Device(self.mg_name)
+            _, values = self.mg.count(1)
+            for channel, value in values.iteritems():
+                msg = "Value for %s is not numerical" % channel
+                self.assertTrue(is_numerical(value), msg)
+        finally:
+            self.pool.DeleteElement(self.mg_name)
+
+    def tearDown(self):
+        SarTestTestCase.tearDown(self)

--- a/src/sardana/taurus/core/tango/sardana/test/test_pool.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_pool.py
@@ -46,6 +46,7 @@ def is_numerical(obj):
                 return True
     return False
 
+
 @insertTest(helper_name="count", test_method_doc="count with PC",
             elements=["_test_ct_1_1", "_test_ct_1_2", "_test_pc_1_1"])
 @insertTest(helper_name="count", test_method_doc="count with Tango attribute",


### PR DESCRIPTION
This PR provides timescan (solves #104).

In order to reuse as much as possible from the existing scan framework I made a decision to relax the “motion” requirements of the `GScan` class so it could be used in scans which do not involve moveables. An alternative solution that I have evaluated was to develop a lower level abstract class e.g. `BaseScan` that would just take care of the basic scan setup and leave the `GScan` strongly linked to the “motion” concepts. I was not sure if this refactoring is really necessary and I consider it more complicated to implement, that’s why I decided to leave only the `GScan` class. But of course we can still do this refactoring in the future, if necessary.

The summary of changes:

- `timescan` macro was added that executes equidistant time scans.
- `TScan` class was developed that may serve to develop other types of timescans e.g. non-equidistant.
- `CAcquisition` class was developed that provides the common logic to `CTScan` and `TScan` such as, processing `ValueBuffer` events, validating compatibility of the measurement group, etc.
- `timescan` macro similarly to the `ascanc` & co. macros does not provide the correct information about the deadtime at the end of the scan. IMHO this can be treated later as an issue.

This PR also fix some issues related with the recent changes in Taurus4 related to the ranges.
