### PR TITLE
Fix bug-34: Make spock wait until Ctrl+C is finished

### DIFF
--- a/src/sardana/spock/spockms.py
+++ b/src/sardana/spock/spockms.py
@@ -340,7 +340,7 @@ class SpockBaseDoor(BaseDoor):
         except KeyboardInterrupt:
             self.write('\nCtrl-C received: Stopping... ')
             self.block_lines = 0
-            self.command_inout("StopMacro")
+            self.stop()
             self.writeln("Done!")
         except PyTango.DevFailed, e:
             if is_non_str_seq(e.args) and \


### PR DESCRIPTION
Ctrl+C, or stopping a macro, exits immediatelly, not waiting until the
stopping has finished. Make the stopping wait until the door state has
changed to different than Running.