### PR TITLE
Deprecate PoolMotorSlim in favor of PoolMotorTV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ This file follows the formats and conventions from [keepachangelog.com]
 - Change epoch from float to formatted date & time in Spec recorder (#766)
 
 ### Deprecated
-- `Controller.getUsedAxis` (Taurus device extension) is deprecated in favor
+- `PoolMotorSlim` widget in favor of `PoolMotorTV` widget (#163, #785) 
+- `Controller.getUsedAxis` (Taurus device extension) in favor
 of `Controller.getUsedAxes` (#609)
 
 ## [2.4.0] 2018-03-14

--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -309,6 +309,9 @@ class PoolMotorSlim(TaurusWidget, PoolMotorClient):
 
     def __init__(self, parent=None, designMode=False):
         TaurusWidget.__init__(self, parent)
+        msg = ("PoolMotorSlim is deprecated since Jul18. Use PoolMotorTV "
+               "instead.")
+        self.deprecated(msg)
 
         #self.call__init__wo_kw(Qt.QWidget, parent)
         #self.call__init__(TaurusBaseWidget, str(self.objectName()), designMode=designMode)


### PR DESCRIPTION
PoolMotorSlim is an old widget for controlling motors that was
developed before TaurusForm and TaurusValues existed. PoolMotorTV
is the modern alternative to PoolMotorSlim. It was discussed several
times that PoolMotorSlim should be deprecated, for example in #163, so
deprecate it now.