### PR TITLE
spock commands not visible with bright background

### DIFF
--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -1063,6 +1063,9 @@ object?   -> Details about 'object'. ?object also works, ?? prints more.
     i_shell.confirm_exit = False
 
     if ipy_ver >= 50000:
+        # Change color for ipy_ver >= 50000 due to 
+        # https://github.com/ipython/ipython/pull/9655
+        i_shell.colors = 'Neutral'
         from IPython.terminal.prompts import (Prompts, Token)
 
         class SpockPrompts(Prompts):

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -1063,7 +1063,7 @@ object?   -> Details about 'object'. ?object also works, ?? prints more.
     i_shell.confirm_exit = False
 
     if ipy_ver >= 50000:
-        # Change color for ipy_ver >= 50000 due to 
+        # Change color for ipy_ver >= 50000 due to
         # https://github.com/ipython/ipython/pull/9655
         i_shell.colors = 'Neutral'
         from IPython.terminal.prompts import (Prompts, Token)


### PR DESCRIPTION
Using Spock with a bright background terminal themes commands are not visible
It seems related with an IPython V5  bug https://github.com/ipython/ipython/pull/9655

Change spock colors to  'Neutral' for IPython >= V5

Fix #706