### PR TITLE
Fix set macro path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /MANIFEST
 /dist
+/src/sardana.egg-info
 /build
 /setup.cfg
 *.pyc

--- a/src/sardana/macroserver/macros/laserShutter.py
+++ b/src/sardana/macroserver/macros/laserShutter.py
@@ -1,0 +1,68 @@
+from epics import caget, caput
+import time
+
+from sardana.macroserver.macro import Macro, macro, Type
+
+@macro()
+def laserOn(self):
+    """Macro laserOn"""
+    pvPrefix = 'SHUTTER:NOPA:'
+    shutterState = caget(pvPrefix + 'Shutter_RBV', as_string=True)
+    if shutterState == "Open":
+        self.output("Laser shutter already open")
+    else:
+        caput(pvPrefix + 'Flip', 3)
+        time.sleep(1)
+        shutterState = caget(pvPrefix + 'Shutter_RBV', as_string=True)
+        if shutterState == "Open":
+            self.output("Laser shutter opened")
+        else:
+            self.output("Could not open Laser shutter")
+
+@macro()
+def laserOff(self):
+    """Macro laserOn"""
+    pvPrefix = 'SHUTTER:NOPA:'
+    shutterState = caget(pvPrefix + 'Shutter_RBV', as_string=True)
+    if shutterState == "Closed":
+        self.output("Laser shutter already closed")
+    else:
+        caput(pvPrefix + 'Flip', 3)
+        time.sleep(1)
+        shutterState = caget(pvPrefix + 'Shutter_RBV', as_string=True)
+        if shutterState == "Closed":
+            self.output("Laser shutter closed")
+        else:
+            self.output("Could not close Laser shutter")
+
+@macro()
+def pumpOn(self):
+    """Macro laserOn"""
+    pvPrefix = 'SHUTTER:MOKE:'
+    shutterState = caget(pvPrefix + 'Shutter_RBV', as_string=True)
+    if shutterState == "Open":
+        self.output("Pump shutter already open")
+    else:
+        caput(pvPrefix + 'Flip', 3)
+        time.sleep(1)
+        shutterState = caget(pvPrefix + 'Shutter_RBV', as_string=True)
+        if shutterState == "Open":
+            self.output("Pump shutter opened")
+        else:
+            self.output("Could not open Pump shutter")
+
+@macro()
+def pumpOff(self):
+    """Macro laserOn"""
+    pvPrefix = 'SHUTTER:MOKE:'
+    shutterState = caget(pvPrefix + 'Shutter_RBV', as_string=True)
+    if shutterState == "Closed":
+        self.output("Pump shutter already closed")
+    else:
+        caput(pvPrefix + 'Flip', 3)
+        time.sleep(1)
+        shutterState = caget(pvPrefix + 'Shutter_RBV', as_string=True)
+        if shutterState == "Closed":
+            self.output("Pump shutter closed")
+        else:
+            self.output("Could not close Pump shutter")

--- a/src/sardana/macroserver/macros/scans.py
+++ b/src/sardana/macroserver/macros/scans.py
@@ -1,0 +1,635 @@
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+"""
+    Macro library containning examples demonstrating specific features or tricks
+    for programming macros for Sardana.
+
+   Available Macros are:
+     ascanr
+     toothedtriangle
+
+"""
+
+__all__ = ["ascan_demo", "ascanr", "toothedtriangle",
+           "regscan", "reg2scan", "reg3scan", "a2scan_mod"]
+
+__docformat__ = 'restructuredtext'
+
+import os
+import numpy
+
+from sardana.macroserver.macro import *
+from sardana.macroserver.scan import *
+
+
+class ascan_demo(Macro):
+    """
+    This is a basic reimplementation of the ascan` macro for demonstration
+    purposes of the Generic Scan framework. The "real" implementation of
+    :class:`sardana.macroserver.macros.ascan` derives from
+    :class:`sardana.macroserver.macros.aNscan` and provides some extra features.
+    """
+
+    # this is used to indicate other codes that the macro is a scan
+    hints = {'scan': 'ascan_demo'}
+    # this hints that the macro requires the ActiveMntGrp environment variable
+    # to be set
+    env = ('ActiveMntGrp',)
+
+    param_def = [
+        ['motor',      Type.Moveable, None, 'Motor to move'],
+        ['start_pos',  Type.Float,    None, 'Scan start position'],
+        ['final_pos',  Type.Float,    None, 'Scan final position'],
+        ['nr_interv',  Type.Integer,  None, 'Number of scan intervals'],
+        ['integ_time', Type.Float,    None, 'Integration time']
+    ]
+
+    def prepare(self, motor, start_pos, final_pos, nr_interv, integ_time, **opts):
+        # parse the user parameters
+        self.start = numpy.array([start_pos], dtype='d')
+        self.final = numpy.array([final_pos], dtype='d')
+        self.integ_time = integ_time
+
+        self.nr_points = nr_interv + 1
+        self.interv_size = (self.final - self.start) / nr_interv
+        self.name = 'ascan_demo'
+        # the "env" dictionary may be passed as an option
+        env = opts.get('env', {})
+
+        # create an instance of GScan (in this case, of its child, SScan
+        self._gScan = SScan(self, generator=self._generator,
+                            moveables=[motor], env=env)
+
+    def _generator(self):
+        step = {}
+        # integ_time is the same for all steps
+        step["integ_time"] = self.integ_time
+        for point_no in xrange(self.nr_points):
+            step["positions"] = self.start + point_no * \
+                self.interv_size  # note that this is a numpy array
+            step["point_id"] = point_no
+            yield step
+
+    def run(self, *args):
+        for step in self._gScan.step_scan():  # just go through the steps
+            yield step
+
+    @property
+    def data(self):
+        return self._gScan.data  # the GScan provides scan data
+
+
+class ascanr(Macro, Hookable):
+    """This is an example of how to handle adding extra info columns in a scan.
+    Does the same than ascan but repeats the acquisitions "repeat" times for each step.
+    It could be implemented deriving from aNscan, but I do it like this for clarity.
+    Look for the comments with "!!!" for tips specific to the extra info columns
+    I do not support constrains in this one for simplicity (see ascan for that)
+
+    Do an absolute scan of the specified motor, repeating measurements in each step.
+    ascanr scans one motor, as specified by motor. The motor starts at the
+    position given by start_pos and ends at the position given by final_pos.
+    At each step, the acquisition will be repeated "repeat" times
+    The step size is (start_pos-final_pos)/nr_interv. The number of data points collected
+    will be (nr_interv+1)*repeat. Count time for each acquisition is given by time which if positive,
+    specifies seconds and if negative, specifies monitor counts. """
+
+    hints = {'scan': 'ascanr', 'allowsHooks': (
+        'pre-move', 'post-move', 'pre-acq', 'post-acq', 'post-step')}
+    env = ('ActiveMntGrp',)
+
+    param_def = [
+        ['motor',      Type.Moveable, None, 'Motor to move'],
+        ['start_pos',  Type.Float,    None, 'Scan start position'],
+        ['final_pos',  Type.Float,    None, 'Scan final position'],
+        ['nr_interv',  Type.Integer,  None, 'Number of scan intervals'],
+        ['integ_time', Type.Float,    None, 'Integration time'],
+        ['repeat',     Type.Integer,  None, 'Number of Repetitions']
+    ]
+
+    def prepare(self, motor, start_pos, final_pos, nr_interv, integ_time, repeat,
+                **opts):
+
+        self.starts = numpy.array([start_pos], dtype='d')
+        self.finals = numpy.array([final_pos], dtype='d')
+        self.nr_interv = nr_interv
+        self.integ_time = integ_time
+        self.repeat = repeat
+        self.opts = opts
+
+        self.nr_points = nr_interv + 1
+        self.interv_sizes = (self.finals - self.starts) / nr_interv
+        self.name = 'ascanr'
+
+        generator = self._generator
+        moveables = [motor]
+        env = opts.get('env', {})
+        constrains = []
+        extrainfodesc = [ColumnDesc(name='repetition',
+                                    dtype='int64', shape=(1,))]  # !!!
+
+        self._gScan = SScan(self, generator, moveables, env,
+                            constrains, extrainfodesc)  # !!!
+
+    def _generator(self):
+        step = {}
+        step["integ_time"] = self.integ_time
+        step[
+            "post-acq-hooks"] = self.getHooks('post-acq') + self.getHooks('_NOHINT_')
+        step["post-step-hooks"] = self.getHooks('post-step')
+        step["check_func"] = []
+        extrainfo = {"repetition": 0}  # !!!
+        step['extrainfo'] = extrainfo  # !!!
+        for point_no in xrange(self.nr_points):
+            step["positions"] = self.starts + point_no * self.interv_sizes
+            step["point_id"] = point_no
+            for i in xrange(self.repeat):
+                extrainfo["repetition"] = i  # !!!
+                yield step
+
+    def run(self, *args):
+        for step in self._gScan.step_scan():
+            yield step
+
+    @property
+    def data(self):
+        return self._gScan.data
+
+
+class toothedtriangle(Macro, Hookable):
+    """toothedtriangle macro implemented with the gscan framework.
+    It performs nr_cycles cycles, each consisting of two stages: the first half
+    of the cycle it behaves like the ascan macro (from start_pos to stop_pos in
+    nr_interv+1 steps).For the second half of the cycle it steps back until
+    it undoes the first half and is ready for the next cycle.
+    At each step, nr_samples acquisitions are performed.
+    The total number of points in the scan is nr_interv*2*nr_cycles*nr_samples+1"""
+
+    hints = {'scan': 'toothedtriangle',
+             'allowsHooks': ('pre-scan', 'pre-move', 'post-move', 'pre-acq',
+                             'post-acq', 'post-step', 'post-scan')
+             }
+    env = ('ActiveMntGrp',)
+
+    param_def = [
+        ['motor',      Type.Moveable, None, 'Motor to move'],
+        ['start_pos',  Type.Float,    None, 'start position'],
+        ['final_pos',  Type.Float,    None, 'position after half cycle'],
+        ['nr_interv',  Type.Integer,  None, 'Number of intervals in half cycle'],
+        ['integ_time', Type.Float,    None, 'Integration time'],
+        ['nr_cycles',  Type.Integer,  None, 'Number of cycles'],
+        ['nr_samples', Type.Integer,  1, 'Number of samples at each point']
+    ]
+
+    def prepare(self, motor, start_pos, final_pos, nr_interv, integ_time,
+                nr_cycles, nr_samples, **opts):
+
+        self.start_pos = start_pos
+        self.final_pos = final_pos
+        self.nr_interv = nr_interv
+        self.integ_time = integ_time
+        self.nr_cycles = nr_cycles
+        self.nr_samples = nr_samples
+        self.opts = opts
+        cycle_nr_points = self.nr_interv + 1 + (self.nr_interv + 1) - 2
+        self.nr_points = cycle_nr_points * nr_samples * nr_cycles + nr_samples
+
+        self.interv_size = (self.final_pos - self.start_pos) / nr_interv
+        self.name = 'toothedtriangle'
+
+        generator = self._generator
+        moveables = []
+        moveable = MoveableDesc(moveable=motor, is_reference=True,
+                                min_value=min(start_pos, final_pos),
+                                max_value=max(start_pos, final_pos))
+        moveables = [moveable]
+        env = opts.get('env', {})
+        constrains = []
+        extrainfodesc = [ColumnDesc(name='cycle', dtype='int64', shape=(1,)),
+                         ColumnDesc(name='interval',
+                                    dtype='int64', shape=(1,)),
+                         ColumnDesc(name='sample', dtype='int64', shape=(1,))]  # !!!
+
+        self._gScan = SScan(self, generator, moveables, env,
+                            constrains, extrainfodesc)  # !!!
+
+    def _generator(self):
+        step = {}
+        step["integ_time"] = self.integ_time
+        step["pre-move-hooks"] = self.getHooks('pre-move')
+        step["post-move-hooks"] = self.getHooks('post-move')
+        step["pre-acq-hooks"] = self.getHooks('pre-acq')
+        step[
+            "post-acq-hooks"] = self.getHooks('post-acq') + self.getHooks('_NOHINT_')
+        step["post-step-hooks"] = self.getHooks('post-step')
+        step["check_func"] = []
+        extrainfo = {"cycle": None, "interval": None, "sample": None, }
+        step['extrainfo'] = extrainfo
+        halfcycle1 = range(self.nr_interv + 1)
+        halfcycle2 = halfcycle1[1:-1]
+        halfcycle2.reverse()
+        intervallist = halfcycle1 + halfcycle2
+        point_no = 0
+        for cycle in xrange(self.nr_cycles):
+            extrainfo["cycle"] = cycle
+            for interval in intervallist:
+                extrainfo["interval"] = interval
+                step["positions"] = numpy.array(
+                    [self.start_pos + (interval) * self.interv_size], dtype='d')
+                for sample in xrange(self.nr_samples):
+                    extrainfo["sample"] = sample
+                    step["point_id"] = point_no
+                    yield step
+                    point_no += 1
+
+        # last step for closing the loop
+        extrainfo["interval"] = 0
+        step["positions"] = numpy.array([self.start_pos], dtype='d')
+        for sample in xrange(self.nr_samples):
+            extrainfo["sample"] = sample
+            step["point_id"] = point_no
+            yield step
+            point_no += 1
+
+    def run(self, *args):
+        for step in self._gScan.step_scan():
+            yield step
+
+    @property
+    def data(self):
+        return self._gScan.data
+
+
+class regscan(Macro):
+    """regscan.
+    Do an absolute scan of the specified motor with different number of intervals for each region.
+    It uses the gscan framework.
+    """
+
+    hints = {'scan': 'regscan'}
+    env = ('ActiveMntGrp',)
+
+    param_def = [
+        ['motor',      Type.Moveable, None, 'Motor to move'],
+        ['integ_time', Type.Float,    None, 'Integration time'],
+        ['start_pos',  Type.Float,    None, 'Start position'],
+        ['step_region',
+         ParamRepeat(['next_pos',  Type.Float,   None, 'next position'],
+                     ['region_nr_intervals',  Type.Float,   None, 'Region number of intervals']),
+         None, 'List of tuples: (next_pos, region_nr_intervals']
+    ]
+
+    def prepare(self, motor, integ_time, start_pos, regions, **opts):
+        self.name = 'regscan'
+        self.integ_time = integ_time
+        self.start_pos = start_pos
+        self.regions = regions
+        self.regions_count = len(self.regions) / 2
+
+        generator = self._generator
+        moveables = [motor]
+        env = opts.get('env', {})
+        constrains = []
+        self._gScan = SScan(self, generator, moveables, env, constrains)
+
+    def _generator(self):
+        step = {}
+        step["integ_time"] = self.integ_time
+
+        point_id = 0
+        region_start = self.start_pos
+        for r in range(len(self.regions)):
+            region_stop, region_nr_intervals = self.regions[
+                r][0], self.regions[r][1]
+            positions = numpy.linspace(
+                region_start, region_stop, region_nr_intervals + 1)
+            if region_start != self.start_pos:
+                # positions must be calculated from the start to the end of the region
+                # but after the first region, the 'start' point must not be
+                # repeated
+                positions = positions[1:]
+            for p in positions:
+                step['positions'] = [p]
+                step['point_id'] = point_id
+                point_id += 1
+                yield step
+            region_start = region_stop
+
+    def run(self, *args):
+        for step in self._gScan.step_scan():
+            yield step
+
+
+class reg2scan(Macro):
+    """reg2scan.
+    Do an absolute scan of the specified motors with different number of intervals for each region.
+    It uses the gscan framework. All the motors will be drived to the same position in each step
+    """
+
+    hints = {'scan': 'reg2scan'}
+    env = ('ActiveMntGrp',)
+
+    param_def = [
+        ['motor1',     Type.Moveable, None, 'Motor to move'],
+        ['motor2',     Type.Moveable, None, 'Motor to move'],
+        ['integ_time', Type.Float,    None, 'Integration time'],
+        ['start_pos',  Type.Float,    None, 'Start position'],
+        ['step_region',
+         ParamRepeat(['next_pos',  Type.Float,   None, 'next position'],
+                     ['region_nr_intervals',  Type.Float,   None, 'Region number of intervals']),
+         None, 'List of tuples: (next_pos, region_nr_intervals']
+    ]
+
+    def prepare(self, motor1, motor2, integ_time, start_pos, regions, **opts):
+        self.name = 'reg2scan'
+        self.integ_time = integ_time
+        self.start_pos = start_pos
+        self.regions = regions
+        self.regions_count = len(self.regions) / 2
+
+        generator = self._generator
+        moveables = [motor1, motor2]
+        env = opts.get('env', {})
+        constrains = []
+        self._gScan = SScan(self, generator, moveables, env, constrains)
+
+    def _generator(self):
+        step = {}
+        step["integ_time"] = self.integ_time
+
+        point_id = 0
+        region_start = self.start_pos
+        for r in range(len(self.regions)):
+            region_stop, region_nr_intervals = self.regions[
+                r][0], self.regions[r][1]
+            positions = numpy.linspace(
+                region_start, region_stop, region_nr_intervals + 1)
+            if region_start != self.start_pos:
+                # positions must be calculated from the start to the end of the region
+                # but after the first region, the 'start' point must not be
+                # repeated
+                positions = positions[1:]
+            for p in positions:
+                step['positions'] = [p, p]
+                step['point_id'] = point_id
+                point_id += 1
+                yield step
+            region_start = region_stop
+
+    def run(self, *args):
+        for step in self._gScan.step_scan():
+            yield step
+
+
+class reg3scan(Macro):
+    """reg3scan.
+    Do an absolute scan of the specified motors with different number of intervals for each region.
+    It uses the gscan framework. All the motors will be drived to the same position in each step
+
+    NOTE: Due to a ParamRepeat limitation, integration time has to be
+    specified before the regions.
+    """
+
+    hints = {'scan': 'reg3scan'}
+    env = ('ActiveMntGrp',)
+
+    param_def = [
+        ['motor1',     Type.Moveable, None, 'Motor to move'],
+        ['motor2',     Type.Moveable, None, 'Motor to move'],
+        ['motor3',     Type.Moveable, None, 'Motor to move'],
+        ['integ_time', Type.Float,    None, 'Integration time'],
+        ['start_pos',  Type.Float,    None, 'Start position'],
+        ['step_region',
+         ParamRepeat(['next_pos',  Type.Float,   None, 'next position'],
+                     ['region_nr_intervals',  Type.Float,   None, 'Region number of intervals']),
+         None, 'List of tuples: (next_pos, region_nr_intervals']
+    ]
+
+    def prepare(self, motor1, motor2, motor3, integ_time, start_pos, regions, **opts):
+        self.name = 'reg3scan'
+        self.integ_time = integ_time
+        self.start_pos = start_pos
+        self.regions = regions
+        self.regions_count = len(self.regions) / 2
+
+        generator = self._generator
+        moveables = [motor1, motor2, motor3]
+        env = opts.get('env', {})
+        constrains = []
+        self._gScan = SScan(self, generator, moveables, env, constrains)
+
+    def _generator(self):
+        step = {}
+        step["integ_time"] = self.integ_time
+
+        point_id = 0
+        region_start = self.start_pos
+        for r in range(len(self.regions)):
+            region_stop, region_nr_intervals = self.regions[
+                r][0], self.regions[r][1]
+            positions = numpy.linspace(
+                region_start, region_stop, region_nr_intervals + 1)
+            if region_start != self.start_pos:
+                # positions must be calculated from the start to the end of the region
+                # but after the first region, the 'start' point must not be
+                # repeated
+                positions = positions[1:]
+            for p in positions:
+                step['positions'] = [p, p, p]
+                step['point_id'] = point_id
+                point_id += 1
+                yield step
+            region_start = region_stop
+
+    def run(self, *args):
+        for step in self._gScan.step_scan():
+            yield step
+
+
+class a2scan_mod(Macro):
+    """a2scan_mod.
+    Do an a2scan with the particularity of different intervals per motor: int_mot1, int_mot2.
+    If int_mot2 < int_mot1, mot2 will change position every int(int_mot1/int_mot2) steps of mot1.
+    It uses the gscan framework.
+    """
+
+    hints = {'scan': 'a2scan_mod'}
+    env = ('ActiveMntGrp',)
+
+    param_def = [
+        ['motor1',      Type.Moveable, None, 'Motor 1 to move'],
+        ['start_pos1',  Type.Float,    None, 'Scan start position 1'],
+        ['final_pos1',  Type.Float,    None, 'Scan final position 1'],
+        ['nr_interv1',  Type.Integer,  None, 'Number of scan intervals of Motor 1'],
+        ['motor2',      Type.Moveable, None, 'Motor 2 to move'],
+        ['start_pos2',  Type.Float,    None, 'Scan start position 2'],
+        ['final_pos2',  Type.Float,    None, 'Scan final position 2'],
+        ['nr_interv2',  Type.Integer,  None, 'Number of scan intervals of Motor 2'],
+        ['integ_time',  Type.Float,    None, 'Integration time']
+    ]
+
+    def prepare(self, motor1, start_pos1, final_pos1, nr_interv1, motor2, start_pos2, final_pos2, nr_interv2, integ_time,
+                **opts):
+        self.name = 'a2scan_mod'
+        self.integ_time = integ_time
+        self.start_pos1 = start_pos1
+        self.final_pos1 = final_pos1
+        self.nr_interv1 = nr_interv1
+        self.start_pos2 = start_pos2
+        self.final_pos2 = final_pos2
+        self.nr_interv2 = nr_interv2
+
+        generator = self._generator
+        moveables = [motor1, motor2]
+        env = opts.get('env', {})
+        constraints = []
+        self._gScan = SScan(self, generator, moveables, env, constraints)
+
+    def _generator(self):
+        step = {}
+        step["integ_time"] = self.integ_time
+
+        start1, end1, interv1 = self.start_pos1, self.final_pos1, self.nr_interv1
+        start2, end2, interv2 = self.start_pos2, self.final_pos2, self.nr_interv2
+
+        # Prepare the positions
+        positions_m1 = numpy.linspace(start1, end1, interv1 + 1)
+        positions_m2 = numpy.linspace(start2, end2, interv2 + 1)
+
+        if interv1 > interv2:
+            positions_m2 = start2 + (float(end2 - start2) / interv2) * (
+                numpy.arange(interv1 + 1) // (float(interv1) / float(interv2)))
+        elif interv2 > interv1:
+            positions_m1 = start1 + (float(end1 - start1) / interv1) * (
+                numpy.arange(interv2 + 1) // (float(interv2) / float(interv1)))
+
+        point_id = 0
+        for pos1, pos2 in zip(positions_m1, positions_m2):
+            step['point_id'] = point_id
+            step['positions'] = [pos1, pos2]
+            yield step
+            point_id += 1
+
+    def run(self, *args):
+        for step in self._gScan.step_scan():
+            yield step
+
+
+class ascanc_demo(Macro):
+    """
+    This is a basic reimplementation of the ascanc` macro for demonstration
+    purposes of the Generic Scan framework. The "real" implementation of
+    :class:`sardana.macroserver.macros.ascanc` derives from
+    :class:`sardana.macroserver.macros.aNscan` and provides some extra features.
+    """
+
+    # this is used to indicate other codes that the macro is a scan
+    hints = {'scan': 'ascanc_demo'}
+    # this hints that the macro requires the ActiveMntGrp environment variable
+    # to be set
+    env = ('ActiveMntGrp',)
+
+    param_def = [
+        ['motor',      Type.Moveable, None, 'Motor to move'],
+        ['start_pos',  Type.Float,    None, 'Scan start position'],
+        ['final_pos',  Type.Float,    None, 'Scan final position'],
+        ['integ_time', Type.Float,    None, 'Integration time']
+    ]
+
+    def prepare(self, motor, start_pos, final_pos, integ_time, **opts):
+        self.name = 'ascanc_demo'
+        # parse the user parameters
+        self.start = numpy.array([start_pos], dtype='d')
+        self.final = numpy.array([final_pos], dtype='d')
+        self.integ_time = integ_time
+        # the "env" dictionary may be passed as an option
+        env = opts.get('env', {})
+
+        # create an instance of GScan (in this case, of its child, CScan
+        self._gScan = CScan(self,
+                            waypointGenerator=self._waypoint_generator,
+                            periodGenerator=self._period_generator,
+                            moveables=[motor],
+                            env=env)
+
+    def _waypoint_generator(self):
+        # a very simple waypoint generator! only start and stop points!
+        yield {"positions": self.start, "waypoint_id": 0}
+        yield {"positions": self.final, "waypoint_id": 1}
+
+    def _period_generator(self):
+        step = {}
+        step["integ_time"] = self.integ_time
+        point_no = 0
+        while(True):  # infinite generator. The acquisition loop is started/stopped at begin and end of each waypoint
+            point_no += 1
+            step["point_id"] = point_no
+            yield step
+
+    def run(self, *args):
+        for step in self._gScan.step_scan():
+            yield step
+
+
+class ascan_with_addcustomdata(ascan_demo):
+    '''
+    example of an ascan-like macro where we demonstrate how to pass custom data to the data handler.
+    This is an extension of the ascan_demo macro. Wemake several calls to `:meth:DataHandler.addCustomData`
+    exemplifying different features.
+    At least the following recorders will act on custom data:
+      - OutputRecorder (this will ignore array data)
+      - NXscan_FileRecorder
+      - SPEC_FileRecorder (this will ignore array data)
+    '''
+
+    def run(self, motor, start_pos, final_pos, nr_interv, integ_time, **opts):
+        # we get the datahandler
+        dh = self._gScan._data_handler
+        # at this point the entry name is not yet set, so we give it explicitly
+        # (otherwise it would default to "entry")
+        dh.addCustomData('Hello world1', 'dummyChar1',
+                         nxpath='/custom_entry:NXentry/customdata:NXcollection')
+        # this is the normal scan loop
+        for step in self._gScan.step_scan():
+            yield step
+        # the entry number is known and the default nxpath is used
+        # "/<currententry>/custom_data") if none given
+        dh.addCustomData('Hello world1', 'dummyChar1')
+        # you can pass arrays (but not all recorders will handle them)
+        dh.addCustomData(range(10), 'dummyArray1')
+        # you can pass a custom nxpath *relative* to the current entry
+        dh.addCustomData('Hello world2', 'dummyChar2',
+                         nxpath='sample:NXsample')
+
+        # calculate a linear fit to the timestamps VS motor positions and store
+        # it
+        x = [r.data[motor.getName()] for r in self.data.records]
+        y = [r.data['timestamp'] for r in self.data.records]
+        fitted_y = numpy.polyval(numpy.polyfit(x, y, 1), x)
+        dh.addCustomData(fitted_y, 'fittedtime',
+                         nxpath='measurement:NXcollection')
+
+        # as a bonus, plot the fit
+        self.pyplot.plot(x, y, 'ro')
+        self.pyplot.plot(x, fitted_y, 'b-')

--- a/src/sardana/macroserver/macros/sequency_macros.py
+++ b/src/sardana/macroserver/macros/sequency_macros.py
@@ -1,0 +1,62 @@
+##############################################################################
+##
+## This file is part of Sardana
+##
+## http://www.tango-controls.org/static/sardana/latest/doc/html/index.html
+##
+## Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+## 
+## Sardana is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+## 
+## Sardana is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+## 
+## You should have received a copy of the GNU Lesser General Public License
+## along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+"""Examples of macro to execute sequencies in a file"""
+
+from __future__ import print_function
+
+__all__ = ["run_seq"]
+
+__docformat__ = 'restructuredtext'
+
+from sardana.macroserver.macro import Type, Macro
+import PyTango
+import time
+
+    
+
+class run_seq(Macro):
+    param_def = [
+        ['seq_file',Type.String,   None, 'Name of the file with the sequency of macros']
+        ]
+    
+    def run(self, seq_file):
+        self.output("Running sequency %s", seq_file)
+
+        try:
+            seq_path = self.getEnv("SequencyPath") + "/"
+        except:
+            self.output("Not SequencyPath defined. File searched in MacroServer dir")
+            seq_path = ""
+
+        seq_file = seq_path + seq_file
+        try:
+            f_seq = open(seq_file, 'r')
+        except:
+            self.output("Enable to read file %s", seq_file)
+            return
+        
+        for macro_info in f_seq:
+            self.output("Running macro %s", macro_info)
+            self.execMacro(macro_info)
+                

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -219,8 +219,12 @@ class MacroManager(MacroServerManager):
         refer to an old module (which could possibly generate problems of type
         class A != class A)."""
         p = []
-        for item in macro_path:
-            p.extend(item.split(":"))
+        
+        if os.name != 'nt':
+            for item in macro_path:
+                p.extend(item.split(":"))
+        else:
+            p = macro_path
 
         # filter empty and commented paths
         p = [i for i in p if i and not i.startswith("#")]

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1131,10 +1131,10 @@ class MacroExecutor(Logger):
             hook = MacroExecutor.RunSubXMLHook(self, macro)
             hook_hints = macro.findall('hookPlace')
             if hook_hints is None:
-                macro_obj.hooks = [hook]
+                macro_obj.appendHook((hook, []))
             else:
                 hook_places = [h.text for h in hook_hints]
-                macro_obj.hooks = [(hook, hook_places)]
+                macro_obj.appendHook((hook, hook_places))
 
         prepare_result = self._prepareMacroObj(macro_obj, macro_params)
         return macro_obj, prepare_result

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -747,6 +747,10 @@ class GScan(Logger):
         ret = []
         for src, label in elements:
             try:
+                is_full_tango_name = src.startswith('tango://')
+                if not is_full_tango_name:
+                    src = 'tango://{}'.format(src)
+
                 if src in all_elements_info:
                     ei = all_elements_info[src]
                     column = ColumnDesc(name=ei.full_name,

--- a/src/sardana/pool/poolcontrollers/AgilisCONEXagpController.py
+++ b/src/sardana/pool/poolcontrollers/AgilisCONEXagpController.py
@@ -1,0 +1,98 @@
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+"""This file contains the code for an hypothetical Springfield motor controller
+used in documentation"""
+
+import pyagilis as agilis
+
+from sardana import State
+from sardana.pool.controller import MotorController
+from sardana import DataAccess
+from sardana.pool.controller import Type, Description, DefaultValue, Access, FGet, FSet
+
+
+class AgilisCONEXagpController(MotorController):
+    ctrl_properties = {'port': {Type: str, Description: 'The port of the rs232 device', DefaultValue: '/dev/ttyUSB0'}}
+
+    axis_attributes = {
+        "Homing" : {
+                Type         : bool,
+                Description  : "(de)activates the motor homing algorithm",
+                DefaultValue : False,
+            },
+    }
+    
+    MaxDevice = 1
+    
+    def __init__(self, inst, props, *args, **kwargs):
+        super(AgilisCONEXagpController, self).__init__(
+            inst, props, *args, **kwargs)
+
+        # initialize hardware communication
+        self.agilis = agilis.controller.AGP(self.port)
+        if self.agilis.getStatus() == 0: # not referenced
+            self.agilis.home()
+        # do some initialization
+        self._motors = {}
+
+    def AddDevice(self, axis):
+        self._motors[axis] = True
+
+    def DeleteDevice(self, axis):
+        del self._motors[axis]
+
+    StateMap = {
+        1: State.On,
+        2: State.Moving,
+        3: State.Fault,
+    }
+
+    def StateOne(self, axis):
+        limit_switches = MotorController.NoLimitSwitch     
+        state = self.agilis.getStatus()
+                
+        return self.StateMap[state], 'some text', limit_switches
+
+    def ReadOne(self, axis):
+        return self.agilis.getCurrentPosition()
+
+    def StartOne(self, axis, position):
+        self.agilis.moveAbsolute(position)
+
+    def StopOne(self, axis):
+        self.agilis.stop()
+
+    def AbortOne(self, axis):
+        self.agilis.stop()
+        
+    def setHoming(self, axis, value):
+        """Homing for given axis"""
+        if value:       
+            self.agilis.home()
+    
+    def getHoming(self, axis):
+        """Homing for given axis"""       
+        return False
+
+    

--- a/src/sardana/pool/poolcontrollers/DelayPseudoMotorController.py
+++ b/src/sardana/pool/poolcontrollers/DelayPseudoMotorController.py
@@ -1,0 +1,26 @@
+import numpy as np
+import scipy.constants
+
+from sardana import pool
+from sardana.pool import PoolUtil
+from sardana.pool.controller import PseudoMotorController
+
+
+class DelayPseudoMotorController(PseudoMotorController):
+    """A Slit pseudo motor controller for handling gap and offset pseudo 
+       motors. The system uses to real motors sl2t (top slit) and sl2b (bottom
+       slit)."""
+    
+    pseudo_motor_roles = ("OutputMotor",)
+    motor_roles = ("InputMotor",)
+    
+    def __init__(self, inst, props):  
+        PseudoMotorController.__init__(self, inst, props)
+    
+    def CalcPhysical(self, axis, pseudo_pos, curr_physical_pos):
+        c_in_mm_ps = scipy.constants.c*1000*1e-12
+        return pseudo_pos[axis-1]*c_in_mm_ps/2
+    
+    def CalcPseudo(self, axis, physical_pos, curr_pseudo_pos):
+        c_in_mm_ps = scipy.constants.c*1000*1e-12
+        return physical_pos[axis-1]/c_in_mm_ps*2

--- a/src/sardana/pool/poolcontrollers/NewportXPSController.py
+++ b/src/sardana/pool/poolcontrollers/NewportXPSController.py
@@ -160,8 +160,8 @@ class NewportXPSController(MotorController):
             raise ValueError('positioner not set for this axis')
         
         if name == "acceleration" or name == "deceleration":
-            [_, _, v, _, _] = self.XPS.PositionerSGammaParametersGet(self.socketSGamma, positioner)
-            v = 1/v
+            [_, vel, acc, _, _] = self.XPS.PositionerSGammaParametersGet(self.socketSGamma, positioner)
+            v = vel/acc
         elif name == "velocity":
             [_, v, _, _, _] = self.XPS.PositionerSGammaParametersGet(self.socketSGamma, positioner)
         elif name == "base_rate":

--- a/src/sardana/pool/poolcontrollers/NewportXPSController.py
+++ b/src/sardana/pool/poolcontrollers/NewportXPSController.py
@@ -1,0 +1,215 @@
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+"""This file contains the code for an hypothetical Springfield motor controller
+used in documentation"""
+
+import newportXPS.XPS as XPS
+import time
+
+from sardana import State
+from sardana.pool.controller import MotorController
+
+from sardana.pool.controller import Type, Description, DefaultValue, Access, FGet, FSet, DataAccess, Memorize, Memorized
+
+
+class NewportXPSController(MotorController):
+    ctrl_properties = {'IP': {Type: str, Description: 'The IP of the XPS controller', DefaultValue: 'xps-controller.hhg.lab'},
+						     'port': {Type: int, Description: 'The port of the XPS controller', DefaultValue: 5001},
+						     }
+    
+    axis_attributes  = {'group': {Type: str, Description: 'Group name of the axis', DefaultValue: 'Single1', Access: DataAccess.ReadWrite, Memorized: Memorize},
+                       'positioner': {Type: str, Description: 'Positioner name of the axis', DefaultValue: 'pos', Access: DataAccess.ReadWrite, Memorized: Memorize}
+                       }
+    
+    MaxDevice = 2
+    timeOut = 5000
+	
+    def __init__(self, inst, props, *args, **kwargs):
+        super(NewportXPSController, self).__init__(
+            inst, props, *args, **kwargs)
+
+        # initialize hardware communication
+        self.XPS = XPS.XPS()
+        self.socketIDmove  = self.XPS.TCP_ConnectToServer(self.IP, self.port, self.timeOut)
+        self.socketIDstate = self.XPS.TCP_ConnectToServer(self.IP, self.port, self.timeOut)
+        self.socketIDread  = self.XPS.TCP_ConnectToServer(self.IP, self.port, self.timeOut)
+        self.socketIDabort = self.XPS.TCP_ConnectToServer(self.IP, self.port, self.timeOut,1)
+        self.socketSGamma  = self.XPS.TCP_ConnectToServer(self.IP, self.port, self.timeOut, 1)
+                
+        # do some initialization
+        self._motors = {}
+        self._target = {}
+        self._threshold = 0.1
+        
+
+    def AddDevice(self, axis):
+        self._motors[axis] = {}
+        self._motors[axis]['target'] = None
+        [_, resp] = self.XPS.ObjectsListGet(self.socketIDabort)
+        [self._motors[axis]['group'], self._motors[axis]['positioner'], _] =  resp.split(';', 2 )
+        
+    def DeleteDevice(self, axis):
+        del self._motors[axis]
+        del self._target[axis]
+
+    StateMap = {
+        1: State.On,
+        2: State.Moving,
+        3: State.Fault,
+    }
+
+    def StateOne(self, axis):
+        group = self._motors[axis]['group']
+        positioner = self._motors[axis]['positioner']
+        
+        if group is None or positioner is None:
+            raise ValueError('Group or positioner not set for this axis')
+            
+        limit_switches = MotorController.NoLimitSwitch
+        target = self._motors[axis]['target']
+        pos = self.ReadOne(axis)
+        
+        if (target is not None) and (abs(pos - target) > self._threshold):
+            MOVING = True
+        else:
+            MOVING = False
+                                        
+        [_, state] = self.XPS.GroupStatusGet(self.socketIDstate, group)
+        time.sleep(0.01)        
+                
+        if ((state >= 43) & (state <= 44)) or MOVING:
+            return self.StateMap[2], 'stage is moving', limit_switches
+        elif (state >= 0) & (state <= 9):
+            return self.StateMap[3], 'stage not initialized', limit_switches
+        elif (state >= 21) & (state <= 39):
+            return self.StateMap[3], 'stage disabled', limit_switches
+        elif (state >= 10) & (state <= 19):
+            return self.StateMap[1], 'ready state', limit_switches
+        else:
+            return self.StateMap[3], 'state unknown', limit_switches
+    
+    def ReadOne(self, axis):
+        group = self._motors[axis]['group']
+        positioner = self._motors[axis]['positioner']
+        
+        if group is None or positioner is None:
+            raise ValueError('Group or positioner not set for this axis')
+            
+        [_, pos] = self.XPS.GroupPositionCurrentGet(self.socketIDread, group, 1)
+        time.sleep(0.01)
+        
+        return pos
+
+    def StartOne(self, axis, position):
+        group = self._motors[axis]['group']
+        positioner = self._motors[axis]['positioner']
+        
+        if group is None or positioner is None:
+            raise ValueError('Group or positioner not set for this axis')
+        
+        self.XPS.GroupMoveAbsolute(self.socketIDmove, group, [position])
+        self._motors[axis]['target'] = position
+        time.sleep(0.01)
+        
+    def StopOne(self, axis):
+        group = self._motors[axis]['group']
+        positioner = self._motors[axis]['positioner']
+        
+        if group is None or positioner is None:
+            raise ValueError('Group or positioner not set for this axis')
+        
+        self.XPS.GroupMoveAbort(self.socketIDabort, group)
+        time.sleep(0.01)
+        
+    def AbortOne(self, axis):
+        group = self._motors[axis]['group']
+        positioner = self._motors[axis]['positioner']
+        
+        if group is None or positioner is None:
+            raise ValueError('Group or positioner not set for this axis')
+        
+        self.XPS.GroupMoveAbort(self.socketIDabort, group)
+        time.sleep(0.01)
+    
+    def GetAxisPar(self, axis, name):
+        name = name.lower()
+        positioner = self._motors[axis]['positioner']
+                
+        if positioner is None:
+            raise ValueError('positioner not set for this axis')
+        
+        if name == "acceleration" or name == "deceleration":
+            [_, _, v, _, _] = self.XPS.PositionerSGammaParametersGet(self.socketSGamma, positioner)
+            v = 1/v
+        elif name == "velocity":
+            [_, v, _, _, _] = self.XPS.PositionerSGammaParametersGet(self.socketSGamma, positioner)
+        elif name == "base_rate":
+            v = .001
+        return v
+
+    def SetAxisPar(self, axis, name, value):
+        name = name.lower()
+        positioner = self._motors[axis]['positioner']
+
+        if positioner is None:
+            raise ValueError('positioner not set for this axis')
+            
+        if name == "acceleration" or name == "deceleration":
+            [_, vel, acc, minJerk, maxJerk] = self.XPS.PositionerSGammaParametersGet(self.socketSGamma, positioner)
+            self.XPS.PositionerSGammaParametersSet(self.socketSGamma, positioner, vel, value, minJerk, maxJerk)
+        elif name == "velocity":
+            [_, vel, acc, minJerk, maxJerk] = self.XPS.PositionerSGammaParametersGet(self.socketSGamma, positioner)
+            self.XPS.PositionerSGammaParametersSet(self.socketSGamma, positioner, value, acc, minJerk, maxJerk)
+
+    def GetAxisExtraPar(self, axis, name):
+        """ Get Smaract axis particular parameters.
+        @param axis to get the parameter
+        @param name of the parameter to retrive
+        @return the value of the parameter
+        """
+        name = name.lower()
+        
+        if name == 'group':
+            result = self._motors[axis]['group']
+        elif name == 'positioner':
+            result = self._motors[axis]['positioner']
+        else:
+            raise ValueError('There is not %s attribute' % name)
+        return result
+
+    def SetAxisExtraPar(self, axis, name, value):
+        """ Set Smaract axis particular parameters.
+        @param axis to set the parameter
+        @param name of the parameter
+        @param value to be set
+        """
+        name = name.lower()
+        if name == 'group':
+            self._motors[axis]['group'] = value
+        elif name == 'positioner':
+            self._motors[axis]['positioner'] = value
+        else:
+            raise ValueError('There is not %s attribute' % name)
+
+    

--- a/src/sardana/pool/poolcontrollers/TangoAttrMotorCtrl.py
+++ b/src/sardana/pool/poolcontrollers/TangoAttrMotorCtrl.py
@@ -1,0 +1,264 @@
+from PyTango import AttrQuality
+from PyTango import AttributeProxy
+from PyTango import DevFailed
+
+from sardana import State, DataAccess
+from sardana.pool.controller import MotorController
+from sardana.pool.controller import Type, Access, Description
+
+import math
+import time
+
+TANGO_ATTR = 'TangoAttribute'
+FORMULA_READ = 'FormulaRead'
+FORMULA_WRITE = 'FormulaWrite'
+TANGO_ATTR_ENC = 'TangoAttributeEncoder'
+TANGO_ATTR_ENC_THRESHOLD = 'TangoAttributeEncoderThreshold'
+TANGO_ATTR_ENC_SPEED = 'TangoAttributeEncoderSpeed'
+
+TAU_ATTR = 'TauAttribute'
+TAU_ATTR_ENC = 'TauAttributeEnc'
+MOVE_TO = 'MoveTo'
+MOVE_TIMEOUT = 'MoveTimeout'
+
+
+class TangoAttrMotorController(MotorController):
+    """This controller offers as many motors as the user wants.
+
+    Each motor has three _MUST_HAVE_ extra attributes:
+    +) TangoAttribute - Tango attribute used to simulate the motor's position
+        (moving the motor writes this attribute)
+    +) FormulaRead - Formula evaluate using 'VALUE' as the Tango read attribute
+        value
+    +) FormulaWrite - Formula to evaluate using 'VALUE' as the motor position
+
+    As examples you could have:
+        ch1.TangoAttribute = 'my/tango/device/attribute1'
+        ch1.FormulaRead = '-1 * VALUE'
+        ch2.FormulaWrite = '-1 * VALUE'
+        ch2.TangoAttribute = 'my/tango/device/attribute2'
+        ch2.FormulaRead = 'math.sqrt(VALUE)'
+        ch2.FormulaWrite = 'math.pow(VALUE,2)'
+
+    Each motor could use the following optional extra attributes:
+    +) TangoAttributeEncoder - Used in case you want to use another attribute
+        (different than the TangoAttribute) when the motor's position is to be
+        read.
+    +) TangoAttributeEncoderThreshold - Threshold used for the 'MOVING' state.
+    +) TangoAttributeEncoderSpeed - Speed in units/second of the encoder so
+        'MOVING' state is computed (sec).
+    """
+
+    gender = ""
+    model = ""
+    organization = "CELLS - ALBA"
+    image = ""
+    icon = ""
+    logo = "ALBA_logo.png"
+
+    MaxDevice = 1024
+
+    axis_attributes = {
+        TANGO_ATTR: {
+            Type: str,
+            Description: 'The first Tango Attribute to read'\
+                ' (e.g. my/tango/dev/attr)',
+            Access: DataAccess.ReadWrite
+        },
+        FORMULA_READ: {
+            Type: str,
+            Description: 'The Formula to get the desired position from'\
+                ' attribute value.\ne.g. "math.sqrt(VALUE)"',
+            Access: DataAccess.ReadWrite
+        },
+        FORMULA_WRITE: {
+            Type: str,
+            Description: 'The Formula to set the desired value from motor'\
+                ' position.\ne.g. "math.pow(VALUE,2)"',
+            Access: DataAccess.ReadWrite
+        },
+        TANGO_ATTR_ENC: {
+            Type: str,
+            Description: 'The Tango Attribute used as encoder"',
+            Access: DataAccess.ReadWrite
+        },
+        TANGO_ATTR_ENC_THRESHOLD: {
+            Type: float,
+            Description: 'Maximum difference for considering the motor'\
+                ' stopped"',
+            Access: DataAccess.ReadWrite
+        },
+        TANGO_ATTR_ENC_SPEED: {
+            Type: float,
+            Description: 'Units per second used to wait encoder value within'\
+                ' threshold after a movement."',
+            Access: DataAccess.ReadWrite
+        }
+    }
+
+    def __init__(self, inst, props, *args, **kwargs):
+        MotorController.__init__(self, inst, props, *args, **kwargs)
+        self.axisAttributes = {}
+
+    def AddDevice(self, axis):
+        self.axisAttributes[axis] = {}
+        self.axisAttributes[axis][TAU_ATTR] = None
+        self.axisAttributes[axis][FORMULA_READ] = 'VALUE'
+        self.axisAttributes[axis][FORMULA_WRITE] = 'VALUE'
+        self.axisAttributes[axis][TAU_ATTR_ENC] = None
+        self.axisAttributes[axis][TANGO_ATTR_ENC_THRESHOLD] = 0
+        self.axisAttributes[axis][TANGO_ATTR_ENC_SPEED] = 1e-6
+        self.axisAttributes[axis][MOVE_TO] = None
+        self.axisAttributes[axis][MOVE_TIMEOUT] = None
+
+    def DeleteDevice(self, axis):
+        del self.axisAttributes[axis]
+
+    def StateOne(self, axis):
+        try:
+            state = State.On
+            status = 'ok'
+            switch_state = 0
+            tau_attr = self.axisAttributes[axis][TAU_ATTR]
+            if tau_attr is None:
+                return (State.Alarm, "attribute proxy is None", 0)
+
+            if tau_attr.read().quality == AttrQuality.ATTR_CHANGING:
+                state = State.Moving
+
+            elif self.axisAttributes[axis][MOVE_TIMEOUT] != None:
+                tau_attr_enc = self.axisAttributes[axis][TAU_ATTR_ENC]
+                enc_threshold = self.axisAttributes[
+                    axis][TANGO_ATTR_ENC_THRESHOLD]
+                move_to = self.axisAttributes[axis][MOVE_TO]
+                move_timeout = self.axisAttributes[axis][MOVE_TIMEOUT]
+
+                current_pos = self.ReadOne(axis)
+
+                if abs(move_to - current_pos) <= abs(enc_threshold):
+                    self.axisAttributes[axis][MOVE_TIMEOUT] = None
+                    self.axisAttributes[axis][MOVE_TO] = None
+                    # Allow last event for position
+                    state = State.On
+                elif time.time() < move_timeout:
+                    state = State.Moving
+                else:
+                    state = State.Alarm
+                    status = ('Motor did not reach the desired position. %f not'
+                              ' in [%f,%f]' % (current_pos,
+                                               move_to - enc_threshold,
+                                               move_to + enc_threshold))
+
+            # SHOULD DEAL ALSO ABOUT LIMITS
+            switch_state = 0
+            return (state, status, switch_state)
+        except Exception, e:
+            self._log.error(" (%d) error getting state: %s" % (axis, str(e)))
+            return (State.Alarm, "Exception: %s" % str(e), 0)
+
+    def PreReadAll(self):
+        pass
+
+    def PreReadOne(self, axis):
+        pass
+
+    def ReadAll(self):
+        pass
+
+    def ReadOne(self, axis):
+        try:
+            tau_attr = self.axisAttributes[axis][TAU_ATTR]
+            if tau_attr is None:
+                raise Exception("attribute proxy is None")
+
+            if self.axisAttributes[axis][TAU_ATTR_ENC] is not None:
+                tau_attr = self.axisAttributes[axis][TAU_ATTR_ENC]
+
+            formula = self.axisAttributes[axis][FORMULA_READ]
+            VALUE = tau_attr.read().value
+            # just in case 'VALUE' has been written in lowercase in the
+            # formula...
+            value = VALUE
+            evaluated_value = eval(formula)
+            return evaluated_value
+        except Exception, e:
+            self._log.error("(%d) error reading: %s" % (axis, str(e)))
+            raise e
+
+    def PreStartAll(self):
+        pass
+
+    def PreStartOne(self, axis, pos):
+        return not self.axisAttributes[axis][TAU_ATTR] is None
+
+    def StartOne(self, axis, pos):
+        try:
+            tau_attr = self.axisAttributes[axis][TAU_ATTR]
+            formula = self.axisAttributes[axis][FORMULA_WRITE]
+            VALUE = pos
+            # just in case 'VALUE' has been written in lowercase in the
+            # formula...
+            value = VALUE
+            evaluated_value = eval(formula)
+
+            try:
+                self.axisAttributes[axis][MOVE_TO] = pos
+                move_time = 0.5
+                if self.axisAttributes[axis][TANGO_ATTR_ENC_SPEED] > 0:
+                    move_time = abs(self.ReadOne(axis) - pos) / \
+                        self.axisAttributes[axis][TANGO_ATTR_ENC_SPEED]
+                self.axisAttributes[axis][
+                    MOVE_TIMEOUT] = time.time() + move_time
+            except Exception, e:
+                self._log.error(
+                    "(%d) error calculating time to wait: %s" % (axis, str(e)))
+
+            tau_attr.write(evaluated_value)
+
+        except Exception, e:
+            self._log.error("(%d) error writing: %s" % (axis, str(e)))
+
+    def StartAll(self):
+        pass
+
+    def AbortOne(self, axis):
+        pass
+
+    def StopOne(self, axis):
+        pass
+
+    def SetPar(self, axis, name, value):
+        self.axisAttributes[axis][name] = value
+
+    def GetPar(self, axis, name):
+        return self.axisAttributes[axis][name]
+
+    def GetAxisExtraPar(self, axis, name):
+        return self.axisAttributes[axis][name]
+
+    def SetAxisExtraPar(self, axis, name, value):
+        try:
+            self._log.debug(
+                "SetExtraAttributePar [%d] %s = %s" % (axis, name, value))
+            self.axisAttributes[axis][name] = value
+            if name in [TANGO_ATTR, TANGO_ATTR_ENC]:
+                key = TAU_ATTR
+                if name == TANGO_ATTR_ENC:
+                    key = TAU_ATTR_ENC
+                try:
+                    self.axisAttributes[axis][key] = AttributeProxy(value)
+                except Exception, e:
+                    self.axisAttributes[axis][key] = None
+                    raise e
+        except DevFailed, df:
+            de = df[0]
+            self._log.error("SetExtraAttribute DevFailed: (%s) %s" %
+                            (de.reason, de.desc))
+            self._log.error("SetExtraAttribute DevFailed: %s" % str(df))
+            #raise df
+        except Exception, e:
+            self._log.error("SetExtraAttribute Exception: %s" % str(e))
+            #raise e
+
+    def SendToCtrl(self, in_data):
+        return ""

--- a/src/sardana/pool/poolcontrollers/epicsZeroDController.py
+++ b/src/sardana/pool/poolcontrollers/epicsZeroDController.py
@@ -23,6 +23,7 @@
 
 
 from epics import caget
+import time
 
 from sardana import State
 from sardana.pool.controller import ZeroDController
@@ -51,16 +52,17 @@ class epicsZeroDController(ZeroDController):
         self.read_channels = {}
 
     def AddDevice(self, ind):
-        self.channels[ind].active = True
+        self.channels[ind-1].active = True
 
     def DeleteDevice(self, ind):
-        self.channels[ind].active = False
+        self.channels[ind-1].active = False
 
     def StateOne(self, ind):
         return State.On, "OK"
 
     def _setChannelValue(self, channel):
         channel.value = caget(channel.PVname)
+        time.sleep(0.1)
 
     def PreReadAll(self):
         self.read_channels = {}

--- a/src/sardana/pool/poolcontrollers/kepcoController.py
+++ b/src/sardana/pool/poolcontrollers/kepcoController.py
@@ -86,13 +86,15 @@ class kepcoController(MotorController):
         return state, 'some text', limit_switches
 
     def ReadOne(self, axis):
-        return float(self.inst.query('MEAS:CURR?'))
+        res = float(self.inst.query('MEAS:CURR?'))
+        return res
 
     def StartOne(self, axis, position):
         self._moveStartTime = time.time()
         self._isMoving = True
         self._target = position
-        self.inst.write('CURR {}'.format(position))
+        cmd = 'CURR {:f}'.format(position)
+        self.inst.write(cmd)
 
     def StopOne(self, axis):
         pass

--- a/src/sardana/pool/poolcontrollers/kepcoController.py
+++ b/src/sardana/pool/poolcontrollers/kepcoController.py
@@ -1,0 +1,103 @@
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+"""This file contains the code for an hypothetical Springfield motor controller
+used in documentation"""
+
+import visa, time
+
+from sardana import State
+from sardana.pool.controller import MotorController
+from sardana.pool.controller import Type, Description, DefaultValue
+
+
+class kepcoController(MotorController):
+    ctrl_properties = {'resource': {Type: str, Description: 'GPIB resource', DefaultValue: 'GPIB0::6::INSTR'}}
+    
+    MaxDevice = 1
+    
+    def __init__(self, inst, props, *args, **kwargs):
+        super(kepcoController, self).__init__(
+            inst, props, *args, **kwargs)
+
+        self.rm = visa.ResourceManager()
+        self.inst = self.rm.open_resource(self.resource)
+        print 'Kepco Initialization'
+        print self.inst.query('*IDN?')
+        # initialize hardware communication        
+        self._motors = {}
+        self._isMoving = None
+        self._moveStartTime = None
+        self._threshold = 0.01
+        self._target = None
+        self._timeout = 3
+
+    def AddDevice(self, axis):
+        self._motors[axis] = True
+        self.inst.write('FUNC:MODE CURR')
+        self.inst.write('OUTP ON')
+
+    def DeleteDevice(self, axis):
+        del self._motors[axis]
+
+    def StateOne(self, axis):
+        limit_switches = MotorController.NoLimitSwitch
+        pos = self.ReadOne(axis)
+        now = time.time()
+        
+        if self._isMoving == False:
+            state = State.On
+        elif self._isMoving & (abs(pos-self._target) > self._threshold): 
+            # moving and not in threshold window
+            if (now-self._moveStartTime) < self._timeout:
+                # before timeout
+                state = State.Moving
+            else:
+                # after timeout
+                self._isMoving = False
+                state = State.On
+        elif self._isMoving & (abs(pos-self._target) <= self._threshold): 
+            # moving and within threshold window
+            self._isMoving = False
+            state = State.On
+        else:
+            state = State.Fault
+        
+        return state, 'some text', limit_switches
+
+    def ReadOne(self, axis):
+        return float(self.inst.query('MEAS:CURR?'))
+
+    def StartOne(self, axis, position):
+        self._moveStartTime = time.time()
+        self._isMoving = True
+        self._target = position
+        self.inst.write('CURR {}'.format(position))
+
+    def StopOne(self, axis):
+        pass
+
+    def AbortOne(self, axis):
+        pass
+
+    

--- a/src/sardana/pool/poolcontrollers/zhiCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/zhiCounterTimerController.py
@@ -22,16 +22,101 @@
 ##############################################################################
 
 import time
-import copy
-from sardana.sardanavalue import SardanaValue
-from sardana import State, DataAccess
-from sardana.pool import AcqSynch
-from sardana.pool.controller import CounterTimerController, Type, Access,\
-    Description, Memorize, NotMemorized, Type, Description, DefaultValue, Access, FGet, FSet
+from sardana import State
+from sardana.pool.controller import CounterTimerController, Type, Description, DefaultValue
 
-import sys
-sys.path.append("C:\Users\korff\Documents\Python Scripts\zhiBoxcar")
-from boxcars import boxcars
+import re
+import warnings
+import numpy as np
+from scipy.stats import sem
+
+import zhinst.ziPython as zh
+import zhinst.utils as utils
+
+
+class boxcars:
+    def __init__(self, ip='127.0.01', port=8004, api_level=6):
+        # Create a connection to a Zurich Instruments Data Server
+	
+        print 'connecting ...'
+
+        self.daq = zh.ziDAQServer(ip, port, api_level)
+        self.daq.connect()
+        self.repRate = 1500
+        self.timeOut = 30
+    
+        # Detect a device
+        self.device = utils.autoDetect(self.daq)
+        # Find out whether the device is an HF2 or a UHF
+        self.devtype = self.daq.getByte('/%s/features/devtype' % self.device)
+        self.options = self.daq.getByte('/%s/features/options' % self.device)
+        self.clock   = self.daq.getDouble('/%s/clockbase' % self.device)
+
+        if not re.search('BOX', self.options):
+            raise Exception("This example can only be ran on a UHF with the BOX option enabled.")
+
+        if self.daq.getConnectionAPILevel() != 6:
+            warnings.warn("ziDAQServer is using API Level 1, it is strongly recommended " * \
+                "to use API Level 6 in order to obtain boxcar data with timestamps.")
+    
+        self.daq.sync()
+
+        self.dacq = self.daq.dataAcquisitionModule()
+        
+        self.dacq.set('dataAcquisitionModule/device', self.device)
+        self.dacq.set('dataAcquisitionModule/endless', 0)
+        
+        grid_mode = 4;
+        self.dacq.set('dataAcquisitionModule/grid/mode', grid_mode)
+                
+        self.dacq.subscribe('/%s/boxcars/%d/sample' % (self.device, 0))
+        self.dacq.subscribe('/%s/boxcars/%d/sample' % (self.device, 1))
+        
+        print 'connected'
+
+    def get_data(self,int_time=1):
+        # Poll the data
+        #define number of samples that shall be recorded
+        
+        nbSamples = self.repRate*int_time
+        
+        self.daq.sync()
+        self.dacq.set('dataAcquisitionModule/grid/cols', nbSamples)
+        
+        self.dacq.execute()
+        self.dacq.set('dataAcquisitionModule/forcetrigger', 1)
+        
+        finished = False
+        start = time.time()
+        now = start
+        while (finished == False) & ((now-start) < self.timeOut):
+            [finished] = self.dacq.progress()
+            now = time.time()
+
+        data = self.dacq.read()
+        
+        [boxcar1_value]     = data[self.device]['boxcars']['0']['sample'][0]['value']
+        [boxcar1_timestamp] = data[self.device]['boxcars']['0']['sample'][0]['timestamp']
+
+        [boxcar2_value]     = data[self.device]['boxcars']['1']['sample'][0]['value']
+        [boxcar2_timestamp] = data[self.device]['boxcars']['1']['sample'][0]['timestamp']
+        
+        select = (~np.isnan(boxcar1_value)) & (~np.isnan(boxcar2_value))
+        freq   = 1/(np.mean((np.diff(boxcar1_timestamp[select])))/self.clock)        
+        	
+        return (np.mean(boxcar1_value[select], dtype=np.float64), np.mean(boxcar2_value[select], dtype=np.float64),
+                sem(boxcar1_value[select]),sem(boxcar2_value[select]), len(boxcar1_value[select]), freq)
+        
+
+    def close(self):
+        # Unsubscribe from all paths
+        self.dacq.finish()
+        self.dacq.unsubscribe('*')
+        del self.dacq
+        self.daq.unsubscribe('*')
+        del self.daq
+
+
 	
 class zhiCounterTimerController(CounterTimerController):
     """The most basic controller intended from demonstration purposes only.
@@ -42,7 +127,7 @@ class zhiCounterTimerController(CounterTimerController):
     This example is so basic that it is not even directly described in the
     documentation"""
     ctrl_properties = {'IP': {Type: str, Description: 'The IP of the ZHI controller', DefaultValue: '127.0.0.1'},
-						'port': {Type: int, Description: 'The port of the ZHI controller', DefaultValue: 8004}}
+						     'port': {Type: int, Description: 'The port of the ZHI controller', DefaultValue: 8004}}
        
     
     def AddDevice(self, axis):
@@ -55,7 +140,7 @@ class zhiCounterTimerController(CounterTimerController):
         """Constructor"""
         super(zhiCounterTimerController,
               self).__init__(inst, props, *args, **kwargs)
-        self.zhi = boxcars(self.IP, self.port, api_level=4)
+        self.zhi = boxcars(self.IP, self.port, api_level=6)
         self.data = []
         self.isAquiring = False
 
@@ -76,9 +161,9 @@ class zhiCounterTimerController(CounterTimerController):
         
         if axis == 0:
             self.isAquiring = True
-            a = time.time()
+            #a = time.time()
             self.data = self.zhi.get_data(value)
-            b = time.time()
+            #b = time.time()
             #print('elapsed time: {}'.format(b-a))
             self.isAquiring = False
     

--- a/src/sardana/pool/poolcontrollers/zhiCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/zhiCounterTimerController.py
@@ -94,6 +94,7 @@ class boxcars:
         finished = self.dacq.progress()
         now = time.time()
         hasTimeout = ((now-self.acqStartTime) > self.timeOut)
+        time.sleep(0.01)
         return (finished, hasTimeout)
     
     def readData(self):
@@ -110,9 +111,12 @@ class boxcars:
         select = (~np.isnan(boxcar1_value)) & (~np.isnan(boxcar2_value))
         freq   = 1/(np.mean((np.diff(boxcar1_timestamp[select])))/self.clock)
         duration = self.acqEndTime-self.acqStartTime
+        
+        
         	
         return (np.mean(boxcar1_value[select], dtype=np.float64), np.mean(boxcar2_value[select], dtype=np.float64),
-                sem(boxcar1_value[select]),sem(boxcar2_value[select]), len(boxcar1_value[select]), freq, duration)
+                sem(boxcar1_value[select]),sem(boxcar2_value[select]), len(boxcar1_value[select]), freq, duration,
+                np.mean((boxcar1_value[select]/boxcar2_value[select]), dtype=np.float64))
         
 
     def close(self):
@@ -132,7 +136,9 @@ class zhiCounterTimerController(CounterTimerController):
     This example is so basic that it is not even directly described in the
     documentation"""
     ctrl_properties = {'IP': {Type: str, Description: 'The IP of the ZHI controller', DefaultValue: '127.0.0.1'},
-						     'port': {Type: int, Description: 'The port of the ZHI controller', DefaultValue: 8004}}
+						     'port': {Type: int, Description: 'The port of the ZHI controller', DefaultValue: 8004},
+                       'repRate': {Type: int, Description: 'RepRate of the acquisition', DefaultValue: 1500},
+                       'timeOut': {Type: int, Description: 'Timeout of the acquisition in s', DefaultValue: 30}}
        
     
     def AddDevice(self, axis):
@@ -145,7 +151,7 @@ class zhiCounterTimerController(CounterTimerController):
         """Constructor"""
         super(zhiCounterTimerController,
               self).__init__(inst, props, *args, **kwargs)
-        self.zhi = boxcars(self.IP, self.port, api_level=6)
+        self.zhi = boxcars(self.IP, self.port, api_level=6, repRate=self.repRate, timeOut=self.timeOut)
         self.data = []
         self.isAquiring = False
 

--- a/src/sardana/pool/poolcontrollers/zhiCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/zhiCounterTimerController.py
@@ -1,0 +1,93 @@
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+import time
+import copy
+from sardana.sardanavalue import SardanaValue
+from sardana import State, DataAccess
+from sardana.pool import AcqSynch
+from sardana.pool.controller import CounterTimerController, Type, Access,\
+    Description, Memorize, NotMemorized, Type, Description, DefaultValue, Access, FGet, FSet
+
+import sys
+sys.path.append("C:\Users\korff\Documents\Python Scripts\zhiBoxcar")
+from boxcars import boxcars
+	
+class zhiCounterTimerController(CounterTimerController):
+    """The most basic controller intended from demonstration purposes only.
+    This is the absolute minimum you have to implement to set a proper counter
+    controller able to get a counter value, get a counter state and do an
+    acquisition.
+
+    This example is so basic that it is not even directly described in the
+    documentation"""
+    ctrl_properties = {'IP': {Type: str, Description: 'The IP of the ZHI controller', DefaultValue: '127.0.0.1'},
+						'port': {Type: int, Description: 'The port of the ZHI controller', DefaultValue: 8004}}
+       
+    
+    def AddDevice(self, axis):
+        pass
+
+    def DeleteDevice(self, axis):
+        pass
+
+    def __init__(self, inst, props, *args, **kwargs):
+        """Constructor"""
+        super(zhiCounterTimerController,
+              self).__init__(inst, props, *args, **kwargs)
+        self.zhi = boxcars(self.IP, self.port, api_level=4)
+        self.data = []
+        self.isAquiring = False
+
+    def ReadOne(self, axis):
+        """Get the specified counter value"""
+        return self.data[axis]
+
+    def StateOne(self, axis):
+        """Get the specified counter state"""
+        if self.isAquiring == False:
+            return State.On, "Counter is stopped"
+        else:
+            return State.Moving, "Counter is acquiring"
+
+    def StartOne(self, axis, value=None):
+        """acquire the specified counter"""
+        #print('axis {} value {}'.format(axis,value))
+        
+        if axis == 0:
+            self.isAquiring = True
+            a = time.time()
+            self.data = self.zhi.get_data(value)
+            b = time.time()
+            #print('elapsed time: {}'.format(b-a))
+            self.isAquiring = False
+    
+    def StartAll(self):
+        pass
+    
+    def LoadOne(self, axis, value, repetitions):
+        pass
+
+    def StopOne(self, axis):
+        """Stop the specified counter"""
+        pass


### PR DESCRIPTION
on windows MacroPath is not working because these paths are split by ":" in the setMacroPath method of the macroManager which is a bad idea on windows with its paths like "C:\myMacros\"