### PR TITLE
Reimplement macrobutton handleEvent

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -90,7 +90,7 @@ class MacroButton(TaurusWidget):
 
     # Override default implementation of handleEvent from TaurusWidget
     # in order to avoid button's text being lost on the MS restart.
-    # More detais in #293 and taurus-org/taurus#635 
+    # More detais in #293 and taurus-org/taurus#635
     def handleEvent(self, evt_src, evt_type, evt_value):
         pass
 

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -88,6 +88,9 @@ class MacroButton(TaurusWidget):
         self.connect(self.ui.button, Qt.SIGNAL('clicked()'),
                      self._onButtonClicked)
 
+    def handleEvent(self, evt_src, evt_type, evt_value):
+        pass
+
     def toggleProgress(self, visible):
         '''deprecated'''
         self.warning('toggleProgress is deprecated. Use showProgress')

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -88,6 +88,9 @@ class MacroButton(TaurusWidget):
         self.connect(self.ui.button, Qt.SIGNAL('clicked()'),
                      self._onButtonClicked)
 
+    # Override default implementation of handleEvent from TaurusWidget
+    # in order to avoid button's text being lost on the MS restart.
+    # More detais in #293 and taurus-org/taurus#635 
     def handleEvent(self, evt_src, evt_type, evt_value):
         pass
 


### PR DESCRIPTION
Macrobutton text is set to the Door name if MacroServer
is stopped. This is a not desired behavior, and the text
of the macrobutton should remain the same.

Reimplement macrobutton handleEvent in order to avoid text
setting when MacroServer is down, or when macroserver is
reconnected.