### PR TITLE
Missing  value of the total_scan_intervals. 

### DIFF
--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -314,7 +314,7 @@ class aNscan(Hookable):
 
     def getIntervalEstimation(self):
         mode = self.mode
-        if mode == StepMode:
+        if mode in [StepMode, ContinuousHwTimeMode, HybridMode]:
             return self.nr_interv
         elif mode == ContinuousMode:
             return self.nr_waypoints


### PR DESCRIPTION
The total_scan_intervals key of the ScanDataEnvironment, does not have value for all aNscan types. 