### PR TITLE
Fix bug in generate timestamps (ascanct & co.)

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1891,7 +1891,7 @@ def generate_timestamps(synchronization):
         timestamp += delay
         ret[index] = dict(timestamp=timestamp)
         index += 1
-        for _ in xrange(1, repeats + 1):
+        for _ in xrange(1, repeats):
             timestamp += total
             ret[index] = dict(timestamp=timestamp)
             index += 1


### PR DESCRIPTION
Too many timestamps are generated. The initial delay already indicates
timestamp of the first point so the loop over repeats must iterate
one time less.  Fix it.