### PR TITLE
Adapt continuous scans to FQDN in Taurus 4 model names

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1836,13 +1836,33 @@ class CAcquisition(object):
             full_name = element.getName()
         else:
             full_name = element.getFullName()
-        # TODO: for Taurus4 compatibility
+
+        # TODO: for Taurus3/Taurus4 compatibility
         # The sardana code is not fully ready to deal with Taurus4 model names
-        # strip scheme name that appeared in the full_name since Taurus4
+        # Necessary changes are:
+        # * strip scheme name that appeared in the full_name since Taurus4
+        # * avoid FQDN introduced wuth taurus-org/taurus#488
         # and come back to the Taurus3 style full name cause all the recording
         # stuff and the measurement group counts is based on them
-        if full_name.startswith("tango://"):
-            full_name = full_name.lstrip("tango://")
+        try:
+            from taurus.core.tango.tangovalidator import\
+                TangoDeviceNameValidator
+            validator = TangoDeviceNameValidator()
+            uri_groups = validator.getUriGroups(full_name, strict=False)
+            dev_name = uri_groups["devname"]
+            fqdn_host = uri_groups["host"]
+            if fqdn_host is not None:
+                port = uri_groups["port"]
+                host = fqdn_host.split(".")[0]
+                full_name = host + ":" + port + "/" + dev_name
+            else:
+                full_name = dev_name
+        except ImportError:
+            # we are in Taurus 3 so neither scheme nor FQDN is in use
+            pass
+        except:
+            msg = "Unknown error in buffer_changed callback"
+            self.warning(msg, exc_info=1)
 
         info = {'label': full_name}
         info.update(buffer_)

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1848,7 +1848,7 @@ class CAcquisition(object):
             from taurus.core.tango.tangovalidator import\
                 TangoDeviceNameValidator
             validator = TangoDeviceNameValidator()
-            uri_groups = validator.getUriGroups(full_name, strict=False)
+            uri_groups = validator.getUriGroups(full_name)
             dev_name = uri_groups["devname"]
             fqdn_host = uri_groups["host"]
             if fqdn_host is not None:


### PR DESCRIPTION
taurus-org/taurus#488 introduced FQDN in model names. The channel's
column description is composed from the full_name that is composed in
the Pool and transferred with the measurement group configuration and it
does not contain the FQDN. Adapt CAcquisition.buffer_changed callback
to be compatible both with Taurus3 and Taurus4.