### PR TITLE
Report error number when loading sequence from txt

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -862,10 +862,9 @@ class TaurusSequencerWidget(TaurusWidget):
         error_line = 0
         for macroNode in newRoot.allMacros():
             error_line += 1
-
             try:
-                macroServerObj.recreateMacroNodeAndFillAdditionalInfos(macroNode)
-
+                macroServerObj.recreateMacroNodeAndFillAdditionalInfos(
+                    macroNode)
             except Exception, e:
                 Qt.QMessageBox.warning(self,
                                        "Error while parsing the sequence",

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -859,8 +859,21 @@ class TaurusSequencerWidget(TaurusWidget):
     def fromPlainText(self, plainText):
         newRoot = self.tree.fromPlainText(plainText)
         macroServerObj = self.getModelObj()
+        error_line = 0
         for macroNode in newRoot.allMacros():
-            macroServerObj.recreateMacroNodeAndFillAdditionalInfos(macroNode)
+            error_line += 1
+
+            try:
+                macroServerObj.recreateMacroNodeAndFillAdditionalInfos(macroNode)
+
+            except Exception, e:
+                Qt.QMessageBox.warning(self,
+                                       "Error while parsing the sequence",
+                                       "Sequence line number %d contains "
+                                       "the following error:\n %s\n "
+                                       "The sequence will not be loaded"
+                                       % (error_line, e))
+                raise e
         return newRoot
 
     def setModel(self, model):


### PR DESCRIPTION
The sequencer allows to import text files with macro sequences.

If a macro from the sequence in the text file contains an error,
report the line where this error is found.