### PR TITLE
Make MacroStatus read return the last macro status

### DIFF
--- a/src/sardana/tango/macroserver/Door.py
+++ b/src/sardana/tango/macroserver/Door.py
@@ -350,7 +350,10 @@ class Door(SardanaDevice):
         self.__buf_data = data
 
     def read_MacroStatus(self, attr):
-        attr.set_value('', '')
+        macro_status = self.door.macro_status
+        codec = CodecFactory().getCodec('json')
+        status = codec.encode(('', macro_status))
+        attr.set_value(*status)
 
     def Abort(self):
         self.debug("Abort is deprecated. Use StopMacro instead")


### PR DESCRIPTION
MacroStatus attribute of the Door returns an empty value. Make it return
a valid value - the last macro status update. If no macro was run yet it
returns `null`.