### PR TITLE
Do not serialize instrument information

### DIFF
--- a/src/sardana/macroserver/macros/test/test_expert.py
+++ b/src/sardana/macroserver/macros/test/test_expert.py
@@ -88,6 +88,9 @@ class MeasTest(RunMacroTestCase, unittest.TestCase):
             import taurus
             taurus.warning("Your system may stay dirty due to an unexpected"
                            " exception during the test.")
+            print "Exception occurred!"
+            print "ExceptionStr: ", self.macro_executor.getExceptionStr()
+            print "CommonBuffer: ", self.macro_executor.getCommonBuffer()
             raise e
 
 # TODO: improve this test: not all sardana controller implement SendToCtrl

--- a/src/sardana/macroserver/macros/test/test_expert.py
+++ b/src/sardana/macroserver/macros/test/test_expert.py
@@ -76,8 +76,14 @@ class MeasTest(RunMacroTestCase, unittest.TestCase):
         try:
             self.macro_runs(macro_name="defmeas",
                             macro_params=[MNTGRP_NAME, CT_NAME1, CT_NAME2])
+            print "defmeas"
+            print "ExceptionStr: ", self.macro_executor.getExceptionStr()
+            print "CommonBuffer: ", self.macro_executor.getCommonBuffer()
             self.macro_runs(macro_name="udefmeas",
                             macro_params=[MNTGRP_NAME])
+            print "udefmeas"
+            print "ExceptionStr: ", self.macro_executor.getExceptionStr()
+            print "CommonBuffer: ", self.macro_executor.getCommonBuffer()
         except Exception, e:
             import taurus
             taurus.warning("Your system may stay dirty due to an unexpected"

--- a/src/sardana/macroserver/macros/test/test_expert.py
+++ b/src/sardana/macroserver/macros/test/test_expert.py
@@ -74,23 +74,24 @@ class MeasTest(RunMacroTestCase, unittest.TestCase):
     def test_meas(self):
         MNTGRP_NAME = "unittestmntgrp01"
         try:
+            import taurus
             self.macro_runs(macro_name="defmeas",
                             macro_params=[MNTGRP_NAME, CT_NAME1, CT_NAME2])
-            print "defmeas"
-            print "ExceptionStr: ", self.macro_executor.getExceptionStr()
-            print "CommonBuffer: ", self.macro_executor.getCommonBuffer()
+            taurus.warning("defmeas")
+            taurus.warning("ExceptionStr: %s" % self.macro_executor.getExceptionStr())
+            taurus.warning("CommonBuffer: %s" % self.macro_executor.getCommonBuffer())
             self.macro_runs(macro_name="udefmeas",
                             macro_params=[MNTGRP_NAME])
-            print "udefmeas"
-            print "ExceptionStr: ", self.macro_executor.getExceptionStr()
-            print "CommonBuffer: ", self.macro_executor.getCommonBuffer()
+            taurus.warning("udefmeas")
+            taurus.warning("ExceptionStr: %s" % self.macro_executor.getExceptionStr())
+            taurus.warning("CommonBuffer: %s" % self.macro_executor.getCommonBuffer())
         except Exception, e:
             import taurus
             taurus.warning("Your system may stay dirty due to an unexpected"
                            " exception during the test.")
-            print "Exception occurred!"
-            print "ExceptionStr: ", self.macro_executor.getExceptionStr()
-            print "CommonBuffer: ", self.macro_executor.getCommonBuffer()
+            taurus.warning("Exception occurred!")
+            taurus.warning("ExceptionStr: %s" % self.macro_executor.getExceptionStr())
+            taurus.warning("CommonBuffer: %s" % self.macro_executor.getCommonBuffer())
             raise e
 
 # TODO: improve this test: not all sardana controller implement SendToCtrl

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -597,7 +597,6 @@ class GScan(Logger):
 
         # add master column
         master = self._master
-        instrument = master['instrument']
 
         # add channels from measurement group
         channels_info = self.measurement_group.getChannelsEnabledInfo()

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -603,7 +603,17 @@ class GScan(Logger):
         channels_info = self.measurement_group.getChannelsEnabledInfo()
         counters = []
         for ci in channels_info:
-            instrument = ci.instrument or ''
+            ctrl_name = ci._controller_name
+            external = ctrl_name.startswith('__')
+            if not external:
+                full_name = ci.full_name
+                # for Taurus 4 compatibility
+                if not full_name.startswith("tango://"):
+                    full_name = "tango://{0}".format(full_name)
+                channel = taurus.Device(full_name)
+                instrument = channel.instrument
+            else:
+                instrument = ''
             try:
                 instrumentFullName = self.macro.findObjs(
                     instrument, type_class=Type.Instrument)[0].getFullName()

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -602,16 +602,16 @@ class GScan(Logger):
         channels_info = self.measurement_group.getChannelsEnabledInfo()
         counters = []
         for ci in channels_info:
-            ctrl_name = ci._controller_name
-            external = ctrl_name.startswith('__')
-            if not external:
-                full_name = ci.full_name
-                # for Taurus 4 compatibility
-                if not full_name.startswith("tango://"):
-                    full_name = "tango://{0}".format(full_name)
+            full_name = ci.full_name
+            # for Taurus 4 compatibility
+            if not full_name.startswith("tango://"):
+                full_name = "tango://{0}".format(full_name)
+            try:
                 channel = taurus.Device(full_name)
                 instrument = channel.instrument
-            else:
+            except:
+                # full_name of external channels is the name of the attribute
+                # external channels are not assigned to instruments
                 instrument = ''
             try:
                 instrumentFullName = self.macro.findObjs(

--- a/src/sardana/pool/poolelement.py
+++ b/src/sardana/pool/poolelement.py
@@ -57,10 +57,6 @@ class PoolElement(PoolBaseElement):
         kwargs = PoolBaseElement.serialize(self, *args, **kwargs)
         kwargs['controller'] = self.controller.full_name
         kwargs['axis'] = self.axis
-        if self.instrument is not None:
-            kwargs['instrument'] = self.instrument.full_name
-        else:
-            kwargs['instrument'] = None
         kwargs['source'] = self.get_source()
         return kwargs
 

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -195,7 +195,6 @@ class PoolMeasurementGroup(PoolGroupElement):
 
         external_from_name = isinstance(channel, (str, unicode))
         ndim = None
-        instrument = None
         if external_from_name:
             name = full_name = source = channel
         else:
@@ -203,10 +202,7 @@ class PoolMeasurementGroup(PoolGroupElement):
             full_name = channel.full_name
             source = channel.get_source()
             ndim = None
-            instrument = None
             ctype = channel.get_type()
-            if ctype != ElementType.External:
-                instrument = channel.instrument
             if ctype == ElementType.CTExpChannel:
                 ndim = 0
             elif ctype == ElementType.PseudoCounter:
@@ -232,8 +228,6 @@ class PoolMeasurementGroup(PoolGroupElement):
         channel_data['source'] = channel_data.get('source', source)
         channel_data['enabled'] = channel_data.get('enabled', True)
         channel_data['label'] = channel_data.get('label', channel_data['name'])
-        channel_data['instrument'] = channel_data.get(
-            'instrument', getattr(instrument, 'name', None))
         channel_data['ndim'] = ndim
         # Probably should be initialized by measurement group
         channel_data['output'] = channel_data.get('output', True)


### PR DESCRIPTION
The PoolElement serialize method include instrument information,
the instrument are dynamically created and the serialization
in the PoolElement causes troubles.

Avoid to pass it.