### PR TITLE
Fix test when TANGO_HOST with PQDN is used (Taurus 3) - revealed during Jan18 release

### DIFF
--- a/src/sardana/tango/pool/test/test_measurementgroup.py
+++ b/src/sardana/tango/pool/test/test_measurementgroup.py
@@ -51,7 +51,7 @@ def _get_full_name(device_proxy, logger=None):
     # try to use Taurus 4 to retrieve FQDN
     try:
         from taurus.core.tango.tangovalidator import TangoDeviceNameValidator
-        full_name, _, _ = TangoDeviceNameValidator().getNames(name)
+        full_name, _, _ = TangoDeviceNameValidator().getNames(full_name)
     # if Taurus3 in use just continue
     except ImportError:
         pass


### PR DESCRIPTION
The problem with tests on openSUSE 11.1 (Taurus 3) revealed during the last release Jan18 and reported in https://github.com/sardana-org/sardana/pull/711#issuecomment-372592667 has to do with PQDN/FQDN compatibility. The good thing is that it was affecting only the tests. Only the systems with TANGO_HOST set to PQDN were affected. 

This PR fixes this problem, so now all the tests passes.