### PR TITLE
Fix error with case sensitivity

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/sardana.py
+++ b/src/sardana/taurus/core/tango/sardana/sardana.py
@@ -201,22 +201,20 @@ class BaseSardanaElementContainer:
         return self.getElement(elem_name) is not None
 
     def getElement(self, elem_name):
-        elem_name = elem_name.lower()
         for elems in self._type_elems_dict.values():
             elem = elems.get(elem_name)  # full_name?
             if elem is not None:
                 return elem
             for elem in elems.values():
-                if elem.name.lower() == elem_name:
+                if elem.name == elem_name:
                     return elem
 
     def getElementWithInterface(self, elem_name, interface):
-        elem_name = elem_name.lower()
         elems = self._interfaces_dict.get(interface, {})
         if elem_name in elems:
             return elems[elem_name]
         for elem in elems.values():
-            if elem.name.lower() == elem_name:
+            if elem.name == elem_name:
                 return elem
 
     def getElements(self):

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -621,6 +621,10 @@ class TaurusSequencerWidget(TaurusWidget):
             self.newSequenceAction.setEnabled(False)
             self.saveSequenceAction.setEnabled(False)
         except:
+            Qt.QMessageBox.warning(self,
+                                   "Loading error",
+                                   "Error loading the sequence \n"
+                                   "Verify the macro syntax")
             self.tree.clearTree()
             self.playSequenceAction.setEnabled(False)
             self.newSequenceAction.setEnabled(False)


### PR DESCRIPTION
Sequencer allows to load from xml and from txt, macros that
contains syntax errors related with the case sensitivity. The
macros are loaded into the sequencer, but they cannot be executed,
because macros are case sensitive.

Do not allow to load macros with syntax errors related with
the case sensitivity. Pop up a message if the syntax is not
correct.