### PR TITLE
Add public access to data_handler in GScan

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -835,6 +835,10 @@ class GScan(Logger):
         return self._data
 
     @property
+    def data_handler(self):
+        return self._data_handler
+
+    @property
     def macro(self):
         return self._macro
 


### PR DESCRIPTION
As agreen in #711 we need a public access to data_handler object of `GScan`, for example for adding
custom data. Add a read only property.

Whenever integrated we should change the examples accessing to it via `_data_handler` protected member e.g. `ascan_with_addcustomdata` macro.
