### PR TITLE
Adding filter to spock logging filehandler

### DIFF
--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -850,7 +850,7 @@ class MacroManager(MacroServerManager):
             self._macro_executors[door] = me = MacroExecutor(door)
         return me
 
-class FileHandlerFilter(logging.Filter):
+class LogMacroFilter(logging.Filter):
     def __init__(self, param=None):
         self.param = param
 
@@ -959,7 +959,7 @@ class LogMacroManager(object):
             logging.handlers.RotatingFileHandler(log_file,
                                                  backupCount=bck_counts)
         file_handler.doRollover()
-        file_handler.addFilter(FileHandlerFilter())
+        file_handler.addFilter(LogMacroFilter())
 
         try:
             format_to_set = macro_obj.getEnv("LogMacroFormat")

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -857,6 +857,9 @@ class FileHandlerFilter(logging.Filter):
     def filter(self, record):
         allow = True
         if record.levelname == "DEBUG":
+            if type(record.msg) != str:
+                allow = False
+                return allow
             if record.msg.find("[START]") != -1:
                 msg = record.msg
                 start = msg.index("'") + 1

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -959,7 +959,20 @@ class LogMacroManager(object):
             logging.handlers.RotatingFileHandler(log_file,
                                                  backupCount=bck_counts)
         file_handler.doRollover()
-        file_handler.addFilter(LogMacroFilter())
+
+        from sardana import sardanacustomsettings
+        log_macro_filter = getattr(sardanacustomsettings,"LOG_MACRO_FILTER")
+        print log_macro_filter
+        if isinstance(log_macro_filter, basestring):
+            print "Es basestring"
+            try:
+                moduleName, filterName = log_macro_filter.rsplit('.', 1)
+                __import__(moduleName)
+                module = sys.modules[moduleName]
+                filter_class = getattr(module, filterName)
+                file_handler.addFilter(filter_class())
+            except:
+                file_handler.addFilter(LogMacroFilter())
 
         try:
             format_to_set = macro_obj.getEnv("LogMacroFormat")

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -54,6 +54,10 @@ SPOCK_INPUT_HANDLER = "CLI"
 #: value - recorder name
 SCAN_RECORDER_MAP = None
 
+#: Filter for macro logging: name of the class to be used as filter for the macro logging
+LOG_MACRO_FILTER = "sardana.macroserver.msmacromanager.LogMacroFilter"
+
 # TODO: Temporary solution, available while Taurus3 is being supported.
 # Maximum number of Taurus deprecation warnings allowed to be displayed.
 TAURUS_MAX_DEPRECATION_COUNTS = 0
+


### PR DESCRIPTION
The output of the implemented  spock logging feature was not accepted by some users.
A filter is added for adapting the output to the user requests.