### PR TITLE
[WIP] Propagate keyboard interrupt exception

### DIFF
--- a/src/sardana/spock/spockms.py
+++ b/src/sardana/spock/spockms.py
@@ -342,6 +342,7 @@ class SpockBaseDoor(BaseDoor):
             self.block_lines = 0
             self.stop()
             self.writeln("Done!")
+            raise KeyboardInterrupt()
         except PyTango.DevFailed, e:
             if is_non_str_seq(e.args) and \
                not isinstance(e.args, (str, unicode)):


### PR DESCRIPTION
If you run on spock a loop and call a macro inside it, it is not possible to abort the loop with one Ctrl-C.

```
for i in range(10):
    %ct
```
If we propagate the keyboard interruption to the ipython it is possible abort the loop. In addition, it can allow to execute ipython scripts with the magic command %run and abort it.
