### PR TITLE
Strip trailing slash from macro path

### DIFF
--- a/src/sardana/macroserver/macroserver.py
+++ b/src/sardana/macroserver/macroserver.py
@@ -207,7 +207,7 @@ class MacroServer(MSContainer, MSObject, SardanaElementManager, SardanaIDManager
         :type macro_path:
             seq<str>
         """
-        self.macro_manager.setMacroPath(macro_path)
+        self.macro_manager.setMacroPath([p.rstrip(os.sep) for p in macro_path])
 
     # --------------------------------------------------------------------------
     # Recorder path related methods


### PR DESCRIPTION
Since `edmac` can only work with paths without trailing slash, this modification will always strip trailing slashes (or other path separators, it uses `os.sep` for this) upon adding new macro path.

I wanted to check if `edctrlcls` and `edctrllib` also work that way, but encountered these problems:
```
Door_demo2_1 [2]: edctrlcls EpochZeroDController
An error occurred while running Macro 'edctrlcls(EpochZeroDController) -> 750e8aa2-2135-11e8-ba32-0800277db4d3':
'ControllerClass' object has no attribute 'file'

Door_demo2_1 [9]: edctrllib /home/daneos/controllers/EpochZeroDController.py
An error occurred while running Macro 'edctrllib(/home/daneos/controllers/EpochZeroDController.py) -> b375e2b2-2136-11e8-ba32-0800277db4d3':
'MacroServer' object has no attribute 'getPool'
```