### PR TITLE
Force the writing of the file on the disk.

### DIFF
--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -222,6 +222,7 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
         self._createPreScanSnapshot(env)
 
         self.fd.flush()
+        os.fsync(self.fd.fileno())
 
     def _compression(self, shape, compfilter='gzip'):
         """
@@ -303,6 +304,7 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
             else:
                 self.debug('missing data for label %r', dd.label)
         self.fd.flush()
+        os.fsync(self.fd.fileno())
 
     def _endRecordList(self, recordlist):
 

--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -222,7 +222,6 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
         self._createPreScanSnapshot(env)
 
         self.fd.flush()
-        os.fsync(self.fd.fileno())
 
     def _compression(self, shape, compfilter='gzip'):
         """
@@ -304,7 +303,6 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
             else:
                 self.debug('missing data for label %r', dd.label)
         self.fd.flush()
-        os.fsync(self.fd.fileno())
 
     def _endRecordList(self, recordlist):
 

--- a/src/sardana/macroserver/recorders/storage.py
+++ b/src/sardana/macroserver/recorders/storage.py
@@ -169,6 +169,7 @@ class FIO_FileRecorder(BaseFileRecorder):
         self.fd.write(outLine)
 
         self.fd.flush()
+        os.fsync(self.fd.fileno())
 
     def _writeRecord(self, record):
         if self.filename is None:
@@ -187,6 +188,7 @@ class FIO_FileRecorder(BaseFileRecorder):
 
         fd.write(outstr)
         fd.flush()
+        os.fsync(self.fd.fileno())
 
         if len(self.mcaNames) > 0:
             self._writeMcaFile(record)
@@ -387,6 +389,7 @@ class SPEC_FileRecorder(BaseFileRecorder):
         self.fd = open(self.filename, 'a')
         self.fd.write(header % data)
         self.fd.flush()
+        os.fsync(self.fd.fileno())
 
     def _prepareMultiLines(self, character, sep, items_list):
         '''Translate list of lists of items into multiple line string
@@ -476,6 +479,7 @@ class SPEC_FileRecorder(BaseFileRecorder):
         fd.write(outstr)
 
         fd.flush()
+        os.fsync(self.fd.fileno())
 
     def _endRecordList(self, recordlist):
         if self.filename is None:
@@ -650,6 +654,7 @@ class NXscan_FileRecorder(BaseNAPI_FileRecorder):
         self._createPreScanSnapshot(env)
 
         self.fd.flush()
+        os.fsync(self.fd.fileno())
 
     def _createPreScanSnapshot(self, env):
         # write the pre-scan snapshot in the
@@ -722,6 +727,7 @@ class NXscan_FileRecorder(BaseNAPI_FileRecorder):
             else:
                 debug("missing data for label '%s'", dd.label)
         fd.flush()
+        os.fsync(self.fd.fileno())
 
     def _endRecordList(self, recordlist):
 

--- a/src/sardana/macroserver/recorders/storage.py
+++ b/src/sardana/macroserver/recorders/storage.py
@@ -654,7 +654,6 @@ class NXscan_FileRecorder(BaseNAPI_FileRecorder):
         self._createPreScanSnapshot(env)
 
         self.fd.flush()
-        os.fsync(self.fd.fileno())
 
     def _createPreScanSnapshot(self, env):
         # write the pre-scan snapshot in the
@@ -727,7 +726,6 @@ class NXscan_FileRecorder(BaseNAPI_FileRecorder):
             else:
                 debug("missing data for label '%s'", dd.label)
         fd.flush()
-        os.fsync(self.fd.fileno())
 
     def _endRecordList(self, recordlist):
 


### PR DESCRIPTION
The scientists have reported a delay between acquisition and the data available in SPEC file. The data is saved on folder which are mounted on NFS. The Pool and the MacroServer are running on a industrial PC and the spock and PyMCA on a workstation.  

PyMca refresh button the points data of the file is not updated correctly while the scan is writing the data. if we  run a 'watch tail -1 scanfile.dat' on the industrial PC, we can see how the scan file is written at each scan point.

Initially we tried to replicate the problem with bash:
```
while true; do date && sleep 1 ; done >file.txt
```
...but this worked fine (delay <3 seconds). We could do "tail -f file.txt" from a separate PC and it was refreshing properly. So we figured the problem was something that could be seen from the python code:
```
#!/usr/bin/env python

import time
import os

file = '/beamlines/bl22/controls/tmp/test.txt'

if _name=='main_':
    with open(file, 'w') as f:
        for i in range (1000):
           f.write('{0}\n'.format(time.time()))
           print 'sleeping'
           f.flush()
           os.fsync(f.fileno())
           time.sleep(1)
```
Without the call to os.fsync, the buffer is not written to disk (NFS in this case) and the client running on a separate machine does not see the new data. Even with this code there is a delay of 3 seconds caused by NFS cache semantics, but this is well withing tolerable limits for the user.

We later did a similar test directly using the sardana code and the proposed fix indeed solves the problem and PyMCA refreshes the data immediately.

Finally, here are some interesting links with miscellaneous info about the problem of buffering when writing data in python along with the subtleties of file buffering at glibc and OS levels:

https://stackoverflow.com/questions/7127075/what-exactly-the-pythons-file-flush-is-doing

https://blog.gocept.com/2013/07/15/reliable-file-updates-with-python/

https://stackoverflow.com/questions/9824806/how-come-a-file-doesnt-get-written-until-i-stop-the-program

https://docs.python.org/2/library/os.html  (check os.fsync)