### PR TITLE
Fix dummy counter value after abort

### DIFF
--- a/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
@@ -132,8 +132,6 @@ class DummyCounterTimerController(CounterTimerController):
         if channel.mode == AcqSynch.SoftwareTrigger:
             if self.integ_time is not None:
                 t = elapsed_time
-                if not channel.is_counting:
-                    t = self.integ_time
                 if ind == self._timer:
                     channel.value = t
                 else:

--- a/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
@@ -165,10 +165,10 @@ class DummyCounterTimerController(CounterTimerController):
                 channel = self.counting_channels[ind]
                 channel.is_counting = False
                 self._updateChannelValue(ind, elapsed_time)
+                self.counting_channels.pop(ind)
             else:
                 channel = self.channels[ind - 1]
                 channel.is_counting = False
-        self.counting_channels = {}
 
     def PreReadAll(self):
         self.read_channels = {}

--- a/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
@@ -132,6 +132,7 @@ class DummyCounterTimerController(CounterTimerController):
         if channel.mode == AcqSynch.SoftwareTrigger:
             if self.integ_time is not None:
                 t = elapsed_time
+                t = min([elapsed_time, self.integ_time])
                 if ind == self._timer:
                     channel.value = t
                 else:


### PR DESCRIPTION
Dummy counters involved in an acquisition that was aborted always
returns the value corresponing to the integration time even
if the abort happend earlier. Fix it and always return the real value
of the counter. This has a side effect on the noramlly finished
acquisition which from now on does not show the round number.

If you don't like the side effect we should work on how to return the round
number in case of normal end of the acquisition. 