### PR TITLE
Avoid errors when acquiring with offline controller

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1140,9 +1140,9 @@ class TangoChannelInfo(BaseChannelInfo):
                 # For backwards compatibility:
                 # starting from Taurus 4.3.0 DevVoid was added to the dict
                 if data_type == PyTango.DevVoid:
-                     self.data_type = None
+                    self.data_type = None
                 else:
-                     raise e
+                    raise e
 
         if 'shape' not in data:
             shape = ()

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -46,6 +46,8 @@ import traceback
 import weakref
 import numpy
 
+import PyTango
+
 from PyTango import DevState, AttrDataFormat, AttrQuality, DevFailed, \
     DeviceProxy
 from taurus import Factory, Device, Attribute
@@ -1131,7 +1133,11 @@ class TangoChannelInfo(BaseChannelInfo):
         data = self.raw_data
 
         if 'data_type' not in data:
-            self.data_type = FROM_TANGO_TO_STR_TYPE[info.data_type]
+            data_type = info.data_type
+            if data_type == PyTango.DevVoid:
+                self.data_type = None
+            else:
+                self.data_type = FROM_TANGO_TO_STR_TYPE[data_type]
 
         if 'shape' not in data:
             shape = ()
@@ -1309,7 +1315,6 @@ class MGConfiguration(object):
                 tg_chs_info[channel_name] = dev_name, attr_name, attr_info
 
     def _build_empty_tango_attr_info(self, channel_data):
-        import PyTango
         ret = PyTango.AttributeInfoEx()
         ret.name = channel_data['name']
         ret.label = channel_data['label']

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1134,10 +1134,17 @@ class TangoChannelInfo(BaseChannelInfo):
 
         if 'data_type' not in data:
             data_type = info.data_type
-            if data_type == PyTango.DevVoid:
-                self.data_type = None
-            else:
+            try:
                 self.data_type = FROM_TANGO_TO_STR_TYPE[data_type]
+            except KeyError, e:
+                # For backwards compatibility:
+                # starting from Taurus 4.3.0 DevVoid was added to the dict
+                if data_type == PyTango.DevVoid:
+                     self.data_type = None
+                else:
+                     raise e
+            
+                
 
         if 'shape' not in data:
             shape = ()

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1143,8 +1143,6 @@ class TangoChannelInfo(BaseChannelInfo):
                      self.data_type = None
                 else:
                      raise e
-            
-                
 
         if 'shape' not in data:
             shape = ()


### PR DESCRIPTION
An experimental channels from an offline controller does not export its
attributes. Then, it is not possible to obtain the Value attribute
configuration and an empty AttributeInfoEx is created for it. Its default
data_type is set to DevVoid. Handle this case and consider the
TangoChannelInfo with an unknown data_type. This avoids errors.

A change was proposed to Taurus that would avoid this PR: https://github.com/taurus-org/taurus/pull/666.