### PR TITLE
Fix MacroServer creation when there are no Pools in database

### DIFF
--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -675,7 +675,7 @@ def prepare_server(args, tango_args):
                 for i in pools:
                     pools_for_choosing.append(pools[i][3])
                 pools_for_choosing = sorted(pools_for_choosing,
-                                      key=lambda s: s.lower())
+                                            key=lambda s: s.lower())
                 no_pool_msg = ("\nMacroServer %s has not been connected to "
                                "any Pool\n" % inst_name)
                 if len(pools_for_choosing) == 0:

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -674,32 +674,35 @@ def prepare_server(args, tango_args):
                 pools_for_choosing = []
                 for i in pools:
                     pools_for_choosing.append(pools[i][3])
-                    sorted_pools = sorted(pools_for_choosing,
-                                          key=lambda s: s.lower())
-                c = 1
-                while True:
-                    if c == 1:
-                        print("\nAvailable Pools:")
-                        for pool in sorted_pools:
-                            print pool
-                        print("")
-                    msg = "Please select the Pool to connect to " \
-                          "(return to finish): "
-                    elem = raw_input(msg).strip()
-                    if not len(elem) and not pool_names:
-                        print("\nMacroServer %s has not been connected to any "
-                              "Pool\n" % inst_name)
-                        break
-                    elif not len(elem):
-                        print("\nMacroServer %s has been connected to "
-                              "Pool/s %s\n" % (inst_name, pool_names))
-                        break
-                    if elem.lower() not in all_pools:
-                        print "Unknown pool element"
-                    else:
-                        c += 1
-                        pool_names.append(elem)
-
+                pools_for_choosing = sorted(pools_for_choosing,
+                                      key=lambda s: s.lower())
+                no_pool_msg = ("\nMacroServer %s has not been connected to "
+                               "any Pool\n" % inst_name)
+                if len(pools_for_choosing) == 0:
+                    print(no_pool_msg)
+                else:
+                    print("\nAvailable Pools:")
+                    for pool in pools_for_choosing:
+                        print pool
+                    print("")
+                    while True:
+                        msg = "Please select the Pool to connect to " \
+                              "(return to finish): "
+                        elem = raw_input(msg).strip()
+                        # no pools selected and user ended loop
+                        if len(elem) == 0 and len(pool_names) == 0:
+                            print(no_pool_msg)
+                            break
+                        # user ended loop with some pools selected
+                        elif len(elem) == 0:
+                            print("\nMacroServer %s has been connected to "
+                                  "Pool/s %s\n" % (inst_name, pool_names))
+                            break
+                        # user entered unknown pool
+                        elif elem.lower() not in all_pools:
+                            print "Unknown pool element"
+                        else:
+                            pool_names.append(elem)
                 log_messages += register_sardana(db, server_name, inst_name,
                                                  pool_names)
             else:


### PR DESCRIPTION
The following error is raised when trying to create a MacroServer instance and the database does not contain any Pools:

```
root@taurus-test:/sardana# ~/.local/bin/MacroServer test
test does not exist. Do you wish to create a new one (Y/n) ? Y

Available Pools:
Traceback (most recent call last):
  File "/root/.local/bin/MacroServer", line 11, in <module>
    load_entry_point('sardana', 'console_scripts', 'MacroServer')()
  File "/sardana/src/sardana/tango/macroserver/__init__.py", line 68, in main
    run(start_time=datetime.datetime.now())
  File "/sardana/src/sardana/tango/macroserver/__init__.py", line 61, in main_macroserver
    name=SERVER_NAME)
  File "/sardana/src/sardana/tango/core/util.py", line 1058, in run
    log_messages.extend(prepare_server(args, tango_args))
  File "/sardana/src/sardana/tango/core/util.py", line 683, in prepare_server
    for pool in sorted_pools:
UnboundLocalError: local variable 'sorted_pools' referenced before assignment
```

Tested with [taurus-test](https://hub.docker.com/r/cpascual/taurus-test/) docker image.

Fix it.