### PR TITLE
Configure CI service for Windows (appveyor)

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,0 +1,67 @@
+# fetch repository as zip archive
+shallow_clone: true
+
+environment:
+    global:
+        VENV_BUILD_DIR: "venv_build"
+        VENV_TEST_DIR: "venv_test"
+
+    matrix:
+        # Python 2.7 (64)
+        - PYTHON_DIR: "C:\\Python27_32"
+          PYTHON_VERSION: "2.7"
+          PYTHON_ARCH: "64"
+          CONDA_PY: "27"
+
+        # Python 2.7
+        - PYTHON_DIR: "C:\\Python27"
+          PYTHON_VERSION: "2.7"
+          PYTHON_ARCH: "32"
+          CONDA_PY: "27"
+
+install:
+    # Add Python to PATH
+    - "SET PATH=%PYTHON_DIR%;%PYTHON_DIR%\\Scripts;%PATH%"
+
+    # Upgrade/install distribution modules
+    - "pip install --upgrade setuptools"
+    - "python -m pip install --upgrade pip"
+
+    # Install virtualenv
+    - "pip install --upgrade virtualenv"
+    - "virtualenv --version"
+
+build_script:
+    # Create build virtualenv
+    - "virtualenv --clear %VENV_BUILD_DIR%"
+    - "%VENV_BUILD_DIR%\\Scripts\\activate.bat"
+
+    # Install wheel
+    - "pip install --upgrade wheel"
+
+    # Build sardana sdist, msi and wheel
+    - "python setup.py sdist bdist_wheel bdist_msi"
+    - ps: "ls dist"
+
+    # Leave build virtualenv
+    - "%VENV_BUILD_DIR%\\Scripts\\deactivate.bat"
+    - "rmdir %VENV_BUILD_DIR% /s /q"
+
+
+#test_script:
+# TODO
+
+
+artifacts:
+    # Archive the generated sdist, wheel and msi packages in the ci.appveyor.com build report.
+    - path: dist\*.tar.gz
+      name: sardana_SDIST
+
+    - path: dist\*.msi
+      name: sardana_MSI
+
+    - path: dist\*.whl
+      name: sardana_WHEEL
+
+#deploy
+# TODO


### PR DESCRIPTION
Add appveyor.yml file to generate sardana artifacts on windows.

A project configuration may be required. Enabling and configuring appveyor 
using an admin user.