### PR TITLE
Add text Run/Abort in macrobutton

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -214,7 +214,7 @@ class MacroButton(TaurusWidget):
         '''same as :meth:`setText`
         '''
         # SHOULD ALSO BE POSSIBLE TO SET AN ICON
-        self.ui.button.setText(text)
+        self.ui.button.setText("Run/Abort:\n" + text)
 
     def setMacroName(self, name):
         '''set the name of the macro to be executed


### PR DESCRIPTION
Add text Run/Abort before the name of the macro in macrobutton,
in order to better descrive its behavior.