### PR TITLE
Docs: change home page address to www.sardana-controls.org

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -36,7 +36,7 @@ Projects related to Sardana
 .. toctree::
     :hidden:
 
-    Home Page <http://sardana-controls.org>
+    Home Page <http://www.sardana-controls.org>
     Project Page <https://github.com/sardana-org/sardana>
     Download from PyPI <http://pypi.python.org/pypi/sardana>
     docs


### PR DESCRIPTION
Due to unknown reasons the sardana-controls.org address does not work
correctly with RTD. Change the Home Page address to a working
address www.sardana-controls.org. In the near future, if we finally
follow the steps of Taurus project to move the docs to github pages,
the sardana-controls.org address should work again.

The same problem applies to sardana-scada.org