### PR TITLE
Reduce motion overheads

### DIFF
--- a/src/sardana/pool/poolmotorgroup.py
+++ b/src/sardana/pool/poolmotorgroup.py
@@ -139,12 +139,9 @@ class PoolMotorGroup(PoolGroupElement):
 
     def on_element_changed(self, evt_src, evt_type, evt_value):
         name = evt_type.name.lower()
-        if name in ('state', 'position'):
+        if name == 'state':
             state, status = self._calculate_states()
-            if name == 'state':
-                propagate_state = evt_type.priority
-            else:
-                propagate_state = 0
+            propagate_state = evt_type.priority
             self.set_state(state, propagate=propagate_state)
             self.set_status(status, propagate=propagate_state)
 

--- a/src/sardana/pool/poolpseudomotor.py
+++ b/src/sardana/pool/poolpseudomotor.py
@@ -303,17 +303,17 @@ class PoolPseudoMotor(PoolBaseGroup, PoolElement):
 
     def on_element_changed(self, evt_src, evt_type, evt_value):
         name = evt_type.name.lower()
-        # always calculate state.
-        status_info = self._calculate_states()
-        state, status = self.calculate_state_info(status_info=status_info)
-        state_propagate = 0
-        status_propagate = 0
-        if name == 'state':
-            state_propagate = evt_type.priority
-        elif name == 'status':
-            status_propagate = evt_type.priority
-        self.set_state(state, propagate=state_propagate)
-        self.set_status(status, propagate=status_propagate)
+        if name in ("state", "status"):
+            status_info = self._calculate_states()
+            state, status = self.calculate_state_info(status_info=status_info)
+            state_propagate = 0
+            status_propagate = 0
+            if name == 'state':
+                state_propagate = evt_type.priority
+            elif name == 'status':
+                status_propagate = evt_type.priority
+            self.set_state(state, propagate=state_propagate)
+            self.set_status(status, propagate=status_propagate)
 
     def add_user_element(self, element, index=None):
         elem_type = element.get_type()


### PR DESCRIPTION
Core objects related to moveables are related by the publisher-subscriber pattern. For example:
* dial position is a publisher and motor’s position is a subscriber
* motor’s position is a publisher and motor is a subscriber
* motor’s position is a publisher and pseudo motor’s position is a subscriber
* pseudo motor’s position is a publisher and pseudo motor is a subscriber
* motor is a publisher and pseudo motor is a subscriber

The attached sketch tries to demonstrate it (please forgive me its poor quality...)

![motion-overheads](https://user-images.githubusercontent.com/6735649/30600634-4d0cf646-9d60-11e7-9a60-785f893835b6.jpg)

Since a pseudo motor is subscribed to motor’s events with the `on_element_changed` callback it processes all the dial position events propagated via the following chain: `dial position -> position -> motor -> pseudo motor`. After looking at the callback code, I think that this is not necessary, cause the only thing that it does is to recalculate the state and status. State and status information are already well calculated because at the beginning and at the end of the motion these are notified with the corresponding events. What is even worse is that the `on_element_changed` callback is called twice because there is an another event propagation route: `dial position -> motor -> pseudo motor`. I propose to filter out events different than state and status. A similar change is proposed for motor groups.