### PR TITLE
Apply an agresive workaround for #494

### DIFF
--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -68,7 +68,7 @@ class MacroServer(SardanaDevice):
         self._macro_server.clear_log_report()
         # Workaround for bug #494.
         factory = taurus.Factory("tango")
-        for attr in factory.tango_attrs:
+        for attr in factory.tango_attrs.values():
             attr.cleanUp()
 
     def init_device(self):

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -66,15 +66,9 @@ class MacroServer(SardanaDevice):
         SardanaDevice.delete_device(self)
         self._macro_server.clear_log_report()
         # Workaround for bug #494.
-        for pool in self._macro_server._pools.values():
-            elements_attr = pool.getAttribute("Elements")
-            # Remove the taurus listeners:(cleanUp)
-            elements_attr.removeListener(
-                self._macro_server.on_pool_elements_changed)
-            elements_attr.removeListener(pool.on_elements_changed)
-            # For taurus4, unsubscribeConfEvents
-            if hasattr(elements_attr, "_unsubscribeConfEvents"):
-                elements_attr._unsubscribeConfEvents()
+        factory = self._macro_server.factory()
+        for attr in factory.tango_attrs:
+            attr.cleanUp()
 
     def init_device(self):
         SardanaDevice.init_device(self)

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -31,6 +31,7 @@ import sys
 from PyTango import Util, Except, DevVoid, DevLong, DevString, DevState, \
     DevEncoded, DevVarStringArray, READ, READ_WRITE, SCALAR, SPECTRUM, DebugIt
 
+import taurus
 from taurus.core.util.codecs import CodecFactory
 
 from sardana import State, SardanaServer
@@ -66,7 +67,7 @@ class MacroServer(SardanaDevice):
         SardanaDevice.delete_device(self)
         self._macro_server.clear_log_report()
         # Workaround for bug #494.
-        factory = self._macro_server.factory()
+        factory = taurus.Factory("tango")
         for attr in factory.tango_attrs:
             attr.cleanUp()
 

--- a/src/sardana/tango/macroserver/test/base.py
+++ b/src/sardana/tango/macroserver/test/base.py
@@ -48,37 +48,34 @@ class BaseMacroServerTestCase(object):
         """Start MacroServer DS.
         """
         try:
+            db = PyTango.Database()
             # Discover the MS launcher script
             msExec = whichexecutable.whichfile("MacroServer")
             # register MS server
             ms_ds_name = "MacroServer/" + self.ms_ds_name
-            ms_free_ds_name = get_free_server(PyTango.Database(), ms_ds_name)
+            ms_free_ds_name = get_free_server(db, ms_ds_name)
             self._msstarter = ProcessStarter(msExec, ms_free_ds_name)
             # register MS device
             dev_name_parts = self.ms_name.split('/')
             prefix = '/'.join(dev_name_parts[0:2])
             start_from = int(dev_name_parts[2])
             self.ms_name = get_free_device(
-                PyTango.Database(), prefix, start_from)
+                db, prefix, start_from)
             self._msstarter.addNewDevice(self.ms_name, klass='MacroServer')
             # register Door device
             dev_name_parts = self.door_name.split('/')
             prefix = '/'.join(dev_name_parts[0:2])
             start_from = int(dev_name_parts[2])
-            self.door_name = get_free_device(PyTango.Database(), prefix,
-                                             start_from)
+            self.door_name = get_free_device(db, prefix, start_from)
             self._msstarter.addNewDevice(self.door_name, klass='Door')
+            db.put_device_property(self.ms_name, {'PoolNames': pool_name})
             # start MS server
             self._msstarter.startDs()
-            # devices
-            self.macroserver = PyTango.DeviceProxy(self.ms_name)
-            self.macroserver.put_property({'PoolNames': pool_name})
-            self.macroserver.Init()
             self.door = PyTango.DeviceProxy(self.door_name)
         except Exception, e:
             # force tearDown in order to eliminate the MacroServer
-            self.tearDown()
             print e
+            self.tearDown()
 
     def tearDown(self):
         """Remove the Pool instance.


### PR DESCRIPTION
The previous woraround does not cover all the possible cases,
after executing some macros (e.g. ct) the MacrpoServer still
not exit smoothly after Ctrl+C

Force cleanUp for all registered taurus attributes.

Fix #494.