### PR TITLE
Allow back. comp. for defining ctrl. property

### DIFF
--- a/src/sardana/pool/poolmetacontroller.py
+++ b/src/sardana/pool/poolmetacontroller.py
@@ -263,19 +263,31 @@ class ControllerClass(SardanaClass):
         self.types = []
         self.dict_extra = {}
         self.api_version = 1
-
         klass = self.klass
         # Generic controller information
         self.ctrl_features = tuple(klass.ctrl_features)
 
         self.ctrl_properties = props = CaselessDict()
         self.ctrl_properties_descriptions = []
+        dep_msg = ("Define the 'Description' controller property using a "
+                   + "string is deprecated use "
+                   + "sardana.pool.controller.Description constant instead")
         for k, v in klass.class_prop.items():  # old member
             props[k] = DataInfo.toDataInfo(k, v)
-            self.ctrl_properties_descriptions.append(v['description'])
+            try:
+                self.ctrl_properties_descriptions.append(v[Description])
+            except KeyError:
+                self.deprecated(dep_msg)
+                self.ctrl_properties_descriptions.append(v['Description'])
+
         for k, v in klass.ctrl_properties.items():
             props[k] = DataInfo.toDataInfo(k, v)
-            self.ctrl_properties_descriptions.append(v['description'])
+            try:
+                self.ctrl_properties_descriptions.append(v[Description])
+            except KeyError:
+                self.deprecated(dep_msg)
+                self.ctrl_properties_descriptions.append(v['Description'])
+
         self.dict_extra['properties'] = tuple(klass.ctrl_properties)
         self.dict_extra['properties_desc'] = self.ctrl_properties_descriptions
 

--- a/src/sardana/pool/poolmetacontroller.py
+++ b/src/sardana/pool/poolmetacontroller.py
@@ -269,15 +269,15 @@ class ControllerClass(SardanaClass):
 
         self.ctrl_properties = props = CaselessDict()
         self.ctrl_properties_descriptions = []
-        dep_msg = ("Define the 'Description' controller property using a "
-                   + "string is deprecated use "
-                   + "sardana.pool.controller.Description constant instead")
+        dep_msg = ("Defining the controller property description using a "
+                   + "string is deprecated, use "
+                   + "sardana.pool.controller.Description constant instead.")
         for k, v in klass.class_prop.items():  # old member
             props[k] = DataInfo.toDataInfo(k, v)
             try:
                 self.ctrl_properties_descriptions.append(v[Description])
             except KeyError:
-                self.deprecated(dep_msg)
+                self.warning(dep_msg)
                 self.ctrl_properties_descriptions.append(v['Description'])
 
         for k, v in klass.ctrl_properties.items():
@@ -285,7 +285,7 @@ class ControllerClass(SardanaClass):
             try:
                 self.ctrl_properties_descriptions.append(v[Description])
             except KeyError:
-                self.deprecated(dep_msg)
+                self.warning(dep_msg)
                 self.ctrl_properties_descriptions.append(v['Description'])
 
         self.dict_extra['properties'] = tuple(klass.ctrl_properties)


### PR DESCRIPTION
Some old controllers define its description property using a string
'Description' instead of using the
'sardana.pool.controller.Description' constant.

A recent modification were base on this constant and cause an
exception during the loading of the controllers.

Add back. comp. raising a deprecation warning.