### PR TITLE
Fix appending of hooks from sequence XML

### DIFF
--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1131,10 +1131,10 @@ class MacroExecutor(Logger):
             hook = MacroExecutor.RunSubXMLHook(self, macro)
             hook_hints = macro.findall('hookPlace')
             if hook_hints is None:
-                macro_obj.hooks = [hook]
+                macro_obj.appendHook((hook, []))
             else:
                 hook_places = [h.text for h in hook_hints]
-                macro_obj.hooks = [(hook, hook_places)]
+                macro_obj.appendHook((hook, hook_places))
 
         prepare_result = self._prepareMacroObj(macro_obj, macro_params)
         return macro_obj, prepare_result


### PR DESCRIPTION
#655 fixed hooks property however the MacroExecutor
was still using it in the wrong way. Properly use the appendHook method
to append hooks instead of setting the whole list of hooks.

Reported in #744.