### PR TITLE
Add optional extrapolation of missing records in continuous scans

### DIFF
--- a/doc/source/users/scan.rst
+++ b/doc/source/users/scan.rst
@@ -185,6 +185,19 @@ Scans are highly configurable using the environment variables
 
 Following variables are supported:
 
+**ApplyExtrapolation**
+    Enable/disable the extrapolation method to fill the missing parts of the
+    very first scan records in case the software synchronized acquisition could
+    not follow the pace. Can be used only with the continuous acquisition
+    macros e.g. *ct* type of continuous scans or timescan. Its value is of
+    boolean type.
+
+    .. note::
+        The ApplyExtrapolation environment variable has been included in
+        Sardana on a provisional basis. Backwards incompatible changes
+        (up to and including removal of this variable) may occur if deemed
+        necessary by the core developers.
+
 **ApplyInterpolation**
     Enable/disable the `zero order hold`_ a.k.a. "constant interpolation"
     method to fill the missing parts of the scan records in case the software

--- a/doc/source/users/scan.rst
+++ b/doc/source/users/scan.rst
@@ -189,8 +189,9 @@ Following variables are supported:
     Enable/disable the `zero order hold`_ a.k.a. "constant interpolation"
     method to fill the missing parts of the scan records in case the software
     synchronized acquisition could not follow the pace. Can be used only
-    with the *ct* type of continuous scans. Its value is of boolean type.
-    
+    with the continuous acquisition macros *ct* type of continuous scans or
+    timescan. Its value is of boolean type.
+
     .. note::
         The ApplyInterpolation environment variable has been included in
         Sardana on a provisional basis with SEP6_. Backwards incompatible

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -312,11 +312,17 @@ class GScan(Logger):
 
         # The Scan data object
         try:
-            applyInterpolation = macro.getEnv('ApplyInterpolation')
+            apply_interpol = macro.getEnv('ApplyInterpolation')
         except UnknownEnv:
-            applyInterpolation = False
+            apply_interpol = False
+        try:
+            apply_extrapol = macro.getEnv('ApplyExtrapolation')
+        except UnknownEnv:
+            apply_extrapol = False
+        # The Scan data object
         data = ScanFactory().getScanData(data_handler,
-                                         apply_interpolation=applyInterpolation)
+                                         apply_interpolation=apply_interpol,
+                                         apply_extrapolation=apply_extrapol)
 
         # The Output recorder (if any)
         output_recorder = self._getOutputRecorder()

--- a/src/sardana/macroserver/scan/scandata.py
+++ b/src/sardana/macroserver/scan/scandata.py
@@ -429,7 +429,7 @@ class RecordList(dict):
         for i in range(start, len(self.records)):
             rc = self.records[i]
             self[self.currentIndex] = rc
-            if self.apply_interpolatio:
+            if self.apply_interpolation:
                 self.applyZeroOrderInterpolation(rc)
             self.datahandler.addRecord(self, rc)
             self.currentIndex += 1

--- a/src/sardana/macroserver/scan/scandata.py
+++ b/src/sardana/macroserver/scan/scandata.py
@@ -233,7 +233,7 @@ class RecordList(dict):
                  initial_data=None):
 
         self.datahandler = datahandler
-        self.applyInterpolation = apply_interpolation
+        self.apply_interpolation = apply_interpolation
         self.initial_data = initial_data
         if environ is None:
             self.environ = RecordEnvironment()
@@ -375,7 +375,7 @@ class RecordList(dict):
             if self.isRecordCompleted(i):
                 rc = self.records[i]
                 self[self.currentIndex] = rc
-                if self.applyInterpolation:
+                if self.apply_interpolation:
                     self.applyZeroOrderInterpolation(rc)
                 self.datahandler.addRecord(self, rc)
                 self.currentIndex += 1
@@ -396,7 +396,7 @@ class RecordList(dict):
         for i in range(start, len(self.records)):
             rc = self.records[i]
             self[self.currentIndex] = rc
-            if self.applyInterpolation:
+            if self.apply_interpolatio:
                 self.applyZeroOrderInterpolation(rc)
             self.datahandler.addRecord(self, rc)
             self.currentIndex += 1

--- a/src/sardana/macroserver/scan/scandata.py
+++ b/src/sardana/macroserver/scan/scandata.py
@@ -230,10 +230,11 @@ class RecordList(dict):
     It is composed of a environment and a list of records"""
 
     def __init__(self, datahandler, environ=None, apply_interpolation=False,
-                 initial_data=None):
+                 apply_extrapolation=False, initial_data=None):
 
         self.datahandler = datahandler
         self.apply_interpolation = apply_interpolation
+        self.apply_extrapolation = apply_extrapolation
         self.initial_data = initial_data
         if environ is None:
             self.environ = RecordEnvironment()
@@ -343,6 +344,34 @@ class RecordList(dict):
                 if interpolate:
                     data[k] = prev_data[k]
 
+    def applyExtrapolation(self, record):
+        """Apply extrapolation to the given record"""
+        data = record.data
+        for k, v in data.items():
+            if v is None:
+                continue
+            # numpy arrays (1D or 2D) are valid values and does not require
+            # extrapolation but provokes TypeError
+            try:
+                extrapolate = math.isnan(v)
+            except TypeError:
+                extrapolate = False
+            if extrapolate:
+                next_idx = self.currentIndex + 1
+                # dig into the record list for the first valid value in the
+                # column and use it to extrapolate missing initial values
+                while True:
+                    next_data = self.records[next_idx].data
+                    next_v = next_data[k]
+                    try:
+                        is_valid = not math.isnan(next_v)
+                    except TypeError:
+                        is_valid = True
+                    if is_valid:
+                        break
+                    next_idx += 1
+                data[k] = next_v
+
     def addData(self, data):
         """Adds data to the record list
 
@@ -371,9 +400,13 @@ class RecordList(dict):
 
     def tryToAdd(self, idx, label):
         start = self.currentIndex
+        # apply extrapolation only at the beginning of the record list
+        apply_extrapolation = (self.apply_extrapolation and start == 0)
         for i in range(start, idx + 1):
             if self.isRecordCompleted(i):
                 rc = self.records[i]
+                if apply_extrapolation:
+                    self.applyExtrapolation(rc)
                 self[self.currentIndex] = rc
                 if self.apply_interpolation:
                     self.applyZeroOrderInterpolation(rc)
@@ -409,9 +442,10 @@ class RecordList(dict):
 class ScanData(RecordList):
 
     def __init__(self, environment=None, data_handler=None,
-                 apply_interpolation=False):
+                 apply_interpolation=False, apply_extrapolation=False):
         dh = data_handler or DataHandler()
-        RecordList.__init__(self, dh, environment, apply_interpolation)
+        RecordList.__init__(self, dh, environment, apply_interpolation,
+                            apply_extrapolation)
 
 
 class ScanFactory(Singleton):
@@ -427,6 +461,8 @@ class ScanFactory(Singleton):
     def getDataHandler(self):
         return DataHandler()
 
-    def getScanData(self, dh, apply_interpolation=False):
+    def getScanData(self, dh, apply_interpolation=False,
+                    apply_extrapolation=False):
         return ScanData(data_handler=dh,
-                        apply_interpolation=apply_interpolation)
+                        apply_interpolation=apply_interpolation,
+                        apply_extrapolation=apply_extrapolation)


### PR DESCRIPTION
The very first points in the continuous acquisition e.g. ascanct may be omitted, for example, if the motor updates to the software synchronizer were not precise/fast enough. In this case the zero order interpolation does not help if we want to get rid of the NaN values.

Introduce a new concept: extrapolation to avoid NaN in the very first points of measurements. Also, add ApplyExtrapolation environment variable to control this feature.