### PR TITLE
Fix getData with aNscan macros

### DIFF
--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -213,6 +213,7 @@ class aNscan(Hookable):
                                 moveables, env, constrains, extrainfodesc)
         else:
             raise ValueError('invalid value for mode %s' % mode)
+        self._data = self._gScan.data
 
     def _stepGenerator(self):
         step = {}
@@ -288,10 +289,6 @@ class aNscan(Hookable):
     def run(self, *args):
         for step in self._gScan.step_scan():
             yield step
-
-    @property
-    def data(self):
-        return self._gScan.data
 
     def getTimeEstimation(self):
         gScan = self._gScan

--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -213,6 +213,12 @@ class aNscan(Hookable):
                                 moveables, env, constrains, extrainfodesc)
         else:
             raise ValueError('invalid value for mode %s' % mode)
+        # _data is the default member where the Macro class stores the data.
+        # Assign the date produced by GScan (or its subclasses) to it so all
+        # the Macro infrastrucutre related to the data works e.g. getter,
+        # property, etc. Ideally this should be done by the data setter
+        # but this is available in the Macro class and we inherit from it
+        # latter. More details in sardana-org/sardana#683.
         self._data = self._gScan.data
 
     def _stepGenerator(self):


### PR DESCRIPTION
The 'getData' method of a aNscan Macro does not return the data, raising the exception "Macro XXX does not produce any data" because the Macro class is returning the value of self._data.

In a aNscan macro the data is available in data @property -> self.data, this PR fix the problem on execute the 'getData' method returning the data.

