### PR TITLE
Adding min_value and max_value to column_desc for mesh scans

### DIFF
--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -708,7 +708,9 @@ class mesh(Macro, Hookable):
         generator = self._generator
         moveables = []
         for m, start, final in zip(self.motors, self.starts, self.finals):
-            moveables.append(MoveableDesc(moveable=m, min_value=min(start,final), max_value=max(start,final)))
+            moveables.append(MoveableDesc(moveable=m,
+                                          min_value=min(start, final),
+                                          max_value=max(start, final)))
         moveables[0].is_reference = True
         env = opts.get('env', {})
         constrains = [getCallable(cns) for cns in opts.get(

--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -706,7 +706,10 @@ class mesh(Macro, Hookable):
         self.name = opts.get('name', 'mesh')
 
         generator = self._generator
-        moveables = self.motors
+        moveables = []
+        for m, start, final in zip(self.motors, self.starts, self.finals):
+            moveables.append(MoveableDesc(moveable=m, min_value=min(start,final), max_value=max(start,final)))
+        moveables[0].is_reference = True
         env = opts.get('env', {})
         constrains = [getCallable(cns) for cns in opts.get(
             'constrains', [UNCONSTRAINED])]


### PR DESCRIPTION
In the Nscans the column_desc in the data record contains min_value and max_value with the scan limits. We need this information also for the mesh scan. This PR implement it.