### PR TITLE
Allow function generation when group has 1 repeat only

### DIFF
--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -38,6 +38,7 @@ def strictly_increasing(l):
     """Check whether list l has strictly increasing values"""
     return all(x < y for x, y in zip(l, l[1:]))
 
+
 def strictly_decreasing(l):
     """Check whether list l has strictly deacreasing values"""
     return all(x > y for x, y in zip(l, l[1:]))

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -339,19 +339,18 @@ class FunctionGenerator(EventGenerator, Logger):
                     passive_events.append(passive_event)
                     active_event_in_initial_domain += total_in_initial_domain
                     active_event_in_active_domain += total_in_active_domain
-                # determine direction
-                direction = 1
-                if total_in_initial_domain < 0:
-                    direction = -1
-                if self.direction is None:
-                    self.direction = direction
-                elif self.direction != direction:
-                    msg = "active values indicate contradictory directions"
-                    raise ValueError(msg)
             else:
                 active_events.append(active_event_in_initial_domain)
                 passive_event = active_event_in_active_domain + active
                 passive_events.append(passive_event)
+
+        # determine direction
+        if self.direction is None:
+            if strictly_increasing(active_events):
+                self.direction = 1
+            elif strictly_decreasing(active_events):
+                self.direction = -1
+            else:
                 msg = "active values indicate contradictory directions"
                 raise ValueError(msg)
 

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -288,9 +288,9 @@ class FunctionGenerator(EventGenerator, Logger):
             initial_param = group.get(Initial)
             if initial_param is None:
                 initial_param = dict()
-            if not initial_param.has_key(Time):
+            if Time not in initial_param:
                 delay_param = group.get(Delay)
-                if delay_param.has_key(Time):
+                if Time in delay_param:
                     initial_param[Time] = delay_param[Time]
                 group[Initial] = initial_param
             # determine active domain in use
@@ -316,7 +316,7 @@ class FunctionGenerator(EventGenerator, Logger):
                     self.active_domain_in_use = Position
                 else:
                     raise ValueError(msg)
-            elif active_param.has_key(self.active_domain):
+            elif self.active_domain in active_param:
                 self.active_domain_in_use = self.active_domain
             else:
                 raise ValueError(msg)

--- a/src/sardana/util/funcgenerator.py
+++ b/src/sardana/util/funcgenerator.py
@@ -34,6 +34,15 @@ from sardana.pool.pooldefs import SynchParam, SynchDomain
 from taurus.core.util.log import Logger
 
 
+def strictly_increasing(l):
+    """Check whether list l has strictly increasing values"""
+    return all(x < y for x, y in zip(l, l[1:]))
+
+def strictly_decreasing(l):
+    """Check whether list l has strictly deacreasing values"""
+    return all(x > y for x, y in zip(l, l[1:]))
+
+
 class FunctionGenerator(EventGenerator, Logger):
     """Generator of active and passive events describing a rectangular
     function.


### PR DESCRIPTION
Allow function generation when group has 1 repeat only

When group has one repeat only the generation of active and passive events
is much simpler. It requires only Initial and Active parameters and Total
parameter is not needed. Implement different algorithm of generation of
events when repeats is 1.

Any @sardana-org/integrators could take a look on this, please?