### PR TITLE
Fix repetitions for software acquisition

### DIFF
--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -316,7 +316,7 @@ class PoolAcquisition(PoolAction):
                 sw_acq_kwargs = dict(kwargs)
                 sw_acq_kwargs['config'] = sw_acq_cfg
                 sw_acq_kwargs['integ_time'] = integ_time
-                sw_acq_kwargs['repetitions'] = repetitions
+                sw_acq_kwargs['repetitions'] = 1
                 self.set_sw_config(sw_acq_kwargs)
             if len(zerod_acq_cfg['controllers']):
                 zerod_acq_kwargs = dict(kwargs)


### PR DESCRIPTION
Software synchronized acquisition receives wrong number of repetitions
(the global one, that should be passed only to the hardware synchronized 
acquisition). Fix it by setting 1 as number of repetitions - single software
synchronized acquisitions will be repeated while the software synchronizer
triggers them.