### PR TITLE
Start hardware TriggerGates as last ones

### DIFF
--- a/src/sardana/pool/poolsynchronization.py
+++ b/src/sardana/pool/poolsynchronization.py
@@ -138,6 +138,11 @@ class PoolSynchronization(PoolAction):
                                               self._synch_soft)
                 self.add_finish_hook(remove_pos_listener, False)
 
+            # start software synchronizer
+            if self._listener is not None:
+                self._synch_soft.start()
+                get_thread_pool().add(self._synch_soft.run)
+
             # PreStartAll on all controllers
             for pool_ctrl in pool_ctrls:
                 pool_ctrl.ctrl.PreStartAll()
@@ -163,10 +168,6 @@ class PoolSynchronization(PoolAction):
             # StartAll on all controllers
             for pool_ctrl in pool_ctrls:
                 pool_ctrl.ctrl.StartAll()
-
-            if self._listener is not None:
-                self._synch_soft.start()
-                get_thread_pool().add(self._synch_soft.run)
 
     def is_triggering(self, states):
         """Determines if we are triggering or if the triggering has ended


### PR DESCRIPTION
Software synchronizer is started as the last one in the synchronization
action when the hardware TriggerGate elements are already working. This is
not a problem if the hardware TriggetGate elements work in the position
domain but if they work in the time domain they may start triggering too
fast with respect to the motor's move - the motors are started to move
by the GScan when the MeasurementGroup Start has finsihed. Make the hardware
TriggerGate elements start as the last ones in the synchronization action
what aslo means the last ones in the MeasurementGroup Start command. This
change does not affect the software synchronization which works in the
position domain.