### PR TITLE
change epoch from float to formatted date time

### DIFF
--- a/src/sardana/macroserver/recorders/storage.py
+++ b/src/sardana/macroserver/recorders/storage.py
@@ -312,7 +312,7 @@ class SPEC_FileRecorder(BaseFileRecorder):
 
         # datetime object
         start_time = env['starttime']
-        epoch = time.mktime(start_time.timetuple())
+        epoch = time.strftime("%a %b %d %H:%M:%S %Y", start_time.timetuple())
         serialno = env['serialno']
 
         # store names for performance reason


### PR DESCRIPTION
when using xrayutilities one cannot read the spec file written by Sardana because the "#D" field is not in date time format like "Sun May 17 08:09:19 2015"
This is also the way SPEC is saving the "#D" field