### PR TITLE
[WIP] Adapt Sardana to use Taurus 4 compatible names (URI with FQDN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ This file follows the formats and conventions from [keepachangelog.com]
   `Macro.execMacro` (#654)
 
 ### Changed
+- Internally use URI (FQDN) references to be fully compatible with Taurus4
 - Rename edctrl to edctrlcls macro (#541)
 - The way how the master timer/monitor for the acquisition actions is selected.
   Previously the first one for the given synchronization was used, now it is


### PR DESCRIPTION
This PR aims to adapt Sardana to internally use the Taurus 4 compatible names (URI and FQDN). When designing the solution we will assume that:
- Client and Server sides use the same Sardana version
- Backwards compatibility will be maintained but only in one direction i.e. rollbacks will not be supported

The following parts of the code will require changes:

- [x] elements full names (Pool and most probably the MacroServer) containers
- [x] measurement group configuration attribute (controllers and elements names)
- [x] measurement group moveable and moveables attribute (moveables will be introduced after re-reverting #590)
- [x] Sardana model names in taurusgui XML configuration
- [x] all custom modifications for Taurus3 and Taurus4 compatibility
- [x] door and macroserver model names in spock profile files

Fixes issues: #667, #315, #500, ...