### PR TITLE
Do not use os.path.join

### DIFF
--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -245,7 +245,7 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
         Write the pre-scan snapshot in "<entry>/measurement/pre_scan_snapshot".
         Also link to the snapshot datasets from the <entry>/measurement group
         """
-        _meas = self.fd[os.path.join(self.entryname, 'measurement')]
+        _meas = self.fd[(self.entryname + '/' + 'measurement')]
         self.preScanSnapShot = env.get('preScanSnapShot', [])
         _snap = _meas.create_group('pre_scan_snapshot')
         _snap.attrs['NX_class'] = 'NXcollection'

--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -245,7 +245,7 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
         Write the pre-scan snapshot in "<entry>/measurement/pre_scan_snapshot".
         Also link to the snapshot datasets from the <entry>/measurement group
         """
-        _meas = self.fd[(self.entryname + '/' + 'measurement')]
+        _meas = self.fd[(self.entryname + '/measurement')]
         self.preScanSnapShot = env.get('preScanSnapShot', [])
         _snap = _meas.create_group('pre_scan_snapshot')
         _snap.attrs['NX_class'] = 'NXcollection'


### PR DESCRIPTION
os.path.join is failing in windows for this case.
This was making the scans to abort when a h5 files was indicated as ScanFile.

Use the concatenation with plus signs instead.