### PR TITLE
Improve exception handing in continuous scans

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -893,11 +893,11 @@ class GScan(Logger):
                 self.macro.pausePoint()
                 yield i
             endstatus = ScanEndStatus.Normal
-        except StopException, e:
+        except StopException:
             endstatus = ScanEndStatus.Stop
-        except AbortException, e:
+        except AbortException:
             endstatus = ScanEndStatus.Abort
-        except Exception, e:
+        except Exception:
             endstatus = ScanEndStatus.Exception
         finally:
             self._env["endstatus"] = endstatus

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1204,17 +1204,9 @@ class CScan(GScan):
         """Go through the different waypoints."""
         try:
             self._go_through_waypoints()
-        except StopException:
-            self.on_waypoints_end()
-            raise
-        except ScanException:
-            self.on_waypoints_end()
-            raise
         except:
-            self.macro.debug('An error occurred moving to waypoints')
-            self.macro.debug('Details: ', exc_info=True)
             self.on_waypoints_end()
-            raise ScanException('error while moving to waypoints')
+            raise
 
     def _go_through_waypoints(self):
         """Internal, unprotected method to go through the different waypoints."""

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1197,7 +1197,6 @@ class CScan(GScan):
             self._setFastMotions()
             self.macro.info("Correcting overshoot...")
             self.motion.move(restore_positions)
-        self.do_restore()
         self.motion_end_event.set()
         self.motion_event.set()
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1207,9 +1207,11 @@ class CScan(GScan):
             self._go_through_waypoints()
         except StopException:
             self.on_waypoints_end()
-        except ScanException, e:
-            raise e
-        except Exception:
+            raise
+        except ScanException:
+            self.on_waypoints_end()
+            raise
+        except:
             self.macro.debug('An error occurred moving to waypoints')
             self.macro.debug('Details: ', exc_info=True)
             self.on_waypoints_end()


### PR DESCRIPTION
Currently, StopException is not raised again to the higher layers. Due to that
the GScan.step_scan method is not able to determine if the scan was stopped
by the user or not. Furthermore, if the scan was run inside of another macro
the StopException is not propagated to the wrapper macro. Change it and
re-raise the StopException

Apart of that, after ScanException the on_waypoints_end method is not called. This
method does the necessary cleanup. Call it.
