### PR TITLE
[WIP] implement scanstats macro

### DIFF
--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -33,7 +33,8 @@ __all__ = ["a2scan", "a3scan", "a4scan", "amultiscan", "aNscan", "ascan",
            "d2scanc", "d3scanc", "d4scanc", "dscanc",
            "meshc",
            "a2scanct", "a3scanct", "a4scanct", "ascanct", "meshct",
-           "scanhist", "getCallable", "UNCONSTRAINED"]
+           "scanhist", "getCallable", "UNCONSTRAINED",
+           "scanstats"]
 
 __docformat__ = 'restructuredtext'
 
@@ -1848,3 +1849,62 @@ class timescan(Macro, Hookable):
 
     def getIntervalEstimation(self):
         return self.nr_interv
+
+
+class scanstats(Macro):
+    """Calculate basic statistics of the first enabled and plotted counter in
+    the active measurement group for the last scan. Print it and publish it
+    in the env. The macro must be hooked in the post-scan hook place.
+    """
+    
+    def run(self, *args):
+        parent = self.getParentMacro()
+        if parent:
+            mntGrp = self.getEnv('ActiveMntGrp')
+            self.mntGrp = self.getObj(mntGrp, type_class=Type.MeasurementGroup)
+            channels = self.mntGrp.getChannels()
+            select_channel = ''
+            
+            for channel in channels:
+                if channel['enabled'] & channel['plot_type'] == 1:
+                    select_channel = channel['name']                    
+                    break
+            
+            # in case no channel is enabled and plotted just take the first
+            if select_channel == '':
+                select_channel = channels[0]['name']
+                
+            select_motor = str(parent.motors[0])
+            
+            self.info('Statistics on channel: %s' % select_channel)   
+            self.info('Statistics for movable: %s' % select_motor)
+            data = parent.data
+            
+            counter_data = []
+            motor_data = []
+            
+            for idx, rc in data.items():
+                counter_data.append(rc[select_channel])
+                motor_data.append(rc[select_motor])
+            
+            counter_data = numpy.array(counter_data)
+            motor_data = numpy.array(motor_data)
+            
+            CEN = numpy.sum(counter_data*motor_data)/numpy.sum(counter_data)
+            PEAK = motor_data[numpy.argmax(counter_data)]
+            # print statistics
+            self.info('Min:\t %g' % numpy.min(counter_data))
+            self.info('Max:\t %g' % numpy.max(counter_data))
+            self.info('Min at:\t %g' % motor_data[numpy.argmin(counter_data)])
+            self.info('Max at:\t %g' % PEAK)
+            self.info('Mean:\t %g' % numpy.mean(counter_data))
+            self.info('Integral:\t %g' % numpy.sum(counter_data))
+            self.info('CEN:\t %g' % CEN)
+            # set CEN and PEAK as env variables          
+            # set the motor only in case it is hard to access it from another
+            # macro liek pic or cen
+            self.setEnv('ScanStats', {'PEAK':PEAK, 'CEN':CEN,
+                                      'motor':select_motor})
+        else:
+            self.warning('for now the scanstats macro can only be executed as'
+                         ' a post-scan hook')


### PR DESCRIPTION
this is an inital implementation for calculating statistics of a scan.
The macro `scanstats` has to be hooked to the post-scan hook place.
The macro then has access to its parent data, movable and the counters from the measurement group.
Right now it simply mimics SPEC's behaviour of calculating simple statistics only for the first plotted counter - this can be easily expanded to all counters, see also discussion in #290 .

Please review this PR especially for the way I access the counters and motors. I guess this can be done more elegant , e.g. with the new measurement group API?

I decided to memorize the results of the calculation in the env for now. I also save the motor for which the stats were calculated, but I guess the last used motor might be also accessible in another way from within another macro?

One pretty nice thing which SPEC is able to, is to calculate the CEN from a peak or an edge automagically. Does anybody knows how this works?