### PR TITLE
Correcting lsgh if macro several times in same hook position

### DIFF
--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -323,8 +323,7 @@ class lsgh(Macro):
             for place in places:
                 if place not in default_dict.keys():
                     default_dict[place] = []
-                if name not in default_dict[place]:
-                    default_dict[place].append(name)
+                default_dict[place].append(name)
         for pos in default_dict.keys():
             pos_set = 0
             for hook in default_dict[pos]:


### PR DESCRIPTION
The macro lsgh was listing each hook macro only once, even if it was added several times in the same
positon, but the macro was called so many times as it was added. This PR makes consistent the lsgh with what is happening.