### PR TITLE
Fix generic intervals estimation

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -799,27 +799,31 @@ class GScan(Logger):
         interval_nb = 0
         try:
             if not with_time:
-                start_pos = self.motion.readPosition(force=True)
-                v_motors = self.get_virtual_motors()
-                motion_time, acq_time = 0.0, 0.0
-                while interval_nb < max_iter:
-                    step = iterator.next()
-                    end_pos = step['positions']
-                    max_path_duration = 0.0
-                    for v_motor, start, stop in zip(v_motors,
-                                                    start_pos,
-                                                    end_pos):
-                        path = MotionPath(v_motor, start, stop)
-                        max_path_duration = max(
-                            max_path_duration, path.duration)
-                    integ_time = step.get("integ_time", 0.0)
-                    acq_time += integ_time
-                    motion_time += max_path_duration
-                    total_time += integ_time + max_path_duration
-                    interval_nb += 1
-                    start_pos = end_pos
-                if with_interval:
-                    interval_nb = self.macro.getIntervalEstimation()
+                try:
+                    start_pos = self.motion.readPosition(force=True)
+                    v_motors = self.get_virtual_motors()
+                    motion_time, acq_time = 0.0, 0.0
+                    while interval_nb < max_iter:
+                        step = iterator.next()
+                        end_pos = step['positions']
+                        max_path_duration = 0.0
+                        for v_motor, start, stop in zip(v_motors,
+                                                        start_pos,
+                                                        end_pos):
+                            path = MotionPath(v_motor, start, stop)
+                            max_path_duration = max(
+                                max_path_duration, path.duration)
+                        integ_time = step.get("integ_time", 0.0)
+                        acq_time += integ_time
+                        motion_time += max_path_duration
+                        total_time += integ_time + max_path_duration
+                        interval_nb += 1
+                        start_pos = end_pos
+                except StopIteration:
+                    raise
+                finally:
+                    if with_interval:
+                        interval_nb = self.macro.getIntervalEstimation()
             else:
                 while interval_nb < max_iter:
                     step = iterator.next()

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -820,8 +820,6 @@ class GScan(Logger):
                         total_time += integ_time + max_path_duration
                         point_nb += 1
                         start_pos = end_pos
-                except StopIteration:
-                    raise
                 finally:
                     if with_interval:
                         interval_nb = self.macro.getIntervalEstimation()
@@ -830,8 +828,6 @@ class GScan(Logger):
                     while point_nb < max_iter:
                         step = iterator.next()
                         point_nb += 1
-                except StopIteration:
-                    raise
                 finally:
                     total_time = self.macro.getTimeEstimation()
         except StopIteration:

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -826,6 +826,7 @@ class GScan(Logger):
                     interval_nb += 1
                 total_time = self.macro.getTimeEstimation()
         except StopIteration:
+            interval_nb -= 1
             return total_time, interval_nb
         # max iteration reached.
         return -total_time, -interval_nb

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -825,10 +825,14 @@ class GScan(Logger):
                     if with_interval:
                         interval_nb = self.macro.getIntervalEstimation()
             else:
-                while interval_nb < max_iter:
-                    step = iterator.next()
-                    interval_nb += 1
-                total_time = self.macro.getTimeEstimation()
+                try:
+                    while interval_nb < max_iter:
+                        step = iterator.next()
+                        interval_nb += 1
+                except StopIteration:
+                    raise
+                finally:
+                    total_time = self.macro.getTimeEstimation()
         except StopIteration:
             interval_nb -= 1
             return total_time, interval_nb


### PR DESCRIPTION
The generic intervals estimation is used on the mesh and dmesh scans. The method returns the numbers of point and not the number of intervals. On the other scans: aNscan, aNscanct, meshct, etc. the value returned corresponds to the intervals and not to the scan points.
