### PR TITLE
Continuous scans may loose data

### DIFF
--- a/src/sardana/macroserver/scan/scandata.py
+++ b/src/sardana/macroserver/scan/scandata.py
@@ -38,7 +38,6 @@ from taurus.core import TaurusElementType
 from taurus import Release as taurus_release
 
 from sardana.macroserver.scan.recorder import DataHandler
-from threading import RLock
 
 
 class ColumnDesc(object):
@@ -310,7 +309,6 @@ class RecordList(dict):
         else:
             self.environ = environ
         self.records = []
-        self.rlock = RLock()
         # currentIndex indicates the place in the records list
         # where the next completed record will be written
         self.currentIndex = 0
@@ -447,25 +445,24 @@ class RecordList(dict):
         :param data: dictionary with two mandatory elements: label - string
                      and data - list of values
         :type data:  dict"""
-        with self.rlock:
-            label = data['label']
-            rawData = data['data']
-            idxs = data['index']
+        label = data['label']
+        rawData = data['data']
+        idxs = data['index']
 
-            maxIdx = max(idxs)
-            recordsLen = len(self.records)
-            # Calculate missing records
-            missingRecords = recordsLen - (maxIdx + 1)
-            # TODO: implement proper handling of timestamps and moveables
-            if missingRecords < 0:
-                missingRecords = abs(missingRecords)
-                self.initRecords(missingRecords)
-            for idx, value in zip(idxs, rawData):
-                rc = self.records[idx]
-                rc.setRecordNo(idx)
-                rc.data[label] = value
-                self.columnIndexDict[label] = idx + 1
-            self.tryToAdd(idx, label)
+        maxIdx = max(idxs)
+        recordsLen = len(self.records)
+        # Calculate missing records
+        missingRecords = recordsLen - (maxIdx + 1)
+        # TODO: implement proper handling of timestamps and moveables
+        if missingRecords < 0:
+            missingRecords = abs(missingRecords)
+            self.initRecords(missingRecords)
+        for idx, value in zip(idxs, rawData):
+            rc = self.records[idx]
+            rc.setRecordNo(idx)
+            rc.data[label] = value
+            self.columnIndexDict[label] = idx + 1
+        self.tryToAdd(idx, label)
 
     def tryToAdd(self, idx, label):
         start = self.currentIndex

--- a/src/sardana/macroserver/scan/test/test_recorddata.py
+++ b/src/sardana/macroserver/scan/test/test_recorddata.py
@@ -69,6 +69,12 @@ class ScanDataTestCase(unittest.TestCase):
             self.nxs = nxs
         except ImportError:
             self.skipTest("nxs module is not available")
+        # In real world addData are always called sequentially.
+        # This test was developed assuming that these may arrive in
+        # parallel and that addData would protect the critical section, this
+        # is no more the case.
+        self.skipTest("this test wrongly assumes that data may arrive in "
+                      "parallel")
 
         unittest.TestCase.setUp(self)
         self.data_handler = DataHandler()


### PR DESCRIPTION
In one of our setups using continuous scans we found that sporadically the hardware synchronized channels were loosing data but the scan was correctly finishing. With the involved hardware this is not possible and was pointing to a bug in software.

After some debugging we found a wrong implementation on handling the value buffer (data) events on the MacroServer side - see 92dc5c6 comment for more detail.

This issue can be reproduced with the following simplified snippet, when while executing one would see "i is different than idx" messages:

```python
import time
import threading
from sardana.sardanathreadpool import get_thread_pool

pool = get_thread_pool()


lock = threadingLock()
idx = 0


def job(i):
    global idx
    with lock:
        print "Entering critical section of job %d" % i
        if i != idx:
            print "i is different than idx"
        idx += 1
        time.sleep(0.5)
        print "Leaving critical section of job %d" % i


for k in xrange(1000):
    pool.add(job, None, k)

time.sleep(1000)

```

And can be fixed by using a dedicated pool with only one thread where while executing the above messages are not printed:

```python
import time
import threading
from taurus.core.util.threadpool import ThreadPool


__thread_pool_lock = threading.Lock()
__thread_pool = None


def get_thread_pool():
    global __thread_pool

    if __thread_pool:
        return __thread_pool

    global __thread_pool_lock
    with __thread_pool_lock:
        if __thread_pool is None:
            __thread_pool = ThreadPool(name="ValueBufferTH", Psize=1,
                                       Qsize=100000)
        return __thread_pool


pool = get_thread_pool()


lock = threading.Lock()
idx = 0


def job(i):
    global idx
    with lock:
        print "Entering critical section of job %d" % i
        if i != idx:
            print "i is different than idx"
        idx += 1
        time.sleep(0.5)
        print "Leaving critical section of job %d" % i


for k in xrange(1000):
    pool.add(job, None, k)

time.sleep(1000)

```