### PR TITLE
Allow to hide Taurus related deprecation warnings

### DIFF
--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -53,3 +53,7 @@ SPOCK_INPUT_HANDLER = "CLI"
 #: key   - scan file extension e.g. ".h5"
 #: value - recorder name
 SCAN_RECORDER_MAP = None
+
+# TODO: Temporary solution, available while Taurus3 is being supported.
+# Maximum number of Taurus deprecation warnings allowed to be displayed.
+TAURUS_MAX_DEPRECATION_COUNTS = 0

--- a/src/sardana/spock/ipython_00_10/genutils.py
+++ b/src/sardana/spock/ipython_00_10/genutils.py
@@ -1100,6 +1100,15 @@ def mainloop(shell=None, user_ns=None):
 
 
 def run(user_ns=None):
+
+    # TODO: Temporary solution, available while Taurus3 is being supported.
+    from taurus import tauruscustomsettings
+    from sardana import sardanacustomsettings
+    max_counts = getattr(sardanacustomsettings,
+                         'TAURUS_MAX_DEPRECATION_COUNTS')
+    tauruscustomsettings._MAX_DEPRECATIONS_LOGGED = max_counts
+    #
+
     # initialize input handler as soon as possible
     import sardana.spock.inputhandler
     input_handler = sardana.spock.inputhandler.InputHandler()
@@ -1111,6 +1120,12 @@ def run(user_ns=None):
             clean_up()
         except Exception:
             pass
+
+    # TODO: Temporary solution, available while Taurus3 is being supported.
+    from taurus.core.util.log import _DEPRECATION_COUNT
+    from taurus import info
+    info('\n*********************\n%s', _DEPRECATION_COUNT.pretty())
+
 
 # for compatibility reasons with new IPython API (>=0.11) we add the following
 # empty methods

--- a/src/sardana/spock/ipython_00_10/genutils.py
+++ b/src/sardana/spock/ipython_00_10/genutils.py
@@ -1105,7 +1105,7 @@ def run(user_ns=None):
     from taurus import tauruscustomsettings
     from sardana import sardanacustomsettings
     max_counts = getattr(sardanacustomsettings,
-                         'TAURUS_MAX_DEPRECATION_COUNTS')
+                         'TAURUS_MAX_DEPRECATION_COUNTS', 0)
     tauruscustomsettings._MAX_DEPRECATIONS_LOGGED = max_counts
     #
 

--- a/src/sardana/spock/ipython_00_11/genutils.py
+++ b/src/sardana/spock/ipython_00_11/genutils.py
@@ -1240,7 +1240,7 @@ def run():
     from taurus import tauruscustomsettings
     from sardana import sardanacustomsettings
     max_counts = getattr(sardanacustomsettings,
-                         'TAURUS_MAX_DEPRECATION_COUNTS')
+                         'TAURUS_MAX_DEPRECATION_COUNTS', 0)
     tauruscustomsettings._MAX_DEPRECATIONS_LOGGED = max_counts
     #
 

--- a/src/sardana/spock/ipython_00_11/genutils.py
+++ b/src/sardana/spock/ipython_00_11/genutils.py
@@ -1236,6 +1236,14 @@ def prepare_cmdline(argv=None):
 
 def run():
 
+    # TODO: Temporary solution, available while Taurus3 is being supported.
+    from taurus import tauruscustomsettings
+    from sardana import sardanacustomsettings
+    max_counts = getattr(sardanacustomsettings,
+                         'TAURUS_MAX_DEPRECATION_COUNTS')
+    tauruscustomsettings._MAX_DEPRECATIONS_LOGGED = max_counts
+    #
+
     try:
         from IPython.utils.traitlets import Unicode
         from IPython.frontend.qt.console.rich_ipython_widget import RichIPythonWidget
@@ -1267,3 +1275,8 @@ def run():
     prepare_cmdline()
 
     launch_new_instance()
+
+    # TODO: Temporary solution, available while Taurus3 is being supported.
+    from taurus.core.util.log import _DEPRECATION_COUNT
+    from taurus import info
+    info('\n*********************\n%s', _DEPRECATION_COUNT.pretty())

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -1277,7 +1277,7 @@ def run():
     from taurus import tauruscustomsettings
     from sardana import sardanacustomsettings
     max_counts = getattr(sardanacustomsettings,
-                         'TAURUS_MAX_DEPRECATION_COUNTS')
+                         'TAURUS_MAX_DEPRECATION_COUNTS', 0)
     tauruscustomsettings._MAX_DEPRECATIONS_LOGGED = max_counts
     #
 

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -1272,6 +1272,15 @@ def prepare_cmdline(argv=None):
 
 
 def run():
+
+    # TODO: Temporary solution, available while Taurus3 is being supported.
+    from taurus import tauruscustomsettings
+    from sardana import sardanacustomsettings
+    max_counts = getattr(sardanacustomsettings,
+                         'TAURUS_MAX_DEPRECATION_COUNTS')
+    tauruscustomsettings._MAX_DEPRECATIONS_LOGGED = max_counts
+    #
+
     try:
         try:
             # IPython 4.x
@@ -1311,3 +1320,8 @@ def run():
     prepare_cmdline()
 
     launch_new_instance()
+
+    # TODO: Temporary solution, available while Taurus3 is being supported.
+    from taurus.core.util.log import _DEPRECATION_COUNT
+    from taurus import info
+    info('\n*********************\n%s', _DEPRECATION_COUNT.pretty())


### PR DESCRIPTION
Allow choosing the number of Taurus relaged deprecation warnings
that will be displayed, thanks to a sardanacustomsettings
new variable.

Allow to hide Taurus related deprecation warnings if the
variable is set to 0.