### PR TITLE
Synchronization Parameters

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2114,13 +2114,23 @@ class CTScan(CScan, CAcquisition):
             initial_position = start
             total_time = abs(total_position) / path.max_vel
             delay_time = path.max_vel_time
-            synch = [{SynchParam.Delay: {SynchDomain.Time: delay_time},
-                      SynchParam.Initial: {SynchDomain.Position: initial_position},
-                      SynchParam.Active: {SynchDomain.Position: active_position,
-                                          SynchDomain.Time: active_time},
-                      SynchParam.Total: {SynchDomain.Position: total_position,
-                                         SynchDomain.Time: total_time},
-                      SynchParam.Repeats: repeats}]
+
+            # Prepare the list of moveables full names
+            sync_moveable = []
+            for m in moveables:
+                sync_moveable.append(m.full_name)
+
+            synch = [
+                {SynchParam.Delay: {SynchDomain.Time: delay_time},
+                 SynchParam.Initial: {SynchDomain.Position: initial_position},
+                 SynchParam.Active: {SynchDomain.Position: active_position,
+                                     SynchDomain.Time: active_time},
+                 SynchParam.Total: {SynchDomain.Position: total_position,
+                                    SynchDomain.Time: total_time},
+                 SynchParam.Repeats: repeats,
+                 SynchParam.Master: {SynchDomain.Position: MASTER},
+                 SynchParam.Moveables: {SynchDomain.Position: sync_moveable}}]
+
             self.debug('Synchronization: %s' % synch)
             measurement_group.setSynchronization(synch)
             self.macro.checkPoint()

--- a/src/sardana/pool/pooldefs.py
+++ b/src/sardana/pool/pooldefs.py
@@ -108,6 +108,8 @@ class SynchParam(SynchEnum):
     Active = 2
     Repeats = 3
     Initial = 4
+    Moveables = 5
+    Master = 6
 
 # TODO: convert to to python enums, but having in ming problems with
 # JSON serialization: https://bugs.python.org/issue18264

--- a/src/sardana/pool/pooldefs.py
+++ b/src/sardana/pool/pooldefs.py
@@ -68,7 +68,8 @@ class SynchDomain(SynchEnum):
 
     - Time - describes the synchronization in time domain
     - Position - describes the synchronization in position domain
-    - Monitor - not used at the moment but foreseen for synchronization on monitor
+    - Monitor - not used at the moment but foreseen for synchronization on
+                monitor
 
     .. note::
         The SynchDomain class has been included in Sardana
@@ -81,7 +82,8 @@ class SynchDomain(SynchEnum):
     Monitor = 2
 #     - Default - the controller selects the most appropriate domain:
 #       for active events the precedence should be first Position and then Time
-#       for passive events the precedence should be first Time and then Position
+#       for passive events the precedence should be first Time and then
+#       Position
 #    Default = 3
 
 
@@ -113,6 +115,7 @@ class SynchParam(SynchEnum):
 #
 #     Trigger = 0
 #     Gate = 1
+
 
 AcqSynchType = Enumeration("AcqSynchType", ["Trigger", "Gate"])
 

--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -155,19 +155,24 @@ class MeasurementGroup(PoolGroupDevice):
         '''Translates synchronization data structure so it uses SynchDomain
         enums as keys instead of strings.
         '''
+
+        new_synchronization = []
         for group in synchronization:
+            new_group = {}
             for param, conf in group.iteritems():
-                group.pop(param)
                 param = SynchParam.fromStr(param)
-                group[param] = conf
-                # skip repeats cause its value is just a long number
                 if param == SynchParam.Repeats:
-                    continue
-                for domain, value in conf.iteritems():
-                    conf.pop(domain)
-                    domain = SynchDomain.fromStr(domain)
-                    conf[domain] = value
-        return synchronization
+                    new_group[param] = conf
+                else:
+                    new_conf = {}
+                    for domain, value in conf.iteritems():
+                        domain = SynchDomain.fromStr(domain)
+                        if param == SynchParam.Moveables:
+                            value = list(value)
+                        new_conf[domain] = value
+                    new_group[param] = dict(new_conf)
+            new_synchronization.append(dict(new_group))
+        return new_synchronization
 
     def always_executed_hook(self):
         pass

--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -82,7 +82,7 @@ class MeasurementGroup(PoolGroupDevice):
         for i in range(len(self.Elements)):
             try:
                 self.Elements[i] = int(self.Elements[i])
-            except:
+            except Exception:
                 pass
         mg = self.measurement_group
         if mg is None:
@@ -90,26 +90,29 @@ class MeasurementGroup(PoolGroupDevice):
             name = self.alias or full_name
             self.measurement_group = mg = \
                 self.pool.create_measurement_group(name=name,
-                                                   full_name=full_name, id=self.Id,
+                                                   full_name=full_name,
+                                                   id=self.Id,
                                                    user_elements=self.Elements)
         mg.add_listener(self.on_measurement_group_changed)
 
         # force a state read to initialize the state attribute
-        #state = self.measurement_group.state
+        # state = self.measurement_group.state
         self.set_state(DevState.ON)
 
-    def on_measurement_group_changed(self, event_source, event_type, event_value):
+    def on_measurement_group_changed(self, event_source, event_type,
+                                     event_value):
         try:
             self._on_measurement_group_changed(
                 event_source, event_type, event_value)
-        except:
+        except Exception:
             msg = 'Error occured "on_measurement_group_changed(%s.%s): %s"'
             exc_info = sys.exc_info()
             self.error(msg, self.measurement_group.name, event_type.name,
                        exception_str(*exc_info[:2]))
             self.debug("Details", exc_info=exc_info)
 
-    def _on_measurement_group_changed(self, event_source, event_type, event_value):
+    def _on_measurement_group_changed(self, event_source, event_type,
+                                      event_value):
         # during server startup and shutdown avoid processing element
         # creation events
         if SardanaServer.server_state != State.Running:
@@ -168,7 +171,7 @@ class MeasurementGroup(PoolGroupDevice):
 
     def always_executed_hook(self):
         pass
-        #state = to_tango_state(self.motor_group.get_state(cache=False))
+        # state = to_tango_state(self.motor_group.get_state(cache=False))
 
     def read_attr_hardware(self, data):
         pass
@@ -255,7 +258,7 @@ class MeasurementGroup(PoolGroupDevice):
     def Start(self):
         try:
             self.wait_for_operation()
-        except:
+        except Exception:
             raise Exception("Cannot acquire: already involved in an operation")
         self.measurement_group.start_acquisition()
 
@@ -265,7 +268,7 @@ class MeasurementGroup(PoolGroupDevice):
     def StartMultiple(self, n):
         try:
             self.wait_for_operation()
-        except:
+        except Exception:
             raise Exception("Cannot acquire: already involved in an operation")
         self.measurement_group.start_acquisition(multiple=n)
 


### PR DESCRIPTION
The IcePAP and the Pmac controllers allow to reuse the same output pin to generate trigger according any register of their motors. For that reason a general trigger controller for these hardware need to know which motor is using on the acquisition to configure the proper register to generate the triggers. 

On the other hand, IMHO the synchronization object should have the information for the Position Domain for all motors involved on the acquisition, the current implementation generates the information using the master motor (the first one). For a hardware trigger generator which uses Position Domain, this implementation can produce wrong behaviors (and results) if the motor which is configured is not the first one, and to debug the problem could be difficult.  