### PR TITLE
Use old Ubuntu image for travis-ci to fix build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+group: deprecated-2017Q4
+
 language: python
 
 sudo: required


### PR DESCRIPTION
Travis builds started to fail from the Ubuntu Trusty roll-out
from 12.12.2017. Use the old image. More info in:
https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch

Another PR will be open to investigate where exactly is the problem.
From the logs we can see that neither Pool nor MacroServer can be started on docker:
```
$ if [ $TEST == "testsuite" ]; then docker exec sardana-test supervisorctl start Pool; fi
Pool: ERROR (abnormal termination)
$ if [ $TEST == "testsuite" ]; then docker exec sardana-test supervisorctl start MacroServer; fi
MacroServer: ERROR (abnormal termination)
```