### PR TITLE
Import OrderedDict from taurus.external

### DIFF
--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -47,7 +47,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # For Python < 2.7
-    from ordereddict import OrderedDict
+    from taurus.external.ordereddict import OrderedDict
 
 from taurus.core.util.log import Logger
 from taurus.core.util.codecs import CodecFactory

--- a/src/sardana/macroserver/msrecordermanager.py
+++ b/src/sardana/macroserver/msrecordermanager.py
@@ -39,7 +39,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # For Python < 2.7
-    from ordereddict import OrderedDict
+    from taurus.external.ordereddict import OrderedDict
 
 from sardana import sardanacustomsettings
 from sardana.sardanaexception import format_exception_only_str

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -45,7 +45,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # For Python < 2.7
-    from ordereddict import OrderedDict
+    from taurus.external.ordereddict import OrderedDict
 
 from taurus.core.util.log import Logger
 from taurus.core.util.user import USER_NAME

--- a/src/sardana/pool/poolaction.py
+++ b/src/sardana/pool/poolaction.py
@@ -40,7 +40,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # For Python < 2.7
-    from ordereddict import OrderedDict
+    from taurus.external.ordereddict import OrderedDict
 
 from taurus.core.util.log import Logger
 

--- a/src/sardana/pool/poolcontrollermanager.py
+++ b/src/sardana/pool/poolcontrollermanager.py
@@ -41,7 +41,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # For Python < 2.7
-    from ordereddict import OrderedDict
+    from taurus.external.ordereddict import OrderedDict
 
 from taurus.core import ManagerState
 from taurus.core.util.log import Logger

--- a/src/sardana/sardanabuffer.py
+++ b/src/sardana/sardanabuffer.py
@@ -36,7 +36,7 @@ try:
     from collections import OrderedDict
 except ImportError:
     # For Python < 2.7
-    from ordereddict import OrderedDict
+    from taurus.external.ordereddict import OrderedDict
 
 from .sardanavalue import SardanaValue
 from .sardanaevent import EventGenerator, EventType


### PR DESCRIPTION
For python versions < 2.7, import OrderedDict from
taurus.external.ordereddict