### PR TITLE
Check motors limits before motor group movement

### DIFF
--- a/src/sardana/pool/poolmotorgroup.py
+++ b/src/sardana/pool/poolmotorgroup.py
@@ -267,12 +267,14 @@ class PoolMotorGroup(PoolGroupElement):
                 low = None
             if high is not None:
                 if float(new_position) > high:
-                    raise RuntimeError("%s: Requested movement above "
-                                       "upper limit." % element.name)
+                    msg = "requested movement of %s is above its upper limit"\
+                        % element.name
+                    raise RuntimeError(msg)
             if low is not None:
                 if float(new_position) < low:
-                    raise RuntimeError("%s: Requested movement below "
-                                       "lower limit." % element.name)
+                    msg = "requested movement of %s is below its lower limit"\
+                        % element.name
+                    raise RuntimeError(msg)
 
         for new_position, element in zip(new_positions, user_elements):
             element.calculate_motion(new_position, items=items,

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -991,7 +991,6 @@ class MotorGroup(PoolElement, Moveable):
 
     def _start(self, *args, **kwargs):
         new_pos = args[0]
-
         try:
             self.write_attribute('position', new_pos)
         except DevFailed, df:

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -996,7 +996,8 @@ class MotorGroup(PoolElement, Moveable):
         for mot in self.getMotorNames():
             low, high = Device(mot).getPositionObj().getLimits()
             if new_pos[i] < low or new_pos[i] > high:
-                raise RuntimeError("%s: Requested movement beyond the limits." % mot)
+                raise RuntimeError("%s: Requested movement beyond the limits."
+                                   % mot)
             i += 1
 
         try:

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -992,6 +992,8 @@ class MotorGroup(PoolElement, Moveable):
     def _start(self, *args, **kwargs):
         new_pos = args[0]
 
+        # TODO: limits verification should be done on the server side, see:
+        # https://github.com/sardana-org/sardana/pull/560#issuecomment-332843074
         i = 0
         for mot in self.getMotorNames():
             low, high = Device(mot).getPositionObj().getLimits()

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -992,16 +992,6 @@ class MotorGroup(PoolElement, Moveable):
     def _start(self, *args, **kwargs):
         new_pos = args[0]
 
-        # TODO: limits verification should be done on the server side, see:
-        # github.com/sardana-org/sardana/pull/560#issuecomment-332843074
-        i = 0
-        for mot in self.getMotorNames():
-            low, high = Device(mot).getPositionObj().getLimits()
-            if new_pos[i] < low or new_pos[i] > high:
-                raise RuntimeError("%s: Requested movement beyond the limits."
-                                   % mot)
-            i += 1
-
         try:
             self.write_attribute('position', new_pos)
         except DevFailed, df:

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -991,6 +991,14 @@ class MotorGroup(PoolElement, Moveable):
 
     def _start(self, *args, **kwargs):
         new_pos = args[0]
+
+        i = 0
+        for mot in self.getMotorNames():
+            low, high = Device(mot).getPositionObj().getLimits()
+            if new_pos[i] < low or new_pos[i] > high:
+                raise RuntimeError("%s: Requested movement beyond the limits." % mot)
+            i += 1
+
         try:
             self.write_attribute('position', new_pos)
         except DevFailed, df:

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -993,7 +993,7 @@ class MotorGroup(PoolElement, Moveable):
         new_pos = args[0]
 
         # TODO: limits verification should be done on the server side, see:
-        # https://github.com/sardana-org/sardana/pull/560#issuecomment-332843074
+        # github.com/sardana-org/sardana/pull/560#issuecomment-332843074
         i = 0
         for mot in self.getMotorNames():
             low, high = Device(mot).getPositionObj().getLimits()


### PR DESCRIPTION
Fix for bug #259 (SF#414).
Before starting group movement I check the limits for each motor and raise an exception if requested position is outside. 