### PR TITLE
Add CI for Debian 9 and Taurus 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ python:
 
 env:
   - TEST="flake8"
-  - TEST="testsuite"
+  - TEST="testsuite" DOCKER_IMG=reszelaz/sardana-test
+  - TEST="testsuite" DOCKER_IMG=reszelaz/sardana-test:taurus-support-3.x
 
 before_install:
   # install flake8 to perform python code style check in the script part
@@ -23,8 +24,8 @@ before_install:
 
 install:
   # run reszelaz/sardana-test docker container (Debian8 with sardana-deps)
-  - if [ $TEST == "testsuite" ]; then docker pull reszelaz/sardana-test; fi
-  - if [ $TEST == "testsuite" ]; then docker run -d --name=sardana-test -h sardana-test --volume=`pwd`:/sardana reszelaz/sardana-test; fi
+  - if [ $TEST == "testsuite" ]; then docker pull $DOCKER_IMG; fi
+  - if [ $TEST == "testsuite" ]; then docker run -d --name=sardana-test -h sardana-test --volume=`pwd`:/sardana $DOCKER_IMG; fi
 
   # wait approx. 10 s (supervisor starts mysql and Tango DB)
   - if [ $TEST == "testsuite" ]; then sleep 10; fi


### PR DESCRIPTION
Use two different docker images for CI:
- Debian 8 together with Taurus 3
- Debian 9 together with Taurus 4