### PR TITLE
Add configuration attribute to DiscretePseudoMotorController

### DIFF
--- a/src/sardana/macroserver/macros/discrete.py
+++ b/src/sardana/macroserver/macros/discrete.py
@@ -23,7 +23,7 @@
 
 """ Discrete pseudo motor controller configuration related macros"""
 
-__all__ = ["def_dpm_pos", "udef_dpm_pos", "prdef_dpm_conf"]
+__all__ = ["def_discr_pos", "udef_discr_pos", "prdef_discr"]
 
 __docformat__ = 'restructuredtext'
 

--- a/src/sardana/macroserver/macros/discrete.py
+++ b/src/sardana/macroserver/macros/discrete.py
@@ -105,7 +105,7 @@ class DiscretePseudoMotorConfiguration(dict):
         return value
 
 
-class def_dpm_pos(Macro):
+class def_discr_pos(Macro):
     """
     Define a (calibrated) point for a discrete pseudomotor configuration.
 
@@ -122,6 +122,12 @@ class def_dpm_pos(Macro):
     case. However, if no dmin and dmax are provided, the previous
     calibration values for dmin and dmax are calculated and used to rebuild
     the calibration.
+
+    .. note::
+        The def_discr_pos macro has been included in sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including removal of the macro) may occur if
+        deemed necessary by the core developers.
     """
     param_def = [
         ['pseudo', Type.PseudoMotor, None, 'Discrete pseudomotor name.'],
@@ -139,9 +145,15 @@ class def_dpm_pos(Macro):
         conf.add_point(label, pos, setpos, dmin, dmax)
 
 
-class udef_dpm_pos(Macro):
+class udef_discr_pos(Macro):
     """
     Remove a point from a discrete pseudomotor configuration.
+
+    .. note::
+        The udef_discr_pos macro has been included in sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including removal of the macro) may occur if
+        deemed necessary by the core developers.
     """
     param_def = [
         ['pseudo', Type.PseudoMotor, None, 'Discrete pseudomotor name'],
@@ -153,9 +165,15 @@ class udef_dpm_pos(Macro):
         conf.remove_point(label)
 
 
-class prdef_dpm_conf(Macro):
+class prdef_discr(Macro):
     """
     Print discrete pseudomotor configuration.
+
+    .. note::
+    The prdef_discr_pos macro has been included in sardana
+    on a provisional basis. Backwards incompatible changes
+    (up to and including removal of the macro) may occur if
+    deemed necessary by the core developers.
     """
     param_def = [
         ['pseudo', Type.PseudoMotor, None, 'Discrete pseudomotor name'],

--- a/src/sardana/macroserver/macros/discretepm.py
+++ b/src/sardana/macroserver/macros/discretepm.py
@@ -39,7 +39,7 @@ class DiscretePseudoMotorConfiguration(dict):
         self.update(conf)
 
     def get_configuration(self):
-        value = self.pseudo.read_attribute('configuration').value
+        value = self.pseudo.getAttribute('configuration').read().value
         fmt, data = self.json.decode(('json', value))
         return data
 
@@ -82,7 +82,7 @@ class DiscretePseudoMotorConfiguration(dict):
     def _update(self):
         try:
             fmt, value = self.json.encode(('', self))
-            self.pseudo.write_attribute('configuration', value)
+            self.pseudo.getAttribute('configuration').write(value)
             self.macro.debug('Updated configuration:\n{0}'.format(self))
         except Exception as e:
             msg = 'Cannot update configuration]\n{0}\{1}'.format(e, self)

--- a/src/sardana/macroserver/macros/discretepm.py
+++ b/src/sardana/macroserver/macros/discretepm.py
@@ -1,0 +1,124 @@
+from sardana.macroserver.macro import Macro, Type
+import json
+import math
+
+
+class DiscretePseudoMotorConfiguration(dict):
+    def __init__(self, pseudo_obj, macro):
+        self.pseudo = pseudo_obj
+        self.macro = macro
+        _physical_motor_name = self.pseudo.physical_elements[0]
+        self.motor = macro.getMoveable(_physical_motor_name)
+        conf = self.get_configuration()
+        super(DiscretePseudoMotorConfiguration, self).__init__(conf)
+
+    def get_configuration(self):
+        return json.loads(self.pseudo.read_attribute('configuration').value)
+
+    def has_calibration(self):
+        return all(['set' in self[x].keys() for x in self.keys()])
+
+    def add_point(self, label, pos, dmin, dmax, set):
+        point = dict()
+        point['pos'] = int(pos)
+        # Calculate point calibration if required
+        if self.has_calibration():
+            # Set to current physical position if no value supplied as argument
+            if math.isinf(set):
+                point['set'] = self.motor.position
+            else:
+                point['set'] = float(set)
+            # If point exists, we use current min, max values
+            if label in self.keys() and math.isinf(dmin) and math.isinf(dmax):
+                p = self[label]
+                min_pos = point['set'] - abs(p['set'] - p['min'])
+                max_pos = point['set'] + abs(p['set'] - p['max'])
+            # else, new point has new calibration,
+            else:
+                min_pos = point['set'] - dmin
+                max_pos = point['set'] + dmax
+
+            point['min'] = min_pos
+            point['max'] = max_pos
+
+        self[label] = point
+        self._update()
+
+    def remove_point(self, label):
+        try:
+            self.pop(label)
+            self._update()
+        except Exception as e:
+            self.macro.error('Cannot remove label {0}\n{1}'.format(label, e))
+
+    def _update(self):
+        try:
+            self.pseudo.write_attribute('configuration', json.dumps(self))
+            self.macro.debug('Updated configuration:\n{0}'.format(self))
+        except Exception as e:
+            msg = 'Cannot update configuration]\n{0}\{1}'.format(e, self)
+            self.macro.error(msg)
+
+    def __str__(self):
+        return json.dumps(self, indent=4, sort_keys=True)
+
+
+class def_dpm_pos(Macro):
+    """
+    Define a (calibrated) point for a discrete pseudomotor configuration.
+
+    The mandatory parameters to execute the macro are: pseudo, label and pos.
+
+    Two different scenarios exist: To define a new point or to modify an
+    existing one. The controller protects from uploading repeated pos values.
+
+    If the point is new, the default dmin and dmax parameters are used to
+    construct the calibration. If no set point is provided, the current
+    physical position is used instead.
+
+    If the point already exists, the values are updated as in the previous
+    case. However, if no dmin and dmax are provided, the previous
+    calibration values for dmin and dmax are calculated and used to rebuild
+    the calibration.
+    """
+    param_def = [
+        ['pseudo', Type.PseudoMotor, None, 'Discrete pseudomotor name'],
+        ['label', Type.String, None, 'Label name'],
+        ['pos', Type.Integer, None, 'Pseudo position'],
+        ['dmin', Type.Float, float('-inf'),
+         'Delta increment defining the minimum position'],
+        ['dmax', Type.Float, float('inf'),
+         'Delta increment defining the maximum position'],
+        ['set', Type.Float, float('inf'), 'Real position'],
+        ]
+
+    def run(self, pseudo, label, pos, dmin, dmax, set):
+        conf = DiscretePseudoMotorConfiguration(pseudo, self)
+        conf.add_point(label, pos, dmin, dmax, set)
+
+
+class udef_dpm_pos(Macro):
+    """
+    Remove a point from a discrete pseudomotor configuration.
+    """
+    param_def = [
+        ['pseudo', Type.PseudoMotor, None, 'Discrete pseudomotor name'],
+        ['label', Type.String, None, 'Label name'],
+    ]
+
+    def run(self, pseudo, label):
+        conf = DiscretePseudoMotorConfiguration(pseudo, self)
+        conf.remove_point(label)
+
+
+class prdef_dpm_conf(Macro):
+    """
+    Print discrete pseudomotor configuration.
+    """
+    param_def = [
+        ['pseudo', Type.PseudoMotor, None, 'Discrete pseudomotor name'],
+    ]
+
+    def run(self, pseudo):
+        conf = DiscretePseudoMotorConfiguration(pseudo, self)
+        self.output(conf)

--- a/src/sardana/macroserver/macros/discretepm.py
+++ b/src/sardana/macroserver/macros/discretepm.py
@@ -24,6 +24,7 @@
 """ Discrete pseudo motor controller configuration related macros"""
 import math
 from taurus.core.util.codecs import CodecFactory
+from taurus.console.table import Table
 from sardana.macroserver.macro import Macro, Type
 
 
@@ -156,4 +157,29 @@ class prdef_dpm_conf(Macro):
 
     def run(self, pseudo):
         conf = DiscretePseudoMotorConfiguration(pseudo, self)
-        self.output(conf)
+        col_head_str = [['pos'], ['set'], ['min'], ['max']]
+        row_head_str = []
+        value_list = []
+
+        for k, v in conf.items():
+            row_head_str.append(k)
+            _row_values = [k]
+            for i in col_head_str:
+                _row_values.append(v[i[0]])
+            value_list.append(_row_values)
+
+        if len(value_list):
+            # Sort by position column
+            value_list = sorted(value_list, key=lambda x: x[1])
+            # Transpose matrix
+            value_list = map(list, zip(*value_list))
+            # Extract sorted row headers
+            row_head_str = value_list[0]
+            # Extract sorted values
+            value_list = value_list[1:]
+            table = Table(value_list, row_head_str=row_head_str,
+                          col_head_str=col_head_str, col_head_width=15)
+            for line in table.genOutput():
+                self.output(line)
+        else:
+            self.output('No configuration available')

--- a/src/sardana/macroserver/macros/discretepm.py
+++ b/src/sardana/macroserver/macros/discretepm.py
@@ -22,6 +22,11 @@
 ##############################################################################
 
 """ Discrete pseudo motor controller configuration related macros"""
+
+__all__ = ["def_dpm_pos", "udef_dpm_pos", "prdef_dpm_conf"]
+
+__docformat__ = 'restructuredtext'
+
 import math
 from taurus.core.util.codecs import CodecFactory
 from taurus.console.table import Table
@@ -29,6 +34,7 @@ from sardana.macroserver.macro import Macro, Type
 
 
 class DiscretePseudoMotorConfiguration(dict):
+
     def __init__(self, pseudo_obj, macro):
         self.pseudo = pseudo_obj
         self.macro = macro

--- a/src/sardana/macroserver/macros/discretepm.py
+++ b/src/sardana/macroserver/macros/discretepm.py
@@ -1,3 +1,28 @@
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+""" Discrete pseudo motor controller configuration related macros"""
+
 from sardana.macroserver.macro import Macro, Type
 import json
 import math

--- a/src/sardana/macroserver/macros/discretepm.py
+++ b/src/sardana/macroserver/macros/discretepm.py
@@ -36,7 +36,7 @@ class DiscretePseudoMotorConfiguration(dict):
         cf = CodecFactory()
         self.json = cf.getCodec('json')
         conf = self.get_configuration()
-        super(DiscretePseudoMotorConfiguration, self).__init__(conf)
+        self.update(conf)
 
     def get_configuration(self):
         value = self.pseudo.read_attribute('configuration').value

--- a/src/sardana/macroserver/macros/discretepm.py
+++ b/src/sardana/macroserver/macros/discretepm.py
@@ -43,16 +43,16 @@ class DiscretePseudoMotorConfiguration(dict):
     def has_calibration(self):
         return all(['set' in self[x].keys() for x in self.keys()])
 
-    def add_point(self, label, pos, dmin, dmax, set):
+    def add_point(self, label, pos, dmin, dmax, setpos):
         point = dict()
         point['pos'] = int(pos)
         # Calculate point calibration if required
         if self.has_calibration():
             # Set to current physical position if no value supplied as argument
-            if math.isinf(set):
+            if math.isinf(setpos):
                 point['set'] = self.motor.position
             else:
-                point['set'] = float(set)
+                point['set'] = float(setpos)
             # If point exists, we use current min, max values
             if label in self.keys() and math.isinf(dmin) and math.isinf(dmax):
                 p = self[label]

--- a/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
+++ b/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
@@ -51,8 +51,8 @@ class DiscretePseudoMotorController(PseudoMotorController):
     organization = "Sardana team"
     image = ""
 
-    pseudo_motor_roles = ("OutputMotor",)
-    motor_roles = ("InputMotor",)
+    pseudo_motor_roles = ("PseudoMotor",)
+    motor_roles = ("Motor",)
 
     axis_attributes = {CALIBRATION:  # type hackish until arrays supported
                        {Type: str,

--- a/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
+++ b/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
@@ -138,7 +138,6 @@ class DiscretePseudoMotorController(PseudoMotorController):
             labels = self._labels_cfg
         else:
             # TODO: Remove when we do not support more
-            print('holaaaa', self._labels)
             positions = self._positions
             calibration = self._calibration
             labels = self._labels

--- a/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
+++ b/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
@@ -77,7 +77,9 @@ class DiscretePseudoMotorController(PseudoMotorController):
         PseudoMotorController.__init__(self, inst, props, *args, **kwargs)
         self._calibration = None
         self._positions = None
-        self._labels = None
+        self._calibration = []
+        self._positions = []
+        self._labels = []
 
     def GetAxisAttributes(self, axis):
         axis_attrs = PseudoMotorController.GetAxisAttributes(self, axis)

--- a/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
+++ b/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
@@ -52,8 +52,8 @@ class DiscretePseudoMotorController(PseudoMotorController):
     organization = "Sardana team"
     image = ""
 
-    pseudo_motor_roles = ("PseudoMotor",)
-    motor_roles = ("Motor",)
+    pseudo_motor_roles = ("DiscreteMoveable",)
+    motor_roles = ("ContinuousMoveable",)
 
     axis_attributes = {CALIBRATION:  # type hackish until arrays supported
                        {Type: str,

--- a/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
+++ b/src/sardana/pool/poolcontrollers/DiscretePseudoMotorController.py
@@ -42,8 +42,9 @@ MSG_API = 'The new API is using! You must use configuration attribute.'
 
 
 class DiscretePseudoMotorController(PseudoMotorController):
-    """A discrete pseudo motor controller which converts physical motor positions
-    to discrete values"""
+    """
+    A discrete pseudo motor controller which converts physical motor
+    positions to discrete values"""
 
     gender = "DiscretePseudoMotorController"
     model = "PseudoMotor"
@@ -114,7 +115,7 @@ class DiscretePseudoMotorController(PseudoMotorController):
             value = int(value)
             try:
                 positions.index(value)
-            except:
+            except Exception:
                 raise Exception("Invalid position.")
             else:
                 return value
@@ -155,7 +156,7 @@ class DiscretePseudoMotorController(PseudoMotorController):
             self._log.debug("Value = %s", value)
             try:
                 positions.index(value)
-            except:
+            except Exception:
                 raise Exception("Invalid position.")
             return value
         # case 1+fussy: the write to the to the DiscretePseudoMotorController
@@ -164,7 +165,7 @@ class DiscretePseudoMotorController(PseudoMotorController):
             self._log.debug("Value = %s", value)
             try:
                 destination = positions.index(value)
-            except:
+            except Exception:
                 raise Exception("Invalid position.")
             self._log.debug("destination = %s", destination)
             calibrated_position = calibration[
@@ -223,7 +224,7 @@ class DiscretePseudoMotorController(PseudoMotorController):
 
         try:
             self._calibration = json.loads(value)
-        except:
+        except Exception:
             raise Exception("Rejecting calibration: invalid structure")
 
     def getConfiguration(self, axis):


### PR DESCRIPTION
Provide a more pythonic interface to the discrete pseudo motor
configuration.

The new configuration attribute encapsulates the values
from the label and calibration attributes as a dictionary.

The dictionary keys are extracted from the labels attribute.
and each dictionary entry is also a dictionary with four keys:
a `pos` key corresponding to the label enumerated position
integer value and three float values corresponding to the
calibration values and named as `min`, `set`, and `max`.

Three different macros are proposed to manage this configuration:
`def_dpm_pos`, `udef_dpm_pos` and `prdef_dpm` to add/remove a point
to the configuration and to print the configuration on screen.