### PR TITLE
Add internal reference to keep subscribed attrs alive

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -338,14 +338,14 @@ class BaseDoor(MacroServerDevice):
                 attr.subscribeEvent(self.logReceived, log_name)
             self._log_attr[log_name] = attr
 
-        input_attr = self.getAttribute("Input")
-        input_attr.addListener(self.inputReceived)
+        self.__input_attr = self.getAttribute("Input")
+        self.__input_attr.addListener(self.inputReceived)
 
-        record_data_attr = self.getAttribute('RecordData')
-        record_data_attr.addListener(self.recordDataReceived)
+        self.__record_data_attr = self.getAttribute('RecordData')
+        self.__record_data_attr.addListener(self.recordDataReceived)
 
-        macro_status_attr = self.getAttribute('MacroStatus')
-        macro_status_attr.addListener(self.macroStatusReceived)
+        self.__macro_status_attr = self.getAttribute('MacroStatus')
+        self.__macro_status_attr.addListener(self.macroStatusReceived)
 
         self._experiment_configuration = ExperimentConfiguration(self)
 
@@ -784,15 +784,17 @@ class BaseMacroServer(MacroServerDevice):
         self._elements = BaseSardanaElementContainer()
         self.call__init__(MacroServerDevice, name, **kw)
 
-        attr = self.getAttribute("Elements")
-        attr.setSerializationMode(TaurusSerializationMode.Serial)
-        attr.addListener(self.on_elements_changed)
-        attr.setSerializationMode(TaurusSerializationMode.Concurrent)
+        self.__elems_attr = self.getAttribute("Elements")
+        self.__elems_attr.setSerializationMode(TaurusSerializationMode.Serial)
+        self.__elems_attr.addListener(self.on_elements_changed)
+        self.__elems_attr.setSerializationMode(
+            TaurusSerializationMode.Concurrent)
 
-        attr = self.getAttribute('Environment')
-        attr.setSerializationMode(TaurusSerializationMode.Serial)
-        attr.addListener(self.on_environment_changed)
-        attr.setSerializationMode(TaurusSerializationMode.Concurrent)
+        self.__env_attr = self.getAttribute('Environment')
+        self.__env_attr.setSerializationMode(TaurusSerializationMode.Serial)
+        self.__env_attr.addListener(self.on_environment_changed)
+        self.__env_attr.setSerializationMode(
+            TaurusSerializationMode.Concurrent)
 
     NO_CLASS_TYPES = 'ControllerClass', 'ControllerLibrary', \
                      'MacroLibrary', 'Instrument', 'Meta', 'ParameterType'

--- a/src/sardana/taurus/core/tango/sardana/motion.py
+++ b/src/sardana/taurus/core/tango/sardana/motion.py
@@ -346,7 +346,7 @@ class Motion(BaseMotion):
                  for moveable in self.moveable_list]
         return max(times)
 
-    def getTotalLastMotionTime():
+    def getTotalLastMotionTime(self):
         return self.__total_motion_time
 
     def startMove(self, pos_list, timeout=None):

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1511,8 +1511,8 @@ class MeasurementGroup(PoolElement):
         self._last_integ_time = None
         self.call__init__(PoolElement, name, **kw)
 
-        cfg_attr = self.getAttribute('configuration')
-        cfg_attr.addListener(self.on_configuration_changed)
+        self.__cfg_attr = self.getAttribute('configuration')
+        self.__cfg_attr.addListener(self.on_configuration_changed)
 
         self._value_buffer_cb = None
         self._codec = CodecFactory().getCodec("json")
@@ -1914,7 +1914,8 @@ class Pool(TangoDevice, MoveableSource):
         self.call__init__(MoveableSource)
 
         self._elements = BaseSardanaElementContainer()
-        self.getAttribute("Elements").addListener(self.on_elements_changed)
+        self.__elements_attr = self.getAttribute("Elements")
+        self.__elements_attr.addListener(self.on_elements_changed)
 
     def getObject(self, element_info):
         elem_type = element_info.getType()
@@ -1968,6 +1969,7 @@ class Pool(TangoDevice, MoveableSource):
             except:
                 self.warning("Failed to remove %s", element_data)
         for element_data in elems.get('change', ()):
+            # TODO: element is assigned but not used!! (check)
             element = self._removeElement(element_data)
             element = self._addElement(element_data)
         return elems

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -961,6 +961,8 @@ class TaurusSequencer(MacroExecutionWindow):
                 self._qDoor,
                 Qt.SIGNAL("macroStatusUpdated"),
                 self.taurusSequencerWidget.onMacroStatusUpdated)
+            self._qDoor = None
+
         if doorName == "":
             return
         self._qDoor = Device(doorName)


### PR DESCRIPTION
Sardana extensions wrongly expect attributes to be
alive even if no one keeps a ref to them.
After https://github.com/taurus-org/taurus/pull/692, this is no longer the case, and
sardana extensions must keep their own references.