### PR TITLE
Allow starting MacroServer w/o Pool

### DIFF
--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -682,8 +682,8 @@ def prepare_server(args, tango_args):
                         print all_pools
                     else:
                         pool_names.append(elem)
-                    log_messages += register_sardana(db,
-                                                     server_name, inst_name, pool_names)
+                log_messages += register_sardana(db, server_name, inst_name,
+                                                 pool_names)
             else:
                 log_messages += register_sardana(db, server_name, inst_name)
     return log_messages


### PR DESCRIPTION
It is not possible to start a new instance of the MacroServer without connecting to a Pool. Fix it.

To test it, assuming that you don't have `test` MacroServer defined in your database, start in the console: 

```
$> MacroServer test --log-level=debug
```

This will offer you to connect to available Pools. Just ignore this offer and press Enter.

Before this was failing with:

```
The device server MacroServer/test is not defined in database. Exiting!
```

Now it starts the server correctly.
