### PR TITLE
[WIP] NXscanH5_FileRecorder backwards compatibility with old libraries

### DIFF
--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -125,14 +125,14 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
         except ValueError:
             # Warn and abort
             if self.entryname in self.fd.keys():
-                msg = ('{ename:r} already exists in {fname:r}.' +
+                msg = ('{ename:r} already exists in {fname:s}.' +
                        'Aborting macro to prevent data corruption.\n' +
                        'This is likely caused by a wrong ScanID\n' +
                        'Possible workarounds:\n' +
                        '  * first, try re-running this macro (the ScanID ' +
                        'may be automatically corrected)\n'
                        '  * if not, try changing ScanID with senv, or...\n' +
-                       '  * change the file name ({ename:r} will be in both ' +
+                       '  * change the file name ({ename:s} will be in both ' +
                        'files containing different data)\n' +
                        '\nPlease report this problem.'
                        ).format(ename=self.entryname, fname=self.filename)

--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -40,6 +40,7 @@ import h5py
 from sardana.taurus.core.tango.sardana import PlotType
 from sardana.macroserver.scan.recorder import BaseFileRecorder, SaveModes
 
+
 def timedelta_total_seconds(timedelta):
     """Eqiuvalent to timedelta.total_seconds introduced with python 2.7."""
     return (

--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -40,6 +40,12 @@ import h5py
 from sardana.taurus.core.tango.sardana import PlotType
 from sardana.macroserver.scan.recorder import BaseFileRecorder, SaveModes
 
+def timedelta_total_seconds(timedelta):
+    """Eqiuvalent to timedelta.total_seconds introduced with python 2.7."""
+    return (
+        timedelta.microseconds + 0.0 +
+        (timedelta.seconds + timedelta.days * 24 * 3600) * 10 ** 6) / 10 ** 6
+
 
 class NXscanH5_FileRecorder(BaseFileRecorder):
 
@@ -175,7 +181,12 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
         _pname = nxentry.create_dataset('program_name', data=program_name)
         _pname.attrs['version'] = sardana.release.version
         nxentry.create_dataset('start_time', data=env['starttime'].isoformat())
-        _epoch = (env['starttime'] - datetime(1970, 1, 1)).total_seconds()
+        timedelta = (env['starttime'] - datetime(1970, 1, 1))
+        try:
+            _epoch = timedelta.total_seconds()
+        except AttributeError:
+            # for python 2.6 compatibility
+            _epoch = timedelta_total_seconds(timedelta)
         nxentry.attrs['epoch'] = _epoch
         nxentry.create_dataset('title', data=env['title'])
         nxentry.create_dataset('entry_identifier', data=str(env['serialno']))


### PR DESCRIPTION
During the Jul17 release tests, it has been discovered that the new H5 recorder has problems with the old versions of dependencies. These are python 2.6 and some specific versions of h5py and libhdf5.
The python 2.6 backwards compatibility is already provided in this PR.

The h5py 1.3.0 and libhdf5 1.8.1 issue is:
```
SardanaTP.W002 DEBUG    2017-08-02 08:21:27,921 Door/demo2/1: Traceback (most recent call last):                                                                               
  File "/homelocal/sicilia/tmp/local/lib64/python2.6/site-packages/sardana-2.3.0-py2.6.egg/sardana/macroserver/msmacromanager.py", line 1277, in runMacro                      
    for step in macro_obj.exec_():                                                                                                                                             
  File "/homelocal/sicilia/tmp/local/lib64/python2.6/site-packages/sardana-2.3.0-py2.6.egg/sardana/macroserver/macro.py", line 2276, in exec_                                  
    for i in it:                                                                                                                                                               
  File "/homelocal/sicilia/tmp/local/lib64/python2.6/site-packages/sardana-2.3.0-py2.6.egg/sardana/macroserver/macros/scan.py", line 281, in run                               
    for step in self._gScan.step_scan():                                                                                                                                       
  File "/homelocal/sicilia/tmp/local/lib64/python2.6/site-packages/sardana-2.3.0-py2.6.egg/sardana/macroserver/scan/gscan.py", line 898, in step_scan                          
    self.end()                                                                                                                                                                 
  File "/homelocal/sicilia/tmp/local/lib64/python2.6/site-packages/sardana-2.3.0-py2.6.egg/sardana/macroserver/scan/gscan.py", line 856, in end                                
    self.data.end()                                                                                                                                                            
  File "/homelocal/sicilia/tmp/local/lib64/python2.6/site-packages/sardana-2.3.0-py2.6.egg/sardana/macroserver/scan/scandata.py", line 401, in end                             
    self.datahandler.addRecord(self, rc)                                                                                                                                       
  File "/homelocal/sicilia/tmp/local/lib64/python2.6/site-packages/sardana-2.3.0-py2.6.egg/sardana/macroserver/scan/recorder/datarecorder.py", line 68, in addRecord           
    recorder.writeRecord(record)                                                                                                                                               
  File "/homelocal/sicilia/tmp/local/lib64/python2.6/site-packages/sardana-2.3.0-py2.6.egg/sardana/macroserver/scan/recorder/datarecorder.py", line 142, in writeRecord        
    self._writeRecord(record)                                                                                                                                                  
  File "/homelocal/sicilia/tmp/local/lib64/python2.6/site-packages/sardana-2.3.0-py2.6.egg/sardana/macroserver/recorders/h5storage.py", line 298, in _writeRecord              
    _ds.resize(record.recordno + 1, axis=0)                                                                                                                                    
  File "/homelocal/sicilia/lib/python/site-packages/h5py/highlevel.py", line 1114, in resize                                                                                   
    raise NotImplementedError("Resizing is only available with HDF5 1.8.")                                                                                                     
NotImplementedError: Resizing is only available with HDF5 1.8. 
```

We have decided to not delay the Jul17 release due to that - most of the users are already using python 2.7 and more recent versions of H5 libraries.
The workaround to this problem is to use the old recorder, by changing the `<sardana>/src/sardana/sardanacustomsettings.py`:
```
SCAN_RECORDER_MAP = {".h5": "NXscan_FileRecorder"}`
