### PR TITLE
Fix incorrect conversion to boolean

### DIFF
--- a/src/sardana/macroserver/basetypes.py
+++ b/src/sardana/macroserver/basetypes.py
@@ -64,7 +64,6 @@ class Boolean(ParamType):
             value = False
         else:
             raise ValueError('{0} is not a boolean'.format(str_repr))
-
         return value
 
 

--- a/src/sardana/macroserver/basetypes.py
+++ b/src/sardana/macroserver/basetypes.py
@@ -57,7 +57,15 @@ class Boolean(ParamType):
     type_class = bool
 
     def getObj(self, str_repr):
-        return str_repr.lower() == "true"
+        str_repr = str_repr.lower()
+        if str_repr in ['true', '1']:
+            value = True
+        elif str_repr in ['false', '0']:
+            value = False
+        else:
+            raise ValueError('{0} is not a boolean'.format(str_repr))
+
+        return value
 
 
 class String(ParamType):

--- a/src/sardana/spock/ipython_00_10/genutils.py
+++ b/src/sardana/spock/ipython_00_10/genutils.py
@@ -685,7 +685,10 @@ def _macro_completer(self, event):
     if possible_params:
         res = []
         for param in possible_params:
-            res.extend(ms.getElementNamesWithInterface(param['type']))
+            if param['type'].lower() == 'boolean':
+                res.extend(['True', 'False'])
+            else:
+                res.extend(ms.getElementNamesWithInterface(param['type']))
         return res
 
 

--- a/src/sardana/spock/ipython_00_11/genutils.py
+++ b/src/sardana/spock/ipython_00_11/genutils.py
@@ -646,7 +646,10 @@ def _macro_completer(self, event):
     if possible_params:
         res = []
         for param in possible_params:
-            res.extend(ms.getElementNamesWithInterface(param['type']))
+            if param['type'].lower() == 'boolean':
+                res.extend(['True', 'False'])
+            else:
+                res.extend(ms.getElementNamesWithInterface(param['type']))
         return res
 
 

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -653,7 +653,11 @@ def _macro_completer(self, event):
     if possible_params:
         res = []
         for param in possible_params:
-            res.extend(ms.getElementNamesWithInterface(param['type']))
+            if param['type'].lower() == 'boolean':
+                res.extend(['True', 'False'])
+            else:
+                res.extend(ms.getElementNamesWithInterface(param['type']))
+
         return res
 
 

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -657,7 +657,6 @@ def _macro_completer(self, event):
                 res.extend(['True', 'False'])
             else:
                 res.extend(ms.getElementNamesWithInterface(param['type']))
-
         return res
 
 


### PR DESCRIPTION
The boolean type is not protected and it does not allow to use 0/1 as values. 

Macro to test it:
```python
class test_boolean(Macro):
    param_def = [['val', Type.Boolean, None, 'value']]

    def run(self, value):
        self.info(value)

````