### PR TITLE
Allows hooks in timescan

### DIFF
--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -1819,6 +1819,9 @@ class timescan(Macro, Hookable):
     of latency_time and measurement group latency time.
     """
 
+    hints = {'scan': 'timescan', 'allowsHooks': ('pre-scan', 'pre-acq',
+                                                 'post-acq', 'post-scan')}
+
     param_def = [
         ['nr_interv', Type.Integer, None, 'Number of scan intervals'],
         ['integ_time', Type.Float, None, 'Integration time'],

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2639,6 +2639,10 @@ class TScan(GScan, CAcquisition):
             for hook in macro.getHooks('pre-scan'):
                 hook()
 
+        if hasattr(macro, 'getHooks'):
+            for hook in macro.getHooks('pre-acq'):
+                hook()
+
         yield 0
         measurement_group.measure(synchronization,
                                   self.value_buffer_changed)
@@ -2647,6 +2651,10 @@ class TScan(GScan, CAcquisition):
         self.join_thread_pool()
         self._fill_missing_records()
         yield 100
+
+        if hasattr(macro, 'getHooks'):
+            for hook in macro.getHooks('post-acq'):
+                hook()
 
         if hasattr(macro, 'getHooks'):
             for hook in macro.getHooks('post-scan'):


### PR DESCRIPTION
Expose allowsHooks hint of timescan macro.
Implement pre-acq and post-acq hooks in TScan class.
@sardana-org/integrators can you take a look, please?