### PR TITLE
Change text of macro button to indicate abort action (Issue322)

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -81,7 +81,7 @@ class MacroButton(TaurusWidget):
         self.macro_args = []
         self.macro_id = None
         self.running_macro = None
-        self._text = ""
+        self._text = "Macro"
         self.abort_text = "Abort"
 
         self.ui.progress.setValue(0)

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -81,6 +81,8 @@ class MacroButton(TaurusWidget):
         self.macro_args = []
         self.macro_id = None
         self.running_macro = None
+        self._text = ""
+        self.abort_text = "Abort"
 
         self.ui.progress.setValue(0)
 
@@ -144,8 +146,13 @@ class MacroButton(TaurusWidget):
         # In case state is not ON, and macro not triggered by the button,
         # disable it
         door_available = True
-        if state not in [PyTango.DevState.ON, PyTango.DevState.ALARM] and not self.ui.button.isChecked():
+
+        state_ON_or_ALARM = [PyTango.DevState.ON, PyTango.DevState.ALARM]
+        if state not in state_ON_or_ALARM and not self.ui.button.isChecked():
             door_available = False
+
+        if state in state_ON_or_ALARM:
+            self.ui.button.setText(self._text)
 
         self.ui.button.setEnabled(door_available)
         self.ui.progress.setEnabled(door_available)
@@ -208,6 +215,7 @@ class MacroButton(TaurusWidget):
         '''same as :meth:`setText`
         '''
         # SHOULD ALSO BE POSSIBLE TO SET AN ICON
+        self._text = text
         self.ui.button.setText(text)
 
     def setMacroName(self, name):
@@ -263,8 +271,11 @@ class MacroButton(TaurusWidget):
 
     def _onButtonClicked(self):
         if self.ui.button.isChecked():
+            self.abort_text = "Abort " + self._text
+            self.ui.button.setText(self.abort_text)
             self.runMacro()
         else:
+            self.ui.button.setText(self._text)
             self.abort()
 
     @ProtectTaurusMessageBox(msg='Error while executing the macro.')
@@ -305,6 +316,7 @@ class MacroButton(TaurusWidget):
         if ans == Qt.QMessageBox.Ok:
             self.door.abort(synch=True)
         else:
+            self.ui.button.setText(self.abort_text)
             self.ui.button.setChecked(True)
             self.door.ResumeMacro()
 


### PR DESCRIPTION
Add text 'Abort' in MacroButton when a macro is
running. This gives information to the users on how the
macro can be aborted by pushing the MacroButton.