### PR TITLE
Eliminate ElementList Door attribute

### DIFF
--- a/src/sardana/tango/macroserver/Door.py
+++ b/src/sardana/tango/macroserver/Door.py
@@ -325,11 +325,6 @@ class Door(SardanaDevice):
         value = attr.get_write_value()
         self.door.get_input_handler().input_received(value)
 
-    #@DebugIt()
-    def read_ElementList(self, attr):
-        element_list = self.macro_server_device.getElementList()
-        attr.set_value(*element_list)
-
     def sendRecordData(self, format, data):
         self.push_change_event('RecordData', format, data)
 
@@ -519,8 +514,4 @@ class DoorClass(SardanaDeviceClass):
                        {'label': 'Record Data', }],
         'MacroStatus': [[DevEncoded, SCALAR, READ],
                         {'label': 'Macro Status', }],
-        'ElementList': [[DevEncoded, SCALAR, READ],
-                        {'label': "Element list",
-                            'description': 'the list of all elements (a '
-                            'JSON encoded dict)', }],
     }


### PR DESCRIPTION
The Elements attributes are foreseen for exposing all elements
to the clients in form of encoded stream of data

e.g. Pool's elements, MacroServer elements.

Eliminate ElementList Door attribute since it is accessible from
the MacroServer.