### PR TITLE
Extend repeat macro to run it easily from spock

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -822,30 +822,45 @@ class logmacro(Macro):
         else:
             self.setEnv('LogMacro', False)
 
-
 class repeat(Hookable, Macro):
-    """This macro executes as many repetitions of it's body hook macros as
-    specified by nr parameter. If nr parameter has negative value,
-    repetitions will be executed until you stop repeat macro."""
+    """This macro executes as many repetitions of a set of macros as
+    specified by nr parameter. The macros to be repeated can be 
+    given as parameters or as body hooks. 
+    If the macros are given as parameters the body hooks are ignored. 
+    If nr has negative value, repetitions will be executed until you 
+    stop repeat macro.
 
+    .. note::
+        The repeat macro has been included in Sardana
+        on a provisional basis. Backwards incompatible changes
+        (up to and including removal of the macro) may occur if
+        deemed necessary by the core developers."""
+    
     # hints = { 'allowsHooks': ('body', 'break', 'continue') }
     hints = {'allowsHooks': ('body',)}
 
     param_def = [
-        ['nr', Type.Integer, None, 'Nr of iterations']
+        ['nr', Type.Integer, None, 'Nr of iterations'],
+        ['macro_name_params', [['token', Type.String, None, 'Macro name and parameters (if any)'], {'min':0}], None, "List with macro name and parameters (if any)"]
     ]
 
-    def prepare(self, nr):
+    def prepare(self, nr, macro_name_params):
         # self.breakHooks = self.getHooks("break")
         # self.continueHooks = self.getHooks("continue")
         self.bodyHooks = self.getHooks("body")
+        self.macro_name_params = macro_name_params
 
     def __loop(self):
         self.checkPoint()
-        for bodyHook in self.bodyHooks:
-            bodyHook()
+        if self.macro_name_params == None:
+            for bodyHook in self.bodyHooks:
+                bodyHook()
+        else:
+            for macro in self.macro_name_params:
+                self.execMacro(macro)
 
-    def run(self, nr):
+    def run(self, nr, macro_name_params):
+        self.output(macro_name_params)
         if nr < 0:
             while True:
                 self.__loop()

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -826,7 +826,8 @@ class repeat(Hookable, Macro):
     """This macro executes as many repetitions of a set of macros as
     specified by nr parameter. The macros to be repeated can be
     given as parameters or as body hooks.
-    If the macros are given as parameters the body hooks are ignored.
+    If both are given first will be executed the ones given as
+    parameters and then the ones given as body hooks.
     If nr has negative value, repetitions will be executed until you
     stop repeat macro.
 

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -824,10 +824,10 @@ class logmacro(Macro):
 
 class repeat(Hookable, Macro):
     """This macro executes as many repetitions of a set of macros as
-    specified by nr parameter. The macros to be repeated can be 
-    given as parameters or as body hooks. 
-    If the macros are given as parameters the body hooks are ignored. 
-    If nr has negative value, repetitions will be executed until you 
+    specified by nr parameter. The macros to be repeated can be
+    given as parameters or as body hooks.
+    If the macros are given as parameters the body hooks are ignored.
+    If nr has negative value, repetitions will be executed until you
     stop repeat macro.
 
     .. note::
@@ -835,13 +835,18 @@ class repeat(Hookable, Macro):
         on a provisional basis. Backwards incompatible changes
         (up to and including removal of the macro) may occur if
         deemed necessary by the core developers."""
-    
+
     # hints = { 'allowsHooks': ('body', 'break', 'continue') }
     hints = {'allowsHooks': ('body',)}
 
     param_def = [
         ['nr', Type.Integer, None, 'Nr of iterations'],
-        ['macro_name_params', [['token', Type.String, None, 'Macro name and parameters (if any)'], {'min':0}], None, "List with macro name and parameters (if any)"]
+        ['macro_name_params', [
+                ['token', Type.String,
+                None, 'Macro name and parameters (if any)'],
+                {'min': 0}
+            ],
+            None, "List with macro name and parameters (if any)"]
     ]
 
     def prepare(self, nr, macro_name_params):
@@ -852,7 +857,7 @@ class repeat(Hookable, Macro):
 
     def __loop(self):
         self.checkPoint()
-        if self.macro_name_params == None:
+        if self.macro_name_params is None:
             for bodyHook in self.bodyHooks:
                 bodyHook()
         else:

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -854,12 +854,12 @@ class repeat(Hookable, Macro):
 
     def __loop(self):
         self.checkPoint()
-        if self.macro_name_params is None:
-            for bodyHook in self.bodyHooks:
-                bodyHook()
-        else:
+        if len(self.macro_name_params) > 0:
             for macro in self.macro_name_params:
                 self.execMacro(macro)
+        else:
+            for bodyHook in self.bodyHooks:
+                bodyHook()
 
     def run(self, nr, macro_name_params):
         self.output(macro_name_params)

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -855,8 +855,8 @@ class repeat(Hookable, Macro):
     def __loop(self):
         self.checkPoint()
         if len(self.macro_name_params) > 0:
-            for macro in self.macro_name_params:
-                self.execMacro(macro)
+            for macro_cmd in self.macro_name_params:
+                self.execMacro(macro_cmd)
         else:
             for bodyHook in self.bodyHooks:
                 bodyHook()

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -857,12 +857,10 @@ class repeat(Hookable, Macro):
         if len(self.macro_name_params) > 0:
             for macro_cmd in self.macro_name_params:
                 self.execMacro(macro_cmd)
-        else:
-            for bodyHook in self.bodyHooks:
-                bodyHook()
+        for bodyHook in self.bodyHooks:
+            bodyHook()
 
     def run(self, nr, macro_name_params):
-        self.output(macro_name_params)
         if nr < 0:
             while True:
                 self.__loop()

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -836,22 +836,19 @@ class repeat(Hookable, Macro):
         (up to and including removal of the macro) may occur if
         deemed necessary by the core developers."""
 
-    # hints = { 'allowsHooks': ('body', 'break', 'continue') }
     hints = {'allowsHooks': ('body',)}
 
     param_def = [
         ['nr', Type.Integer, None, 'Nr of iterations'],
         ['macro_name_params', [
                 ['token', Type.String,
-                None, 'Macro name and parameters (if any)'],
+                 None, 'Macro name and parameters (if any)'],
                 {'min': 0}
             ],
             None, "List with macro name and parameters (if any)"]
     ]
 
     def prepare(self, nr, macro_name_params):
-        # self.breakHooks = self.getHooks("break")
-        # self.continueHooks = self.getHooks("continue")
         self.bodyHooks = self.getHooks("body")
         self.macro_name_params = macro_name_params
 


### PR DESCRIPTION
According to the discussion in #802, the syntax is implemented as:

Door> repeat 100 "ascan mot01 0 10 10 0.1" "ct 10" "dscan mot02 -20 20 6 0.2"