### PR TITLE
Add missing percent sign to an error message

### DIFF
--- a/src/sardana/sardanautils.py
+++ b/src/sardana/sardanautils.py
@@ -123,7 +123,7 @@ def assert_type(type_info, value):
             recv = recv.__name__
         except:
             recv = str(recv)
-        raise TypeError("Expected %s, but received %s", expected, recv)
+        raise TypeError("Expected %s, but received %s" % (expected, recv))
     return ret
 
 _DTYPE_FUNC = {


### PR DESCRIPTION
There was a TypeError that had a malformed message due to a missing percent sign that should fill the error message with types.