### PR TITLE
Removed uselles setting of label config in PMTV

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -1423,9 +1423,6 @@ class PoolMotorTV(TaurusValue):
         self.setReadWidgetClass(PoolMotorTVReadWidget)
         self.setWriteWidgetClass(PoolMotorTVWriteWidget)
         self.setUnitsWidgetClass(PoolMotorTVUnitsWidget)
-
-        self.setLabelConfig('dev_alias')
-
         self.motor_dev = None
         self._expertView = False
         self.limits_listener = None


### PR DESCRIPTION
Setting of label config in PMTV has no effect - the widget works exactly the same
if the line is removed. This applies both to Taurus3 and Taurus4.