### PR TITLE
Present Pool Servers by alphabetical order

### DIFF
--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -682,12 +682,9 @@ def prepare_server(args, tango_args):
                         print("\nAvailable Pools:")
                         for pool in sorted_pools:
                             print pool
-                        msg = "\nPlease select the Pool to connect to " \
-                              "(return to finish): "
-                    else:
-                        msg = "\nIf you wish to connect to more than one " \
-                              "Pool, \nplease select the new Pool to  " \
-                              "connect to (return to finish): "
+                        print("")
+                    msg = "Please select the Pool to connect to " \
+                          "(return to finish): "
                     elem = raw_input(msg).strip()
                     if not len(elem) and not pool_names:
                         print("\nMacroServer %s has not been connected to any "
@@ -698,7 +695,7 @@ def prepare_server(args, tango_args):
                               "Pool/s %s\n" % (inst_name, pool_names))
                         break
                     if elem.lower() not in all_pools:
-                        print "Unknown pool element\n"
+                        print "Unknown pool element"
                     else:
                         c += 1
                         pool_names.append(elem)

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -678,10 +678,10 @@ def prepare_server(args, tango_args):
                                           key=lambda s: s.lower())
                 c = 1
                 while True:
-                    print("\nAvailable Pools:")
-                    for pool in sorted_pools:
-                        print pool
                     if c == 1:
+                        print("\nAvailable Pools:")
+                        for pool in sorted_pools:
+                            print pool
                         msg = "\nPlease select the Pool to connect to " \
                               "(return to finish): "
                     else:

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -676,22 +676,33 @@ def prepare_server(args, tango_args):
                     pools_for_choosing.append(pools[i][3])
                     sorted_pools = sorted(pools_for_choosing,
                                           key=lambda s: s.lower())
+                c = 1
                 while True:
                     print("\nAvailable Pools:")
                     for pool in sorted_pools:
                         print pool
-                    elem = raw_input(
-                        "\nPlease select the Pool to connect to "
-                        "(return to finish): ").strip()
-                    if not len(elem):
-                        print("MacroServer %s has not been linked to any Pool"
-                              % inst_name)
+                    if c == 1:
+                        msg = "\nPlease select the Pool to connect to " \
+                              "(return to finish): "
+                    else:
+                        msg = "\nIf you wish to connect to more than one " \
+                              "Pool, \nplease select the new Pool to  " \
+                              "connect to (return to finish): "
+                    elem = raw_input(msg).strip()
+                    if not len(elem) and not pool_names:
+                        print("\nMacroServer %s has not been connected to any "
+                              "Pool\n" % inst_name)
+                        break
+                    elif not len(elem):
+                        print("\nMacroServer %s has been connected to "
+                              "Pool/s %s\n" % (inst_name, pool_names))
                         break
                     if elem.lower() not in all_pools:
                         print "Unknown pool element\n"
                     else:
+                        c += 1
                         pool_names.append(elem)
-                        break
+
                 log_messages += register_sardana(db, server_name, inst_name,
                                                  pool_names)
             else:

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -658,7 +658,8 @@ def prepare_server(args, tango_args):
 
     db = Database()
     if not exists_server_instance(db, server_name, inst_name):
-        if ask_yes_no('%s does not exist. Do you wish create a new one' % inst_name, default='y'):
+        if ask_yes_no('%s does not exist. Do you wish to create a new '
+                      'one' % inst_name, default='y'):
             if server_name == 'MacroServer':
                 # build list of pools to which the MacroServer should connect
                 # to
@@ -670,18 +671,27 @@ def prepare_server(args, tango_args):
                     if pool_alias is not None:
                         all_pools.append(pool_alias)
                 all_pools = map(str.lower, all_pools)
+                pools_for_choosing = []
                 for i in pools:
-                    print pools[i][3]
+                    pools_for_choosing.append(pools[i][3])
+                    sorted_pools = sorted(pools_for_choosing,
+                                          key=lambda s: s.lower())
                 while True:
+                    print("\nAvailable Pools:")
+                    for pool in sorted_pools:
+                        print pool
                     elem = raw_input(
-                        "Please select pool to connect to (return to finish): ").strip()
+                        "\nPlease select the Pool to connect to "
+                        "(return to finish): ").strip()
                     if not len(elem):
+                        print("MacroServer %s has not been linked to any Pool"
+                              % inst_name)
                         break
                     if elem.lower() not in all_pools:
-                        print "Unknown pool element"
-                        print all_pools
+                        print "Unknown pool element\n"
                     else:
                         pool_names.append(elem)
+                        break
                 log_messages += register_sardana(db, server_name, inst_name,
                                                  pool_names)
             else:


### PR DESCRIPTION
When creating a MacroServer, the Pool names are presented in
order to allow the user to choose one of them.

Present them by alphabetical order.