### PR TITLE
Workaround for bug #427 - default values of repeat parameters

### DIFF
--- a/src/sardana/macroserver/macros/lists.py
+++ b/src/sardana/macroserver/macros/lists.py
@@ -45,6 +45,8 @@ Left, Right, HCenter = Alignment.Left, Alignment.Right, Alignment.HCenter
 
 
 class _ls(Macro):
+    # TODO: duplication of the default value definition is a workaround
+    # for #427. See commit message cc3331a for more details.
     param_def = [
         ['filter',
          ParamRepeat(['filter', Type.String, ".*",

--- a/src/sardana/macroserver/macros/lists.py
+++ b/src/sardana/macroserver/macros/lists.py
@@ -47,9 +47,9 @@ Left, Right, HCenter = Alignment.Left, Alignment.Right, Alignment.HCenter
 class _ls(Macro):
     param_def = [
         ['filter',
-         ParamRepeat(['filter', Type.String, '.*',
+         ParamRepeat(['filter', Type.String, ".*",
                       'a regular expression filter'], min=1),
-         '.*', 'a regular expression filter'],
+         [".*"], 'a regular expression filter'],
     ]
 
     def get_column_names(self):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -200,7 +200,7 @@ class wa(Macro):
         ['filter',
          ParamRepeat(['filter', Type.String, '.*',
                       'a regular expression filter'], min=1),
-         '.*', 'a regular expression filter'],
+         ['.*'], 'a regular expression filter'],
     ]
 
     def prepare(self, filter, **opts):
@@ -231,7 +231,7 @@ class pwa(Macro):
         ['filter',
          ParamRepeat(['filter', Type.String, '.*',
                       'a regular expression filter'], min=1),
-         '.*', 'a regular expression filter'],
+         ['.*'], 'a regular expression filter'],
     ]
 
     def run(self, filter):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -196,6 +196,8 @@ class wu(Macro):
 class wa(Macro):
     """Show all motor positions"""
 
+    # TODO: duplication of the default value definition is a workaround
+    # for #427. See commit message cc3331a for more details.
     param_def = [
         ['filter',
          ParamRepeat(['filter', Type.String, '.*',
@@ -227,6 +229,8 @@ class wa(Macro):
 class pwa(Macro):
     """Show all motor positions in a pretty table"""
 
+    # TODO: duplication of the default value definition is a workaround
+    # for #427. See commit message cc3331a for more details.
     param_def = [
         ['filter',
          ParamRepeat(['filter', Type.String, '.*',


### PR DESCRIPTION
It is not well defined how to use default values of repeat parameters.
Now there exist two possibilities of definition: either on the repeat
parameter level or on the member level. For repeat parameters of only
one member defining the default value on the member level is not enough
cause the execution of the macro with the Macro.execMacro call fails.
The failure is related with the ParamDecoder.decodeRepeat implementation.
Duplicating the default value on the repeat parameter level workarounds
this. Apply this workaround until #427 is properly fixed.