### PR TITLE
Move index offset setting

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2238,6 +2238,9 @@ class CTScan(CScan, CAcquisition):
             measurement_group.setSynchronization(synch)
             self.macro.checkPoint()
 
+            # Set the index offset used in CAcquisition class.
+            self._index_offset = i * self.macro.nr_points
+
             # extra post configuration
             if hasattr(macro, 'getHooks'):
                 for hook in macro.getHooks('post-configuration'):
@@ -2301,7 +2304,6 @@ class CTScan(CScan, CAcquisition):
             theoretical_positions = generate_positions(motors, starts, finals,
                                                        nr_points)
             theoretical_timestamps = generate_timestamps(synch, dt_timestamp)
-            self._index_offset = i * self.macro.nr_points
             for index, data in theoretical_positions.items():
                 data.update(theoretical_timestamps[index])
                 initial_data[index + self._index_offset] = data

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2201,6 +2201,9 @@ class CTScan(CScan, CAcquisition):
                     msg = "Scan start and end must be different."
                 raise ScanException(msg)
 
+            # Set the index offset used in CAcquisition class.
+            self._index_offset = i * self.macro.nr_points
+
             startTimestamp = time.time()
 
             # extra pre configuration
@@ -2237,9 +2240,6 @@ class CTScan(CScan, CAcquisition):
             self.debug('Synchronization: %s' % synch)
             measurement_group.setSynchronization(synch)
             self.macro.checkPoint()
-
-            # Set the index offset used in CAcquisition class.
-            self._index_offset = i * self.macro.nr_points
 
             # extra post configuration
             if hasattr(macro, 'getHooks'):


### PR DESCRIPTION
Move the setting of _index_offset attribute before the post-configuration hook, to allow its changing if the nr_point changes between waypoints.