### PR TITLE
Properly clean hooks information when setting hooks property

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -237,6 +237,8 @@ class Hookable(Logger):
                     self.info(
                         'Deprecation warning: hooks should be set with a list of hints. See Hookable API docs')
 
+            # delete _hookHintsDict to force its recreation on the next access
+            del self._hookHintsDict
             # create _hookHintsDict
             self._getHookHintsDict()['_ALL_'] = zip(*self._hooks)[0]
             nohints = self._hookHintsDict['_NOHINTS_']


### PR DESCRIPTION
Setting hooks property only partially cleans the internal data structures
containing information about hooks. Apart of cleaning the _hooks structure
also clean the _hookHintsDict