### PR TITLE
Fix validating motor positions with limits in ascanct & co.

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2048,8 +2048,8 @@ class CTScan(CScan, CAcquisition):
                     msg = 'start position of motor %s (%f) ' % (name, start) +\
                           'is out of range (%f, %f)' % (min_pos, max_pos)
                     raise ScanException(msg)
-                if final < min_pos or start > max_pos:
-                    name = moveable.getName
+                if final < min_pos or final > max_pos:
+                    name = moveable.getName()
                     msg = 'final position of motor %s (%f) ' % (name, final) +\
                           'is out of range (%f, %f)' % (min_pos, max_pos)
                     raise ScanException(msg)


### PR DESCRIPTION
Final position is wrongly check against its limits. Fix it.
Also fix the motor name extraction in order to correctly format the error message.