### PR TITLE
Implement timeout/watchdog in continuous scans (issue-136)

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2182,7 +2182,7 @@ class CTScan(CScan, CAcquisition):
             finally:
                 # wait extra 15 s to for the acquisition to finish
                 # if it does not finish, abort the measurement group
-                # (this could be due to missed hardware triggers or 
+                # (this could be due to missed hardware triggers or
                 # positioning problems)
                 # TODO: allow parametrizing timeout
                 timeout = 15

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2180,10 +2180,12 @@ class CTScan(CScan, CAcquisition):
                     "Moving to waypoint position: %s" % repr(final_pos))
                 motion.move(final_pos)
             finally:
-                # for the moment just adds an extra 15 s to wait for the
-                # acquisition to finish TODO: allow parametrizing extra time
-                EXTRA_TIME = 10
-                timeout = delay_time + total_time * repeats + EXTRA_TIME
+                # wait extra 15 s to for the acquisition to finish
+                # if it does not finish, abort the measurement group
+                # (this could be due to missed hardware triggers or 
+                # positioning problems)
+                # TODO: allow parametrizing timeout
+                timeout = 15
                 measurement_group.waitFinish(timeout=timeout, id=mg_id)
                 # TODO: For Taurus 4 / Taurus 3 compatibility
                 if hasattr(measurement_group, "stateObj"):

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -446,13 +446,24 @@ class PoolElement(BaseElement, TangoDevice):
         return (ts2,)
 
     def waitFinish(self, timeout=None, id=None):
+        """Wait for the operation to finish
+
+        :param timeout: optional timeout (seconds)
+        :type timeout: float
+        :param id: id of the opertation returned by start
+        :type id: tuple(float)
+        """
+        # Due to taurus-org/taurus #573 we need to divide the timeout
+        # in two intervals
+        if timeout is not None:
+            timeout = timeout / 2
         if id is not None:
             id = id[0]
         evt_wait = self._getEventWait()
         evt_wait.lock()
         try:
             evt_wait.waitEvent(DevState.MOVING, after=id, equal=False,
-                               timeout=timeout)
+                               timeout=timeout, retries=1)
         finally:
             self.__go_end_time = time.time()
             self.__go_time = self.__go_end_time - self.__go_start_time


### PR DESCRIPTION
Hardware problems (missed triggers or positioning problems) could leave the
acquisition waiting infinitely. Add a timeout/watchdog mechanism that will
stop the measurement group if the estimated acquisition time elapses and
the measurement group does not finish. Add an extra time (15 s) to be
sure that the acquisition will not finish. Fix #136.

The extra time is hardcoded now. But I imagine we will make it configurable in the future when we get experience with this kind of problems.