### PR TITLE
Skip configuration loading for ctrls disabled.

### DIFF
--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -542,14 +542,10 @@ class PoolMeasurementGroup(PoolGroupElement):
         cfg = self.get_configuration()
         # g_timer, g_monitor = cfg['timer'], cfg['monitor']
         for ctrl, ctrl_data in cfg['controllers'].items():
-            # skip external channels
-            if isinstance(ctrl, str):
+            if isinstance(ctrl, str):  # skip external channels
                 continue
-            # telling controller in which acquisition mode it will participate
             if not ctrl.is_online():
                 continue
-
-            # skip controllers without any channel enabled
             if ctrl not in self._enabled_ctrls:
                 self.debug('Skipping load configuration {}'.format(ctrl))
                 continue

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -143,7 +143,7 @@ class PoolMeasurementGroup(PoolGroupElement):
         # key: PoolController; value: AcqSynch
         self._ctrl_to_acq_synch = {}
         # list of controller with channels enabled.
-        self._ctrl_enable = []
+        self._enabled_ctrls = []
         kwargs['elem_type'] = ElementType.MeasurementGroup
         PoolGroupElement.__init__(self, **kwargs)
         configuration = kwargs.get("configuration")
@@ -284,7 +284,7 @@ class PoolMeasurementGroup(PoolGroupElement):
         config['controllers'] = controllers = {}
 
         external_user_elements = []
-        self._ctrl_enable = []
+        self._enabled_ctrls = []
         for index, element in enumerate(user_elements):
             elem_type = element.get_type()
             if elem_type == ElementType.External:
@@ -294,7 +294,7 @@ class PoolMeasurementGroup(PoolGroupElement):
             ctrl = element.controller
             ctrl_data = controllers.get(ctrl)
             # include all controller in the enabled list
-            self._ctrl_enable.append(ctrl)
+            self._enabled_ctrls.append(ctrl)
             if ctrl_data is None:
                 controllers[ctrl] = ctrl_data = {}
                 ctrl_data['channels'] = channels = {}
@@ -332,7 +332,7 @@ class PoolMeasurementGroup(PoolGroupElement):
         return config
 
     def set_configuration(self, config=None, propagate=1, to_fqdn=True):
-        self._ctrl_enable = []
+        self._enabled_ctrls = []
         if config is None:
             config = self._build_configuration()
         else:
@@ -376,7 +376,7 @@ class PoolMeasurementGroup(PoolGroupElement):
                 if ctrl_to_acq_synch:
                     self._ctrl_to_acq_synch[c] = acq_synch
                 if ctrl_enabled:
-                    self._ctrl_enable.append(c)
+                    self._enabled_ctrls.append(c)
 
             # sorted ids may not be consecutive (if a channel is disabled)
             indexes = sorted(user_elem_ids.keys())
@@ -550,7 +550,7 @@ class PoolMeasurementGroup(PoolGroupElement):
                 continue
 
             # skip controllers without any channel enabled
-            if ctrl not in self._ctrl_enable:
+            if ctrl not in self._enabled_ctrls:
                 self.debug('Skipping load configuration {}'.format(ctrl))
                 continue
 

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -547,7 +547,6 @@ class PoolMeasurementGroup(PoolGroupElement):
             if not ctrl.is_online():
                 continue
             if ctrl not in self._enabled_ctrls:
-                self.debug('Skipping load configuration {}'.format(ctrl))
                 continue
 
             ctrl.set_ctrl_par('acquisition_mode', self.acquisition_mode)


### PR DESCRIPTION
We use one measurement group with all the channels of the beamline, and according to the experiment we enable/disable the channels. If there is a controller with all the channels disabled, the measurement group  start method, will load the configuration into the controller anyway, this will take an unnecessary amount of time. In the worst case, the starting of the measurement group can trigger a timeout exception. 