### PR TITLE
Workaround issue 693 - avoid deadlocks when aborting a macro

### DIFF
--- a/src/sardana/tango/macroserver/Door.py
+++ b/src/sardana/tango/macroserver/Door.py
@@ -359,7 +359,6 @@ class Door(SardanaDevice):
     def AbortMacro(self):
         self.debug("Aborting")
         self.macro_executor.abort()
-        self.debug("Finished aborting")
 
     def is_Abort_allowed(self):
         return True

--- a/src/sardana/tango/macroserver/Door.py
+++ b/src/sardana/tango/macroserver/Door.py
@@ -357,7 +357,10 @@ class Door(SardanaDevice):
         return self.StopMacro()
 
     def AbortMacro(self):
-        self.debug("Aborting")
+        macro = self.getRunningMacro()
+        if macro is None:
+            return
+        self.debug("aborting %s" % macro._getDescription())
         self.macro_executor.abort()
 
     def is_Abort_allowed(self):
@@ -377,7 +380,7 @@ class Door(SardanaDevice):
         macro = self.getRunningMacro()
         if macro is None:
             return
-        self.debug("stopping macro %s" % macro._getDescription())
+        self.debug("stopping %s" % macro._getDescription())
         self.macro_executor.stop()
 
     def is_StopMacro_allowed(self):
@@ -389,7 +392,7 @@ class Door(SardanaDevice):
         macro = self.getRunningMacro()
         if macro is None:
             return
-        self.debug("resume macro %s" % macro._getDescription())
+        self.debug("resuming %s" % macro._getDescription())
         self.macro_executor.resume()
 
     def is_ResumeMacro_allowed(self):


### PR DESCRIPTION
This is a workaround for #693 that we will apply for Jan18 release instead of integrating #695 which has a side effect (probably due to a bug in Tango).