### PR TITLE
Add protection for SW synchronizer

### DIFF
--- a/src/sardana/pool/poolsynchronization.py
+++ b/src/sardana/pool/poolsynchronization.py
@@ -66,6 +66,12 @@ class PoolSynchronization(PoolAction):
 
     def __init__(self, main_element, name="Synchronization"):
         PoolAction.__init__(self, main_element, name)
+        # Even if rest of Sardana is using "." in logger names use "-" as
+        # sepator. This is in order to avoid confusion about the logger
+        # hierary - by default python logging use "." to indicate loggers'
+        # hirarchy in case parent-children relation is established between the
+        # loggers.
+        # TODO: review if it is possible in Sardana to use a common separator.
         soft_synch_name = main_element.name + "-SoftSynch"
         self._synch_soft = FunctionGenerator(name=soft_synch_name)
         self._listener = None

--- a/src/sardana/pool/poolsynchronization.py
+++ b/src/sardana/pool/poolsynchronization.py
@@ -66,7 +66,8 @@ class PoolSynchronization(PoolAction):
 
     def __init__(self, main_element, name="Synchronization"):
         PoolAction.__init__(self, main_element, name)
-        self._synch_soft = FunctionGenerator()
+        soft_synch_name = main_element.name + "-SoftSynch"
+        self._synch_soft = FunctionGenerator(name=soft_synch_name)
         self._listener = None
 
     def add_listener(self, listener):

--- a/src/sardana/pool/test/fake.py
+++ b/src/sardana/pool/test/fake.py
@@ -89,8 +89,9 @@ class FakePool(object):
 class FakeElement(object):
     '''Fake pool element'''
 
-    def __init__(self, pool):
+    def __init__(self, pool, name="FakeElement"):
         self.pool = pool
+        self.name = name
 
     def on_element_changed(self, *args, **kwargs):
         pass

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -50,6 +50,7 @@ class FunctionGenerator(EventGenerator, Logger):
     def __init__(self, name="FunctionGenerator"):
         EventGenerator.__init__(self)
         Logger.__init__(self, name)
+        self._name = name
         self._initial_domain = None
         self._active_domain = None
         self._position_event = threading.Event()
@@ -64,6 +65,11 @@ class FunctionGenerator(EventGenerator, Logger):
         self._direction = None
         self._condition = None
         self._id = None
+
+    def get_name(self):
+        return self._name
+
+    name = property(get_name)
 
     def set_initial_domain(self, domain):
         self._initial_domain = domain

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -27,10 +27,10 @@ import math
 import copy
 import numpy
 
-
 from sardana import State
 from sardana.sardanaevent import EventGenerator, EventType
 from sardana.pool.pooldefs import SynchParam, SynchDomain
+from taurus.core.util.log import Logger
 
 
 class FunctionGenerator(EventGenerator):
@@ -62,6 +62,7 @@ class FunctionGenerator(EventGenerator):
         self._direction = None
         self._condition = None
         self._id = None
+        self.logger = Logger('FunctionGenerator')
 
     def set_initial_domain(self, domain):
         self._initial_domain = domain
@@ -135,8 +136,12 @@ class FunctionGenerator(EventGenerator):
 
     def event_received(self, *args, **kwargs):
         _, _, v = args
-        self._position = v.value
-        self._position_event.set()
+        if v.error:
+            self.logger.error("Synchronizer value could not be read")
+            self.logger.error(v.exc_info)
+        else:
+            self._position = v.value
+            self._position_event.set()
 
     def start(self):
         self._start_time = time.time()

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -136,7 +136,7 @@ class FunctionGenerator(EventGenerator):
 
     def event_received(self, *args, **kwargs):
         _, _, v = args
-        if v.in_error:
+        if v.error:
             self.logger.error("Synchronization base attribute is in error")
             self.logger.debug("Details: %s" % v.exc_info)
             return

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -26,6 +26,7 @@ import threading
 import math
 import copy
 import numpy
+import traceback
 
 from sardana import State
 from sardana.sardanaevent import EventGenerator, EventType
@@ -137,8 +138,10 @@ class FunctionGenerator(EventGenerator):
     def event_received(self, *args, **kwargs):
         _, _, v = args
         if v.error:
-            self.logger.error("Synchronization base attribute is in error")
-            self.logger.debug("Details: %s" % v.exc_info)
+            exc_info = v.exc_info
+            self.logger.error("Synchronization base attribute in error")
+            msg = "Details: " + "".join(traceback.format_exception(*exc_info))
+            self.logger.debug(msg)
             return
         self._position = v.value
         self._position_event.set()

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -46,7 +46,7 @@ class FunctionGenerator(EventGenerator):
 
     MAX_NAP_TIME = 0.1
 
-    def __init__(self):
+    def __init__(self, name="FunctionGenerator"):
         EventGenerator.__init__(self)
         self._initial_domain = None
         self._active_domain = None
@@ -62,7 +62,7 @@ class FunctionGenerator(EventGenerator):
         self._direction = None
         self._condition = None
         self._id = None
-        self.logger = Logger('FunctionGenerator')
+        self.logger = Logger(name)
 
     def set_initial_domain(self, domain):
         self._initial_domain = domain

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -34,7 +34,7 @@ from sardana.pool.pooldefs import SynchParam, SynchDomain
 from taurus.core.util.log import Logger
 
 
-class FunctionGenerator(EventGenerator):
+class FunctionGenerator(EventGenerator, Logger):
     """Generator of active and passive events describing a rectangular
     function.
 
@@ -49,6 +49,7 @@ class FunctionGenerator(EventGenerator):
 
     def __init__(self, name="FunctionGenerator"):
         EventGenerator.__init__(self)
+        Logger.__init__(self, name)
         self._initial_domain = None
         self._active_domain = None
         self._position_event = threading.Event()
@@ -63,7 +64,6 @@ class FunctionGenerator(EventGenerator):
         self._direction = None
         self._condition = None
         self._id = None
-        self.logger = Logger(name)
 
     def set_initial_domain(self, domain):
         self._initial_domain = domain
@@ -139,9 +139,9 @@ class FunctionGenerator(EventGenerator):
         _, _, v = args
         if v.error:
             exc_info = v.exc_info
-            self.logger.error("Synchronization base attribute in error")
+            self.error("Synchronization base attribute in error")
             msg = "Details: " + "".join(traceback.format_exception(*exc_info))
-            self.logger.debug(msg)
+            self.debug(msg)
             return
         self._position = v.value
         self._position_event.set()

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -136,12 +136,12 @@ class FunctionGenerator(EventGenerator):
 
     def event_received(self, *args, **kwargs):
         _, _, v = args
-        if v.error:
-            self.logger.error("Synchronizer value could not be read")
-            self.logger.error(v.exc_info)
-        else:
-            self._position = v.value
-            self._position_event.set()
+        if v.in_error:
+            self.logger.error("Synchronization base attribute is in error")
+            self.logger.debug("Details: %s" % v.exc_info)
+            return
+        self._position = v.value
+        self._position_event.set()
 
     def start(self):
         self._start_time = time.time()

--- a/src/sardana/util/test/test_funcgenerator.py
+++ b/src/sardana/util/test/test_funcgenerator.py
@@ -57,6 +57,7 @@ class Position(EventGenerator):
     def __init__(self):
         EventGenerator.__init__(self)
         self.value = None
+        self.error = False
 
     def run(self, start=0, end=2, step=0.01, sleep=0.01):
         for position in numpy.arange(start, end, step):


### PR DESCRIPTION
Add protection for software synchronizer for cases when the
motor controller ReadOne method fails. Log the errors in
the Pool logs, and continue the scan, given that may be
just a temporary unavailability of the motor's position.