### PR TITLE
Fix use of mutable channels object

### DIFF
--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -545,6 +545,23 @@ class PoolAcquisitionBase(PoolAction):
                 # only CT will be read in the loop, 1D and 2D not
                 if ElementType.CTExpChannel in ctrl.get_ctrl_types():
                     _pool_ctrl_dict_loop[ctrl] = pool_ctrl_data
+            # ctrl that contains the master timer/monitor can not be disabled
+            elif ctrl is master_ctrl:
+                self.main_element.set_state(State.Fault, propagate=2)
+                msg = "master timer/monitor ({0}) is disabled".format(
+                    master.name)
+                raise RuntimeError(msg)
+
+        # timer/monitor channels can not be disabled
+        for pool_ctrl in pool_ctrls:
+            ctrl = pool_ctrl.ctrl
+            pool_ctrl_data = pool_ctrls_dict[pool_ctrl]
+            timer_monitor = pool_ctrl_data[master_key]
+            if timer_monitor not in channels:
+                self.main_element.set_state(State.Fault, propagate=2)
+                msg = "timer/monitor ({0}) of {1} controller is "\
+                      "disabled)".format(timer_monitor.name, pool_ctrl.name)
+                raise RuntimeError(msg)
 
         # make sure the controller which has the master channel is the last to
         # be called

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -524,6 +524,7 @@ class PoolAcquisitionBase(PoolAction):
         # channels that are acquired (only enabled)
         self._channels = channels = {}
 
+        # select only suitable e.g. enabled, timerable controllers & channels
         for ctrl, pool_ctrl_data in pool_ctrls_dict.items():
             # skip not timerable controllers e.g. 0D
             if not ctrl.is_timerable():
@@ -531,7 +532,6 @@ class PoolAcquisitionBase(PoolAction):
             ctrl_enabled = False
             elements = pool_ctrl_data['channels']
             for element, element_info in elements.items():
-
                 # skip disabled elements
                 if not element_info['enabled']:
                     continue
@@ -550,8 +550,8 @@ class PoolAcquisitionBase(PoolAction):
         # be called
         pool_ctrls.remove(master_ctrl)
         pool_ctrls.append(master_ctrl)
-        with ActionContext(self):
 
+        with ActionContext(self):
             # PreLoadAll, PreLoadOne, LoadOne and LoadAll
             for pool_ctrl in pool_ctrls:
                 try:
@@ -587,21 +587,19 @@ class PoolAcquisitionBase(PoolAction):
                     msg = ("Load sequence of %s failed" % pool_ctrl.name)
                     raise Exception(msg)
 
-            # PreStartAll on all controllers
+            # PreStartAll on all enabled controllers
             for pool_ctrl in pool_ctrls:
                 pool_ctrl.ctrl.PreStartAll()
 
-            # PreStartOne & StartOne on all elements
+            # PreStartOne & StartOne on all enabled elements
             for pool_ctrl in pool_ctrls:
                 ctrl = pool_ctrl.ctrl
                 pool_ctrl_data = pool_ctrls_dict[pool_ctrl]
                 elements = pool_ctrl_data['channels'].keys()
                 timer_monitor = pool_ctrl_data[master_key]
-
                 # make sure that the timer/monitor is started as the last one
                 elements.remove(timer_monitor)
                 elements.append(timer_monitor)
-
                 for element in elements:
                     try:
                         channel = channels[element]
@@ -626,7 +624,7 @@ class PoolAcquisitionBase(PoolAction):
             for channel in channels:
                 channel.set_state(State.Moving, propagate=2)
 
-            # StartAll on all controllers
+            # StartAll on all enabled controllers
             for pool_ctrl in pool_ctrls:
                 try:
                     pool_ctrl.ctrl.StartAll()

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -544,8 +544,8 @@ class PoolAcquisitionBase(PoolAction):
                 if ElementType.CTExpChannel in ctrl.get_ctrl_types():
                     _pool_ctrl_dict_loop[ctrl] = pool_ctrl_data
 
-        # # make sure the controller which has the master channel is the last to
-        # # be called
+        # make sure the controller which has the master channel is the last to
+        # be called
         pool_ctrls.remove(master_ctrl)
         pool_ctrls.append(master_ctrl)
         with ActionContext(self):

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -535,9 +535,11 @@ class PoolAcquisitionBase(PoolAction):
                 # skip disabled elements
                 if not element_info['enabled']:
                     continue
+                # Add only the enabled channels
                 channel = Channel(element, info=element_info)
                 channels[element] = channel
                 ctrl_enabled = True
+            # check if the ctrl has enabled channels
             if ctrl_enabled:
                 pool_ctrls.append(ctrl)
                 # only CT will be read in the loop, 1D and 2D not
@@ -599,12 +601,13 @@ class PoolAcquisitionBase(PoolAction):
                 # make sure that the timer/monitor is started as the last one
                 elements.remove(timer_monitor)
                 elements.append(timer_monitor)
+
                 for element in elements:
                     try:
                         channel = channels[element]
                     except KeyError:
                         continue
-
+                    axis = element.axis
                     ret = ctrl.PreStartOne(axis, master_value)
                     if not ret:
                         msg = ("%s.PreStartOne(%d) returns False" %


### PR DESCRIPTION
Improve the start_action method, solve problems on manage mutable
objects enabling/disabling measurement group channels.

This patch solves conflicts on save the measurement Group configurations when it has disabled channels.
This Pull Request is related with [PR-607](https://github.com/sardana-org/sardana/pull/607)
