### PR TITLE
[WIP] Add support to GeneralHooks (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ This file follows the formats and conventions from [keepachangelog.com]
   (`ApplyExtrapolation` environment variable) (#588)
 - `--file` option to sequencer - it allows to load a sequence file
   directly on the application startup moment (#283, #551)
+- Report error line number when loading a sequence from a txt file
+  fails (#114, #552)
 - Present available pools at the macroserver creation moment in the
   alphabetical order (#585, #586)
 - Present available doors at the spock profile creation moment in the
@@ -40,6 +42,8 @@ This file follows the formats and conventions from [keepachangelog.com]
   #615)
 - Selection of the master timer/monitor for each of the acquisition
   sub-actions (hardware and software) (#614)
+- Avoid "already involved in motion" errors due to wrong handling of
+  operation context and Tango state machine (#639)
 - Make the information about the element's instrument fully dynamic and
   remove it from the serialized information (#122, #619)
 - uct macro (#319, #627)

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -212,15 +212,21 @@ class Hookable(Logger):
         self._getHooks().append(hook_info)
         hook = hook_info[0]
         hints = hook_info[1]
-        self._getHookHintsDict()['_ALL_'].append(hook)
+        allowed_hookhints = self.getAllowedHookHints()
         if len(hints) == 0:
+            self._getHookHintsDict()['_ALL_'].append(hook)
             self._hookHintsDict['_NOHINTS_'].append(hook)
             return
         for hint in hints:
-            try:
-                self._hookHintsDict[hint].append(hook)
-            except KeyError:
-                self._hookHintsDict[hint] = [hook]
+            if hint in allowed_hookhints:
+                self._getHookHintsDict()['_ALL_'].append(hook)
+                break
+        for hint in hints:
+            if hint in allowed_hookhints:
+                try:
+                    self._hookHintsDict[hint].append(hook)
+                except KeyError:
+                    self._hookHintsDict[hint] = [hook]
 
     @propertx
     def hooks():

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -202,6 +202,26 @@ class Hookable(Logger):
         else:
             return self._getHookHintsDict().get(hint, [])
 
+    def appendHook(self, hook_info):
+        """Append a hook according to the hook information
+
+        :param hook_info: sequence of two elements, the first one is the hook
+            and its optional parameters/arguments, the second one is the list
+            of hints e.g. hook places
+        """
+        self._getHooks().append(hook_info)
+        hook = hook_info[0]
+        hints = hook_info[1]
+        self._getHookHintsDict()['_ALL_'].append(hook)
+        if len(hints) == 0:
+            self._hookHintsDict['_NOHINTS_'].append(hook)
+            return
+        for hint in hints:
+            try:
+                self._hookHintsDict[hint].append(hook)
+            except KeyError:
+                self._hookHintsDict[hint] = [hook]
+
     @propertx
     def hooks():
         def get(self):

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -312,28 +312,17 @@ class defgh(Macro):
     """Define general hook. Without arguments add default ones """
     
     param_def = [
-        ['macro_name', Type.String, "default", 'Macro name with parameters. Ex.: "mv exp_dmy01 10"'],
-        ['hook_pos', Type.String, "default", 'Position or positions where the hook has to be executed. Ex.: "pre-scan", several positions "pre-scan,post-scan"'],
+        ['macro_name', Type.String, None, 'Macro name with parameters. Ex.: "mv exp_dmy01 10"'],
+        ['hook_pos', Type.String, None, 'Position or positions where the hook has to be executed. Ex.: "pre-scan", several positions "pre-scan,post-scan"'],
     ]
     
     def run(self, macro_name, hook_pos):
-        default_list = [('gh_pre_scan',['pre-scan']),
-                        ('gh_pre_move',['pre-move']),
-                        ('gh_pre_acq',['pre-acq']),
-                        ('gh_post_acq',['post-acq']),
-                        ('gh_post_move',['post-move']),
-                        ('gh_post_step',['post-step']),
-                        ('gh_post_scan',['post-scan'])]
-        if hook_pos == "default":
-            self.info("Defining general hooks with default names")
-            self.debug(default_list)
-            self.setEnv("_GeneralHooks", default_list)
-        else:
-            self.info("Defining general hook")
-            try:
-                macros_list = self.getEnv("_GeneralHooks")
-            except:
-                macros_list = []
+        
+        self.info("Defining general hook")
+        try:
+            macros_list = self.getEnv("_GeneralHooks")
+        except:
+            macros_list = []
             positions_split = hook_pos.split(",")
             positions = []
             for pos in positions_split:

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -302,9 +302,29 @@ class lsgh(Macro):
     def run(self): 
         try:
             general_hooks = self.getEnv("_GeneralHooks")
-            self.output("General Hooks:")
+            default_dict = {'pre-scan': [],
+                            'pre-move': [],
+                            'pre-acq': [],
+                            'post-acq': [],
+                            'post-move': [],
+                            'post-step': [],
+                            'post-scan': []}
+            out = List(['Hook place', 'Hook(s)'])
             for hook in general_hooks:
-                self.output(hook)
+                name = hook[0]
+                places = hook[1]
+                for place in places:
+                    default_dict[place].append(name)
+            for pos in default_dict.keys():
+                pos_set = 0
+                for hook in default_dict[pos]:
+                    if pos_set:
+                        out.appendRow(["", hook])
+                    else:
+                        out.appendRow([pos, hook])
+                    pos_set = 1
+            for line in out.genOutput():
+                self.output(line)
         except:
             self.output("No general hooks")
 
@@ -323,6 +343,7 @@ class defgh(Macro):
             macros_list = self.getEnv("_GeneralHooks")
         except:
             macros_list = []
+            
         positions_split = hook_pos.split(",")
         positions = []
         for pos in positions_split:

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -31,6 +31,7 @@ __docformat__ = 'restructuredtext'
 
 from taurus.console.list import List
 from sardana.macroserver.macro import Macro, Type, ParamRepeat
+from sardana.macroserver.msexception import UnknownEnv
 
 ##########################################################################
 #
@@ -303,29 +304,30 @@ class lsgh(Macro):
     def run(self):
         try:
             general_hooks = self.getEnv("_GeneralHooks")
-
-            out = List(['Hook place', 'Hook(s)'])
-            default_dict = {}
-            for hook in general_hooks:
-                name = hook[0]
-                places = hook[1]
-                for place in places:
-                    if place not in default_dict.keys():
-                        default_dict[place] = []
-                    if name not in default_dict[place]:
-                        default_dict[place].append(name)
-            for pos in default_dict.keys():
-                pos_set = 0
-                for hook in default_dict[pos]:
-                    if pos_set:
-                        out.appendRow(["", hook])
-                    else:
-                        out.appendRow([pos, hook])
-                    pos_set = 1
-            for line in out.genOutput():
-                self.output(line)
-        except:
+        except UnknownEnv:
             self.output("No general hooks")
+            return
+
+        out = List(['Hook place', 'Hook(s)'])
+        default_dict = {}
+        for hook in general_hooks:
+            name = hook[0]
+            places = hook[1]
+            for place in places:
+                if place not in default_dict.keys():
+                    default_dict[place] = []
+                if name not in default_dict[place]:
+                    default_dict[place].append(name)
+        for pos in default_dict.keys():
+            pos_set = 0
+            for hook in default_dict[pos]:
+                if pos_set:
+                    out.appendRow(["", hook])
+                else:
+                    out.appendRow([pos, hook])
+                pos_set = 1
+        for line in out.genOutput():
+            self.output(line)
 
 
 class defgh(Macro):
@@ -353,7 +355,7 @@ class defgh(Macro):
         self.output(macro_name)
         try:
             macros_list = self.getEnv("_GeneralHooks")
-        except:
+        except UnknownEnv:
             macros_list = []
 
         hook_tuple = (macro_name, position)
@@ -376,7 +378,7 @@ class udefgh(Macro):
     def run(self, macro_name, hook_pos):
         try:
             gh_macros_list = self.getEnv("_GeneralHooks")
-        except:
+        except UnknownEnv:
             return
 
         if macro_name == "all":

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -30,7 +30,7 @@ __all__ = ["dumpenv", "load_env", "lsenv", "senv", "usenv",
 __docformat__ = 'restructuredtext'
 
 from taurus.console.list import List
-from sardana.macroserver.macro import *
+from sardana.macroserver.macro import Macro, Type, ParamRepeat
 
 ##########################################################################
 #
@@ -295,14 +295,15 @@ class load_env(Macro):
             for parameter in misc_tree:
                 if parameter.tag != "name":
                     self.setEnv(parameter.tag, parameter.text)
-      
+
+
 class lsgh(Macro):
     """List general hooks"""
-    
-    def run(self): 
+
+    def run(self):
         try:
             general_hooks = self.getEnv("_GeneralHooks")
-            
+
             out = List(['Hook place', 'Hook(s)'])
             default_dict = {}
             for hook in general_hooks:
@@ -326,6 +327,7 @@ class lsgh(Macro):
         except:
             self.output("No general hooks")
 
+
 class defgh(Macro):
     """Define general hook.
     Ex.
@@ -336,37 +338,39 @@ class defgh(Macro):
     defgh "Print 'Hello world'" pre-scan
 
     """
-    
+
     param_def = [
-        ['macro_name', Type.String, None, 'Macro name with parameters. Ex.: "mv exp_dmy01 10"'],
+        ['macro_name', Type.String, None, ('Macro name with parameters. '
+                                           'Ex.: "mv exp_dmy01 10"')],
         ['hookpos_list',
          ParamRepeat(['position', Type.String, None, 'macro name'], min=1),
          None, 'List of positions where the hook has to be executed'],
     ]
-    
+
     def run(self, macro_name, position):
-        
+
         self.info("Defining general hook")
         self.output(macro_name)
         try:
             macros_list = self.getEnv("_GeneralHooks")
         except:
             macros_list = []
-            
+
         hook_tuple = (macro_name, position)
         self.debug(hook_tuple)
         macros_list.append(hook_tuple)
         self.setEnv("_GeneralHooks", macros_list)
         self.debug("General hooks:")
         self.debug(macros_list)
-        
+
 
 class udefgh(Macro):
     """Undefine general hook. Without arguments undefine all """
 
     param_def = [
         ['macro_name', Type.String, "all", 'General hook to be undefined'],
-        ['hook_pos', Type.String, "all", 'Position to undefine the general hook from'],
+        ['hook_pos', Type.String, "all", ('Position to undefine the general '
+                                          'hook from')],
     ]
 
     def run(self, macro_name, hook_pos):
@@ -385,6 +389,5 @@ class udefgh(Macro):
                     macros_list.append(el)
                 else:
                     self.info("Hook %s is undefineed" % macro_name)
-            
+
             self.setEnv("_GeneralHooks", macros_list)
-  

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -323,16 +323,16 @@ class defgh(Macro):
             macros_list = self.getEnv("_GeneralHooks")
         except:
             macros_list = []
-            positions_split = hook_pos.split(",")
-            positions = []
-            for pos in positions_split:
-                positions.append(pos)
-            hook_tuple = (macro_name, positions)
-            self.debug(hook_tuple)
-            macros_list.append(hook_tuple)
-            self.setEnv("_GeneralHooks", macros_list)
-            self.debug("General hooks:")
-            self.debug(macros_list)
+        positions_split = hook_pos.split(",")
+        positions = []
+        for pos in positions_split:
+            positions.append(pos)
+        hook_tuple = (macro_name, positions)
+        self.debug(hook_tuple)
+        macros_list.append(hook_tuple)
+        self.setEnv("_GeneralHooks", macros_list)
+        self.debug("General hooks:")
+        self.debug(macros_list)
         
 
 class udefgh(Macro):

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -299,7 +299,14 @@ class load_env(Macro):
 
 
 class lsgh(Macro):
-    """List general hooks"""
+    """List general hooks.
+
+    .. note::
+        The `lsgh` macro has been included in Sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including its removal) may occur if
+        deemed necessary by the core developers.
+    """
 
     def run(self):
         try:
@@ -333,11 +340,17 @@ class lsgh(Macro):
 class defgh(Macro):
     """Define general hook.
     Ex.
-    defgh "mv [[mot02 9]]" pre-scan
-    defgh "ct 0.1" pre-scan
-    defgh lsm pre-scan
-    defgh "mv mot03 10" pre-scan
-    defgh "Print 'Hello world'" pre-scan
+        defgh "mv [[mot02 9]]" pre-scan
+        defgh "ct 0.1" pre-scan
+        defgh lsm pre-scan
+        defgh "mv mot03 10" pre-scan
+        defgh "Print 'Hello world'" pre-scan
+
+    .. note::
+        The `defgh` macro has been included in Sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including its removal) may occur if
+        deemed necessary by the core developers.
 
     """
 
@@ -367,7 +380,14 @@ class defgh(Macro):
 
 
 class udefgh(Macro):
-    """Undefine general hook. Without arguments undefine all """
+    """Undefine general hook. Without arguments undefine all.
+
+    .. note::
+        The `lsgh` macro has been included in Sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including its removal) may occur if
+        deemed necessary by the core developers.
+    """
 
     param_def = [
         ['macro_name', Type.String, "all", 'General hook to be undefined'],

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -327,7 +327,15 @@ class lsgh(Macro):
             self.output("No general hooks")
 
 class defgh(Macro):
-    """Define general hook. Without arguments add default ones """
+    """Define general hook.
+    Ex.
+    defgh "mv [[mot02 9]]" pre-scan
+    defgh "ct 0.1" pre-scan
+    defgh lsm pre-scan
+    defgh "mv mot03 10" pre-scan
+    defgh "Print 'Hello world'" pre-scan
+
+    """
     
     param_def = [
         ['macro_name', Type.String, None, 'Macro name with parameters. Ex.: "mv exp_dmy01 10"'],
@@ -340,7 +348,6 @@ class defgh(Macro):
         
         self.info("Defining general hook")
         self.output(macro_name)
-        self.output(type(position))
         try:
             macros_list = self.getEnv("_GeneralHooks")
         except:
@@ -349,7 +356,6 @@ class defgh(Macro):
         hook_tuple = (macro_name, position)
         self.debug(hook_tuple)
         macros_list.append(hook_tuple)
-        self.output("set gh")
         self.setEnv("_GeneralHooks", macros_list)
         self.debug("General hooks:")
         self.debug(macros_list)

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -302,19 +302,17 @@ class lsgh(Macro):
     def run(self): 
         try:
             general_hooks = self.getEnv("_GeneralHooks")
-            default_dict = {'pre-scan': [],
-                            'pre-move': [],
-                            'pre-acq': [],
-                            'post-acq': [],
-                            'post-move': [],
-                            'post-step': [],
-                            'post-scan': []}
+            
             out = List(['Hook place', 'Hook(s)'])
+            default_dict = {}
             for hook in general_hooks:
                 name = hook[0]
                 places = hook[1]
                 for place in places:
-                    default_dict[place].append(name)
+                    if place not in default_dict.keys():
+                        default_dict[place] = []
+                    if name not in default_dict[place]:
+                        default_dict[place].append(name)
             for pos in default_dict.keys():
                 pos_set = 0
                 for hook in default_dict[pos]:
@@ -333,24 +331,25 @@ class defgh(Macro):
     
     param_def = [
         ['macro_name', Type.String, None, 'Macro name with parameters. Ex.: "mv exp_dmy01 10"'],
-        ['hook_pos', Type.String, None, 'Position or positions where the hook has to be executed. Ex.: "pre-scan", several positions "pre-scan,post-scan"'],
+        ['hookpos_list',
+         ParamRepeat(['position', Type.String, None, 'macro name'], min=1),
+         None, 'List of positions where the hook has to be executed'],
     ]
     
-    def run(self, macro_name, hook_pos):
+    def run(self, macro_name, position):
         
         self.info("Defining general hook")
+        self.output(macro_name)
+        self.output(type(position))
         try:
             macros_list = self.getEnv("_GeneralHooks")
         except:
             macros_list = []
             
-        positions_split = hook_pos.split(",")
-        positions = []
-        for pos in positions_split:
-            positions.append(pos)
-        hook_tuple = (macro_name, positions)
+        hook_tuple = (macro_name, position)
         self.debug(hook_tuple)
         macros_list.append(hook_tuple)
+        self.output("set gh")
         self.setEnv("_GeneralHooks", macros_list)
         self.debug("General hooks:")
         self.debug(macros_list)

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1109,7 +1109,9 @@ class MacroExecutor(Logger):
         init_opts['macro_line'] = macro_line
 
         macro_obj, prepare_result = self.prepareMacroObj(meta_macro,
-            macro_params, init_opts, prepare_opts)
+                                                         macro_params,
+                                                         init_opts,
+                                                         prepare_opts)
 
         self._prepareGeneralHooks(macro_obj)
 

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -876,8 +876,19 @@ class MacroExecutor(Logger):
         return self.macro_server.macro_manager
 
     def getGeneralHooks(self):
-        # TODO: general hooks should reflect the state of configuration
-        # at the macro/sequence start
+        """Get data structure containing definition of the general hooks.
+
+        .. note::
+        The `general_hooks` has been included in Sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including its removal) may occur if
+        deemed necessary by the core developers.
+
+        .. todo::
+        General hooks should reflect the state of configuration at the
+        macro/sequence start.
+        """
+
         try:
             return self.door.get_env("_GeneralHooks")["_GeneralHooks"]
         except KeyError:

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -878,7 +878,7 @@ class MacroExecutor(Logger):
         # TODO: general hooks should reflect the state of configuration
         # at the macro/sequence start
         try:
-            return self.door.get_env("GeneralHooks")["GeneralHooks"]
+            return self.door.get_env("_GeneralHooks")["_GeneralHooks"]
         except KeyError:
             return []
 

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1109,7 +1109,9 @@ class MacroExecutor(Logger):
         macro_id = init_opts.get("id")
         if macro_id is None:
             init_opts["id"] = macro_id
-        macro_line = self._composeMacroLine(macro_name, macro_params, macro_id)
+        macro_line = self._composeMacroLine(macro_name,
+                                            macro_params,
+                                            macro_id)
 
         init_opts['macro_line'] = macro_line
 

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1108,8 +1108,8 @@ class MacroExecutor(Logger):
 
         init_opts['macro_line'] = macro_line
 
-        macro_obj, prepare_result = self.prepareMacroObj(meta_macro, macro_params,
-                                                         init_opts, prepare_opts)
+        macro_obj, prepare_result = self.prepareMacroObj(meta_macro,
+            macro_params, init_opts, prepare_opts)
 
         self._prepareGeneralHooks(macro_obj)
 

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -873,6 +873,16 @@ class MacroExecutor(Logger):
     def macro_manager(self):
         return self.macro_server.macro_manager
 
+    def getGeneralHooks(self):
+        # TODO: general hooks should reflect the state of configuration
+        # at the macro/sequence start
+        try:
+            return self.door.get_env("GeneralHooks")["GeneralHooks"]
+        except KeyError:
+            return []
+
+    general_hooks = property(getGeneralHooks)
+
     def getNewMacroID(self):
         self._macro_counter -= 1
         return self._macro_counter

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -985,6 +985,9 @@ class MacroExecutor(Logger):
         }
 
         macro_obj = self._createMacroObj(macro_meta, macro_params, init_opts)
+
+        self._prepareGeneralHooks(macro_obj)
+
         for macro in xml_macro.findall('macro'):
             hook = MacroExecutor.RunSubXMLHook(self, macro)
             hook_hints = macro.findall('hookPlace')
@@ -993,6 +996,7 @@ class MacroExecutor(Logger):
             else:
                 hook_places = [h.text for h in hook_hints]
                 macro_obj.hooks = [(hook, hook_places)]
+
         prepare_result = self._prepareMacroObj(macro_obj, macro_params)
         return macro_obj, prepare_result
 
@@ -1104,8 +1108,12 @@ class MacroExecutor(Logger):
 
         init_opts['macro_line'] = macro_line
 
-        return self.prepareMacroObj(meta_macro, macro_params, init_opts,
-                                    prepare_opts)
+        macro_obj, prepare_result = self.prepareMacroObj(meta_macro, macro_params,
+                                                         init_opts, prepare_opts)
+
+        self._prepareGeneralHooks(macro_obj)
+
+        return macro_obj, prepare_result
 
     def getRunningMacro(self):
         return self._macro_pointer


### PR DESCRIPTION
This PR is for development of the GeneralHooks feature as requested in #200.

TODOs:

- [x] Report and fix bug in Hookable.hooks.set (now it only resets the list with hooks and not the dictionary with hints) - @reszelaz
- [x] Before appending a hook to the macro object it would be nice to verify if this macro support a given hook place. This could be consulted with the `Hookable.getAllowedHookHints` method - @teresanunez 
- [x] Agree and implement the commodity macros e.g. `lsgenhook`, `addgenhook`, etc. - @teresanunez 
- [x] Test other use cases e.g. scan macros and hook macros with parameters - @teresanunez 
- [x] Fix setting of GeneralHooks environment in generalHooks.py testing module - @teresanunez 

Open questions:

- [x] Agree on GeneralHooks environment variable syntax (see #200 for discussion) - now it uses the programmatic API e.g. `senv GeneralHooks "[('MyHook1', ['my-hook-place'])]"`?
- [x] Extract GeneralHooks configuration at the very start of the macro/sequence execution (this may be a more general issue)?
- [x] Agree on what to do in case of an error during the general hook execution? Currently an error during the normal hook execution aborts the scan macro.
- [x] Add support to callables?
 
For testing I use this https://github.com/reszelaz/generalHooks. Ideally this should be converted into tests...

Fixes #200