### PR TITLE
Avoid exceptions in spock and widgets when MS is down

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -570,7 +570,14 @@ class BaseDoor(MacroServerDevice):
         return result
 
     def stateChanged(self, s, t, v):
-        self._old_door_state = self.getState()
+        # In contrary to the Taurus3 the Taurus4 raises exceptions when the
+        # device server is getting down and we try to retrieve the state.
+        # In this case provide the same behavior as Taurus3 - assign None to
+        # the old state
+        try:
+            self._old_door_state = self.getState()
+        except PyTango.DevFailed:
+            self._old_door_state = None
         try:
             self._old_sw_door_state = self.getSWState()
         except:


### PR DESCRIPTION
Taurus3 used to return None for the getState query when the device server
was down. Taurus4 raises exceptions which are currently not handled.
In this case provide the same behavior as Taurus3 - assign None to the old
state.

This exceptions appear in spock or any macroserver related widget e.g. macrobutton.