### PR TITLE
PreScanSnapshot does not work with the default H5 recorder

### DIFF
--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -220,9 +220,13 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
         """
         min_rank = self._dataCompressionRank
         if shape is None or min_rank < 0 or len(shape) < min_rank:
-            return None
-        else:
-            return compfilter
+            compfilter = None
+        elif len(shape) == 0:
+            msg = "%s compression is not supported for scalar datasets"\
+                  " - these datasets will not be compressed" % compfilter
+            self.warning(msg)
+            compfilter = None
+        return compfilter
 
     def _createPreScanSnapshot(self, env):
         """

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -180,7 +180,7 @@ class ExperimentConfiguration(object):
         env = door.getEnvironment()
 
         ret = dict(ScanDir=env.get('ScanDir'),
-                   DataCompressionRank=env.get('DataCompressionRank', 0),
+                   DataCompressionRank=env.get('DataCompressionRank', 1),
                    PreScanSnapshot=env.get('PreScanSnapshot', []))
         scan_file = env.get('ScanFile')
         if scan_file is None:


### PR DESCRIPTION
PreScanSnaphot with scalar values does not work:

```
  File "/storagebls/beamlines/bl22/controls/devel/SardanaSep6/sardana/src/sardana/macroserver/msmacromanager.py", line 1277, in runMacro
    for step in macro_obj.exec_():
  File "/storagebls/beamlines/bl22/controls/devel/SardanaSep6/sardana/src/sardana/macroserver/macro.py", line 2276, in exec_
    for i in it:
  File "/homelocal/sicilia/lib/python/site-packages/sardana/macroserver/macros/scan.py", line 251, in run
    for step in self._gScan.step_scan():
  File "/storagebls/beamlines/bl22/controls/devel/SardanaSep6/sardana/src/sardana/macroserver/scan/gscan.py", line 884, in step_scan
    self.start()
  File "/storagebls/beamlines/bl22/controls/devel/SardanaSep6/sardana/src/sardana/macroserver/scan/gscan.py", line 839, in start
    self.data.start()
  File "/storagebls/beamlines/bl22/controls/devel/SardanaSep6/sardana/src/sardana/macroserver/scan/scandata.py", line 289, in start
    self.datahandler.startRecordList(self)
  File "/storagebls/beamlines/bl22/controls/devel/SardanaSep6/sardana/src/sardana/macroserver/scan/recorder/datarecorder.py", line 56, in startRecordList
    recorder.startRecordList(recordlist)
  File "/storagebls/beamlines/bl22/controls/devel/SardanaSep6/sardana/src/sardana/macroserver/scan/recorder/datarecorder.py", line 115, in startRecordList
    self._startRecordList(recordlist)
  File "/storagebls/beamlines/bl22/controls/devel/SardanaSep6/sardana/src/sardana/macroserver/recorders/h5storage.py", line 210, in _startRecordList
    self._createPreScanSnapshot(env)
  File "/storagebls/beamlines/bl22/controls/devel/SardanaSep6/sardana/src/sardana/macroserver/recorders/h5storage.py", line 252, in _createPreScanSnapshot
    compression=self._compression(dd.shape)
  File "/usr/lib64/python2.7/site-packages/h5py/_hl/group.py", line 69, in create_dataset
    dsid = dataset.make_new_dset(self, shape, dtype, data, **kwds)
  File "/usr/lib64/python2.7/site-packages/h5py/_hl/dataset.py", line 79, in make_new_dset
    shuffle, fletcher32, maxshape)
  File "/usr/lib64/python2.7/site-packages/h5py/_hl/filters.py", line 71, in generate_dcpl
    raise TypeError("Scalar datasets don't support chunk/filter options")
TypeError: Scalar datasets don't support chunk/filter options
```

This is due to a limitation of the h5py library - the scalar datasets can not be compressed.

This PR changes the default data compression rank to 1 and more and ignore this and higher data compression ranks in the default H5 recorders at the same time warning the user about this fact in the MacroServer logs. One drawback is that this warning is logged multiple times if multiple scalars are present in the snapshot.

I consider this bug as release critical, so @sardana-org/integrators could you please review it shortly.