### PR TITLE
Macro move_async may fail if movement could not be started

### DIFF
--- a/src/sardana/macroserver/macros/examples/motion.py
+++ b/src/sardana/macroserver/macros/examples/motion.py
@@ -42,10 +42,10 @@ class move_async(Macro):
                  ]
 
     def run(self, moveable, pos):
+        motion = self.getMotion([moveable])
+        self.info('initial position: %s' % motion.readPosition())
+        _id = motion.startMove([pos])
         try:
-            motion = self.getMotion([moveable])
-            self.info('initial position: %s' % motion.readPosition())
-            _id = motion.startMove([pos])
             # Do whatever here (while the moveable is moving)
             self.info('state: %s' % motion.readState())
             # End Do whatever here


### PR DESCRIPTION
Move of a motor may not started if, for example, it was requested to
move out of the limits. In this case does not wait for the movement to
finish.