### PR TITLE
Fix macro hooks setter (broken in #655)

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -238,7 +238,8 @@ class Hookable(Logger):
                         'Deprecation warning: hooks should be set with a list of hints. See Hookable API docs')
 
             # delete _hookHintsDict to force its recreation on the next access
-            del self._hookHintsDict
+            if hasattr(self, '_hookHintsDict'):
+                del self._hookHintsDict
             # create _hookHintsDict
             self._getHookHintsDict()['_ALL_'] = zip(*self._hooks)[0]
             nohints = self._hookHintsDict['_NOHINTS_']


### PR DESCRIPTION
Pull request #655 breaks the hooks setter - if the hooks were never
set the _hookHintsDict was never initialized so it can not be deleted.
Protect the deletion by checking if the member exists.