### PR TITLE
Respect enabled flag on controllers

### DIFF
--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -545,14 +545,6 @@ class PoolAcquisitionBase(PoolAction):
                 if ElementType.CTExpChannel in ctrl.get_ctrl_types():
                     _pool_ctrl_dict_loop[ctrl] = pool_ctrl_data
 
-        pool_ctrls = []
-        self._pool_ctrl_dict_loop = _pool_ctrl_dict_loop = {}
-        for ctrl, v in pool_ctrls_dict.items():
-            if ctrl.is_timerable():
-                pool_ctrls.append(ctrl)
-            if ElementType.CTExpChannel in ctrl.get_ctrl_types():
-                _pool_ctrl_dict_loop[ctrl] = v
-
         # make sure the controller which has the master channel is the last to
         # be called
         pool_ctrls.remove(master_ctrl)


### PR DESCRIPTION
When acquisition starts, the enabled flag is not correctly respected on controllers.
The controllers that are not enabled (none of their channels is enabled) are loaded, started, etc.
This bug was probably introduced while merging SEP6 into develop because this feature
used to worked before. Fix it.