### PR TITLE
Fix 1D's returning numpy arrays

### DIFF
--- a/src/sardana/pool/poolcontrollers/DummyOneDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyOneDController.py
@@ -225,7 +225,6 @@ class DummyOneDController(OneDController):
         elif self._synchronization in (AcqSynch.HardwareTrigger,
                                        AcqSynch.HardwareGate):
             v = copy.deepcopy(channel.buffer_values)
-            v = map(numpy.ndarray.tolist, v)
             channel._counter = channel._counter + len(v)
             channel.buffer_values.__init__()
         self._log.debug("DummyOneDController.ReadOne: returns %r" % v)

--- a/src/sardana/tango/pool/PoolDevice.py
+++ b/src/sardana/tango/pool/PoolDevice.py
@@ -33,6 +33,7 @@ __all__ = ["PoolDevice", "PoolDeviceClass",
 __docformat__ = 'restructuredtext'
 
 import time
+import numpy as np
 
 from PyTango import Util, DevVoid, DevLong64, DevBoolean, DevString, \
     DevVarStringArray, DispLevel, DevState, SCALAR, SPECTRUM, \
@@ -842,9 +843,16 @@ class PoolExpChannelDevice(PoolElementDevice):
         :rtype: str"""
         data = []
         index = []
-        for idx, value in value_chunk.iteritems():
+        for idx, sdn_value in value_chunk.iteritems():
             index.append(idx)
-            data.append(value.value)
+            value = sdn_value.value
+            # TODO: Improve it in the future
+            # In case of big arrays e.g. 10k points and higher there are more
+            # optimal solutions but they require complex changes on encoding
+            # and decoding side.
+            if isinstance(value, np.ndarray):
+                value = value.tolist()
+            data.append(value)
         data = dict(data=data, index=index)
         _, encoded_data = self._codec.encode(('', data))
         return encoded_data


### PR DESCRIPTION
In https://github.com/sardana-org/sardana/issues/487#issuecomment-312236540 @LJBD pointed a possible solution for serializing numpy arrays. However it is quite complex to implement having in mind that we are serializing a more complex data structure that at the moment contains a multiple indexes and multiple values. IMHO it will be quite difficult to serialize it and deserialize it in this way.

A simple `ndarray.tolist` before serializing works well and for arrays of < 10k elements its performance is similar. So I propose to solve it in this way until we find time to optimize it.

Fixes #487 