### PR TITLE
Make get_pool_config compatible with TriggerGate

### DIFF
--- a/src/sardana/tools/config/get_pool_config.py
+++ b/src/sardana/tools/config/get_pool_config.py
@@ -25,7 +25,8 @@ def checkPoolElements(pool):
                                 'OneDExpChannel': [],
                                 'TwoDExpChannel': [],
                                 'PseudoCounter': [],
-                                'ZeroDExpChannel': []}
+                                'ZeroDExpChannel': [],
+                                'TriggerGate': []}
 
     pool_controllers = {}
     for info in pool_dev['ControllerList'].value:


### PR DESCRIPTION
get_pool_config fails with Pools that define TriggerGate elements. Fix it.