### PR TITLE
Fix bug with pseudo counters not involved in acquisition

### DIFF
--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -289,7 +289,11 @@ class PoolAcquisition(PoolAction):
             try:
                 elem.clear_value_buffer()
             except AttributeError:
-                pass
+                continue
+            # clean also the pseudo counters, even the ones that do not
+            # participate directly in the acquisition
+            for pseudo_elem in elem.get_pseudo_elements():
+                pseudo_elem.clear_value_buffer()
         config = kwargs['config']
         synchronization = kwargs["synchronization"]
         integ_time = extract_integ_time(synchronization)


### PR DESCRIPTION
There is a bug in the acquisition process that affects pseudo counters not
included in the measurement group. The first time the acquisition takes place
this pseudo counters are notified about the value buffer events of the
physical element and their value buffers are filled with the calculation
results. The problem appears in the subsequent acquisitions cause the
pseudo counters buffers are not cleared.

Fix it by clearing the pseudo counters buffers at the beginning of each
acquisition.

**Note for the reviewers/integrator**: To reproduce the problem I have used a setup with:
* 11 dummy counters: ct01, ct02, ..., ct11
* 10 IoverI0 pseudo counters: pc01 = ct02/ct01, pc02 = ct03/ct01, ..., pc10 = ct11/ct01
* measurement group containing just the 11 dummy counters

The first ct macro execution works, but the second one fails. Maybe there is a simpler way to reproduce it but I have not investigated.

I consider this bug as release critical, so @sardana-org/integrators could you please review it shortly.