### PR TITLE
Properly synchronize stopping of macro and its reserved objects

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -308,12 +308,14 @@ def mAPI(fn):
             if self._shouldRaiseStopException():
                 if is_macro_th:
                     self.setProcessingStop(True)
+                self.executor._waitStopDone()
                 raise StopException("stopped before calling %s" % fn.__name__)
         ret = fn(*args, **kwargs)
         if not self.isProcessingStop():
             if self._shouldRaiseStopException():
                 if is_macro_th:
                     self.setProcessingStop(True)
+                self.executor._waitStopDone()
                 raise StopException("stopped after calling %s" % fn.__name__)
         return ret
     return new_fn

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -37,6 +37,7 @@ import copy
 import inspect
 import functools
 import traceback
+import threading
 
 from lxml import etree
 
@@ -849,6 +850,10 @@ class MacroExecutor(Logger):
         self._stopped = False
         self._paused = False
         self._last_macro_status = None
+        # threading events for synchronization of stopping/abortting of
+        # reserved objects
+        self._stop_done = None
+        self._abort_done = None
 
         name = "%s.%s" % (str(door), self.__class__.__name__)
         self._macro_status_codec = CodecFactory().getCodec('json')
@@ -1100,11 +1105,23 @@ class MacroExecutor(Logger):
                     self.warning("Unable to abort %s" % obj)
                     self.debug("Details:", exc_info=1)
 
+    def _setStopDone(self, _):
+        self._stop_done.set()
+
+    def _waitStopDone(self, timeout=None):
+        self._stop_done.wait(timeout)
+
+    def _setAbortDone(self, _):
+        self._abort_done.set()
+
+    def _waitAbortDone(self, timeout=None):
+        self._abort_done.wait(timeout)
+
     def abort(self):
-        self.macro_server.add_job(self._abort, None)
+        self.macro_server.add_job(self._abort, self._setAbortDone)
 
     def stop(self):
-        self.macro_server.add_job(self._stop, None)
+        self.macro_server.add_job(self._stop, self._setStopDone)
 
     def _abort(self):
         m = self.getRunningMacro()
@@ -1169,6 +1186,8 @@ class MacroExecutor(Logger):
         self._macro_stack = []
         self._xml_stack = []
         self._macro_pointer = None
+        self._stop_done = threading.Event()
+        self._abort_done = threading.Event()
         self._aborted = False
         self._stopped = False
         self._paused = False
@@ -1285,9 +1304,11 @@ class MacroExecutor(Logger):
         # make sure the macro's on_abort is called and that a proper macro
         # status is sent
         if self._stopped:
+            self._waitStopDone()
             macro_obj._stopOnError()
             self.sendMacroStatusStop()
         elif self._aborted:
+            self._waitAbortDone()
             macro_obj._abortOnError()
             self.sendMacroStatusAbort()
 


### PR DESCRIPTION
The macro reserved objects e.g. motion or measurement groups are stopped
when the user stops the macro e.g. Ctrl+C in spock, or directly door's
StopMacro command. This stop is executed in a worker thread which is
comletly desynchronized with the macro execution thread.

Fix it forcing the MacroExecutor to wait for the stopping thread to finish its job
before executing the on_stop or on_abort methods. Also protect macros that
catch the StopException by waiting in the mAPI decorator.

Fixes #8.

@sardana-org/integrators any volunteer to integrate it?