### PR TITLE
Revert workaround from travis-ci for problems with mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-group: deprecated-2017Q4
-
 language: python
 
 sudo: required


### PR DESCRIPTION
After applying a workaround in the sardana-test docker image it may be enough to remove this workaround from the travis-ci. Trying it...