### PR TITLE
Calculation with real_vel instead ideal_vel

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2084,15 +2084,17 @@ class CTScan(CScan, CAcquisition):
                 while True:
                     moveable.setVelocity(try_vel)
                     get_vel = moveable.getVelocity(force=True)
-                    if get_vel <= ideal_max_vel:
+                    if get_vel < ideal_max_vel:
                         msg = 'Ideal scan velocity {0} of motor {1} cannot ' \
                               'be reached, {2} will be used instead'.format(
                                   ideal_max_vel, moveable.name, get_vel)
                         self.macro.warning(msg)
                         ideal_path.max_vel = get_vel
                         break
-                    else:
+                    elif get_vel > ideal_max_vel:
                         try_vel -= (get_vel - try_vel)
+                    else:
+                        break
             except Exception:
                 self.macro.debug("Unknown error when trying if hardware "
                                  "accepts ideal scan velocity", exc_info=1)

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2099,7 +2099,7 @@ class CTScan(CScan, CAcquisition):
                         new_vel -= (read_vel-new_vel)
             except Exception as e:
                 self.macro.error(e)
-                ideal_path.max_vel =  ideal_path.theo_max_vel
+                ideal_path.max_vel = ideal_path.theo_max_vel
             finally:
                 moveable.setVelocity(bkp_vel)
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2080,7 +2080,7 @@ class CTScan(CScan, CAcquisition):
             # check real_velocity
             bkp_vel = moveable.getVelocity(force=True)
             try:
-                ideal_path.theo_max_vel = ideal_path.max_vel
+                ideal_max_vel = ideal_path.max_vel
                 new_vel = ideal_path.max_vel
 
                 while True:
@@ -2090,7 +2090,7 @@ class CTScan(CScan, CAcquisition):
                         msg = 'Ideal vel: {0} cannot be reached, Real vel: {' \
                               '1}. Set ' \
                               'path.max_vel to real ' \
-                              'vel.'.format(ideal_path.theo_max_vel,
+                              'vel.'.format(ideal_max_vel,
                                             read_vel)
                         self.macro.debug(msg)
                         ideal_path.max_vel = read_vel
@@ -2099,7 +2099,7 @@ class CTScan(CScan, CAcquisition):
                         new_vel -= (read_vel-new_vel)
             except Exception as e:
                 self.macro.error(e)
-                ideal_path.max_vel = ideal_path.theo_max_vel
+                ideal_path.max_vel = ideal_max_vel
             finally:
                 moveable.setVelocity(bkp_vel)
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2078,30 +2078,28 @@ class CTScan(CScan, CAcquisition):
             ideal_path = MotionPath(ideal_vmotor, start, end, active_time)
 
             # check real_velocity
-            bkp_vel = moveable.getVelocity(force=True)
+            backup_vel = moveable.getVelocity(force=True)
+            ideal_max_vel = try_vel = ideal_path.max_vel
             try:
-                ideal_max_vel = ideal_path.max_vel
-                new_vel = ideal_path.max_vel
-
                 while True:
-                    moveable.setVelocity(new_vel)
-                    read_vel = moveable.getVelocity(force=True)
-                    if read_vel <= ideal_path.max_vel:
+                    moveable.setVelocity(try_vel)
+                    get_vel = moveable.getVelocity(force=True)
+                    if get_vel <= ideal_path.max_vel:
                         msg = 'Ideal vel: {0} cannot be reached, Real vel: {' \
                               '1}. Set ' \
                               'path.max_vel to real ' \
                               'vel.'.format(ideal_max_vel,
-                                            read_vel)
+                                            get_vel)
                         self.macro.debug(msg)
-                        ideal_path.max_vel = read_vel
+                        ideal_path.max_vel = get_vel
                         break
                     else:
-                        new_vel -= (read_vel-new_vel)
+                        try_vel -= (get_vel-try_vel)
             except Exception as e:
                 self.macro.error(e)
                 ideal_path.max_vel = ideal_max_vel
             finally:
-                moveable.setVelocity(bkp_vel)
+                moveable.setVelocity(backup_vel)
 
             ideal_path.moveable = moveable
             ideal_path.apply_correction = True


### PR DESCRIPTION
In some cases the ideal velocity cannot be reached and the calculations of the scan are done with a ideal velocity instead the real velocity.
With this PR, the calculations are done with the real velocity, also, the if the real velocity is greater than the ideal velocity, it will try to adjust the real velocity equal or lower than the ideal vel, never greater.