### PR TITLE
Join pool of threads in cont scan

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1892,6 +1892,11 @@ class CAcquisition(object):
         """Wait until all value buffer events are processed."""
         self._countdown_latch.wait()
 
+    def join_thread_pool(self):
+        """Dispose the thread pool. Call it when you finish with processing
+        value_buffer events."""
+        self._thread_pool.join()
+
     @staticmethod
     def is_measurement_group_compatible(measurement_group):
         """Check if the given measurement group is compatible with continuous
@@ -2353,6 +2358,7 @@ class CTScan(CScan, CAcquisition):
         self.cleanup()
         self.macro.debug("Waiting for data events to be processed")
         self.wait_value_buffer()
+        self.join_thread_pool()
         self.macro.debug("All data events are processed")
 
     def scan_loop(self):
@@ -2600,6 +2606,7 @@ class TScan(GScan, CAcquisition):
                                   self.value_buffer_changed)
         self.debug("Waiting for value buffer events to be processed")
         self.wait_value_buffer()
+        self.join_thread_pool()
         self._fill_missing_records()
         yield 100
 


### PR DESCRIPTION
`CAcquisition` is creating a new pool of threads everytime it is instantiated.
These threads requires disposal, othewise the OS will complain that it can
not create more threads.

Add a method to join the pool of threads and call it from continuous scan
and timescan.

Can be tested by counting the number of threads in a process using:
`$> ps huH p <macroserver-pid> | wc -l`
Before it was increasing after every execution of the continuous scan, now it stays contant.

Can @sardana-org/integrators take look on this, please.


