### PR TITLE
Logstash log handler

### DIFF
--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -917,7 +917,7 @@ def prepare_logstash(args):
     except ImportError:
         msg = "Unable to import logstash. Skipping logstash configuration..."
         log_messages.append(msg)
-        return
+        return log_messages
 
     def get_logstash_conf(dev_name):
         try:

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -955,6 +955,9 @@ def prepare_logstash(args):
         root = Logger.getRootLog()
         handler = logstash.TCPLogstashHandler(host, port, version=1)
         root.addHandler(handler)
+        msg = ("Log is being sent to logstash listening on %s:%d",
+               host, port)
+        log_messages.append(msg)
 
     return log_messages
 

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -912,11 +912,13 @@ def prepare_logstash(args):
         deemed necessary by the core developers.
     """
     log_messages = []
+
     try:
         import logstash
     except ImportError:
-        msg = "Unable to import logstash. Skipping logstash configuration..."
-        log_messages.append(msg)
+        msg = ("Unable to import logstash. Skipping logstash "
+               + "configuration...", )
+        log_messages.append(msg,)
         return log_messages
 
     def get_logstash_conf(dev_name):

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -937,9 +937,7 @@ def prepare_logstash(args):
 
     if host is not None:
         root = Logger.getRootLog()
-        fmt = Logger.getLogFormat()
         handler = logstash.TCPLogstashHandler(host, port, version=1)
-        handler.setFormatter(fmt)
         root.addHandler(handler)
 
     return log_messages

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -47,6 +47,7 @@ import string
 import logging
 import os.path
 import traceback
+import itertools
 
 import PyTango
 from PyTango import Util, Database, WAttribute, DbDevInfo, DevFailed, \
@@ -826,6 +827,22 @@ def get_dev_from_class(db, classname):
             out += " (running)"
         res[dev] = full_name, name, alias, out
     return res
+
+
+def get_dev_from_class_server(db, classname, server):
+    """Returns device(s) name for a given class and server"""
+
+    def pairwise(iterable):
+        "s -> (s0, s1), (s2, s3), (s4, s5), ..."
+        a = iter(iterable)
+        return itertools.izip(a, a)
+
+    devices = []
+    device_class_list = db.get_device_class_list(server)
+    for dev, cls in pairwise(device_class_list):
+        if cls == classname:
+            devices.append(dev)
+    return devices
 
 
 def get_free_server(db, prefix, start_from=1):

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -896,6 +896,12 @@ def prepare_logstash(args):
 
     :param args: process execution arguments
     :type args: list<str>
+
+    .. note::
+        The prepare_logstash function has been included in Sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including its removal) may occur if
+        deemed necessary by the core developers.
     """
     log_messages = []
     try:

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -384,11 +384,19 @@ class MacroServerClass(SardanaDeviceClass):
              DefaultLogReportFormat],
         'LogstashHost':
             [DevString,
-             "Hostname where Logstash runs",
+             "Hostname where Logstash runs. "
+             "This property has been included in Sardana on a provisional "
+             "basis. Backwards incompatible changes (up to and including "
+             "its removal) may occur if deemed necessary by the "
+             "core developers.",
              None],
         'LogstashPort':
             [DevLong,
-             "Port on which Logstash will listen on events",
+             "Port on which Logstash will listen on events. "
+             "This property has been included in Sardana on a provisional "
+             "basis. Backwards incompatible changes (up to and including "
+             "its removal) may occur if deemed necessary by the "
+             "core developers.",
              None]
     }
 

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -382,6 +382,14 @@ class MacroServerClass(SardanaDeviceClass):
             [DevString,
              "Log report format [default: '%s']" % DefaultLogReportFormat,
              DefaultLogReportFormat],
+        'LogstashHost':
+            [DevString,
+             "Hostname where Logstash runs",
+             None],
+        'LogstashPort':
+            [DevLong,
+             "Port on which Logstash will listen on events",
+             None]
     }
 
     #    Command definitions

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -1344,11 +1344,19 @@ class PoolClass(PyTango.DeviceClass):
              []],
         'LogstashHost':
             [PyTango.DevString,
-             "Hostname where Logstash runs",
+             "Hostname where Logstash runs. "
+             "This property has been included in Sardana on a provisional "
+             "basis. Backwards incompatible changes (up to and including "
+             "its removal) may occur if deemed necessary by the "
+             "core developers.",
              None],
         'LogstashPort':
             [PyTango.DevLong,
-             "Port on which Logstash will listen on events",
+             "Port on which Logstash will listen on events. "
+             "This property has been included in Sardana on a provisional "
+             "basis. Backwards incompatible changes (up to and including "
+             "its removal) may occur if deemed necessary by the "
+             "core developers.",
              None]
     }
 

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -1342,6 +1342,14 @@ class PoolClass(PyTango.DeviceClass):
             [PyTango.DevVarStringArray,
              "List of instruments (internal property)",
              []],
+        'LogstashHost':
+            [PyTango.DevString,
+             "Hostname where Logstash runs",
+             None],
+        'LogstashPort':
+            [PyTango.DevLong,
+             "Port on which Logstash will listen on events",
+             None]
     }
 
     #    Command definitions


### PR DESCRIPTION
The main purpose of this PR is to allow the use of [elastic stack](https://www.elastic.co/) for:
* logging analysis i.e. merging logs of Pool and MacroServer in a time ordered events
* extracting metrics from the logs about the system performace e.g. server restarts, macro errors, etc.

This PR adds a logging handler for pushing log events to the logstash. An alternative solution, well actually the recommended by elastic one, would be to use Beats. However Beats require a modern OS to run and we at ALBA are stuck with openSUSE 11.1 which does not support it. So, it adds an optional dependency to the [logstash](https://pypi.python.org/pypi/python-logstash/0.4.6) module.

Configuration is done via Tango properties (other soltutions e.g. sardanacustomsettings were also evaluated). Properties `LogstashHost` and `LogstashPort` are available on both Pool and MacroServer devices. In case a single Sardana server is in use, the Pool properties take precedence over the MacroServer properties.

Since this was not yet used in a real environments I decided to mark the new API as provisional just to make easier the eventual improvements.

Exemplary configuration of the elastic components can be found in https://github.com/reszelaz/sardana-elastic.

@sardana-org/integrators could anyone take a look on this?