### PR TITLE
Adding predefined values for string arguments

### DIFF
--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -638,6 +638,13 @@ def _macro_completer(self, event):
     ms = get_macro_server()
 
     macro_name = event.command.lstrip('%')
+
+    env = ms.getEnvironment()
+    pre_values = None
+    for el in env:
+        if el == macro_name + "Predefined":
+            pre_values = ms.getEnvironment()[el]
+
     # calculate parameter index
     param_idx = len(event.line.split()) - 1
     if not event.line.endswith(' '):
@@ -654,6 +661,9 @@ def _macro_completer(self, event):
         res = []
         for param in possible_params:
             res.extend(ms.getElementNamesWithInterface(param['type']))
+        if param['type'] == 'String':
+            for value in pre_values:
+                res.append(str(value))
         return res
 
 


### PR DESCRIPTION
This PR is created for opening a discussion about the implementation of predefined values for string macro arguments, requested from some DESY beamlines. 
The request: they would like to have some predefined values appearing in the screen when they pulse 
'Tab' after a macro name, in case the argument is of type String (in the same way as now, for example, one gets the name of all available Moveable sardana objects pressing 'Tab' after typing 'mv' in spock).
The predefined values are different for each macro.
The implementation I did works like this: one can define an environment variable with the name of the macro + 'Predefined' (as a list). The values in this variable will appear pressing Tab when the name of the macro is typed and the next argument is of type String. 
The implementation is done in the file genutils.py.