### PR TITLE
Remove numpy and pylab from spock namespace

### DIFF
--- a/src/sardana/spock/ipython_00_11/genutils.py
+++ b/src/sardana/spock/ipython_00_11/genutils.py
@@ -1082,6 +1082,7 @@ object?   -> Details about 'object'. ?object also works, ?? prints more.
     term_app.display_banner = True
     term_app.gui = gui_mode
     term_app.pylab = 'qt'
+    term_app.pylab_import_all = False
     #term_app.nosep = False
     #term_app.classic = True
 

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -1122,6 +1122,7 @@ object?   -> Details about 'object'. ?object also works, ?? prints more.
     term_app.display_banner = True
     term_app.gui = gui_mode
     term_app.pylab = 'qt'
+    term_app.pylab_import_all = False
     #term_app.nosep = False
     #term_app.classic = True
 


### PR DESCRIPTION
Enabling pylab support in IPython also exports all numpy and pylab
symbols into the namespace. Some sardana macros may collide with these
symbols e.g. repeat or where. This forces the macro execution with the
"%" symbol - explicitly indicating execution of a magic command.
Disable the export of these symbols into the spock's namespace for
IPython >= 0.11.

I was not able to find such configuration for IPython 0.10 but I think that we at Alba are the only ones using this version. Just in case someone wants to look for it I post a link to the [IPython 0.10.2 documentation](https://ipython.org/ipython-doc/rel-0.10.2/html/index.html).

This improves user experience in #892 and #890.

I've tested it on IPython 0.13.2 and IPython 5.1.0.

@sardana-org/integrators could you please take a look on it?