### PR TITLE
Store FQDN URI for Door and MacroServer in spock conf file

### DIFF
--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -304,7 +304,8 @@ def get_macroserver_for_door(door_name):
             if dev.lower() == door_name:
                 for i, klass in enumerate(klasses):
                     if klass == 'MacroServer':
-                        return "%s:%s/%s" % (db.get_db_host(), db.get_db_port(), devs[i])
+                        full_name, _, _ = from_name_to_tango(devs[i])
+                        return full_name
     else:
         return None
 
@@ -444,6 +445,14 @@ def print_dev_from_class(classname, dft=None):
 
 
 def from_name_to_tango(name):
+    try:
+        from taurus.core.tango.tangovalidator import TangoDeviceNameValidator
+        return TangoDeviceNameValidator().getNames(name)
+    except ImportError:
+        return _from_name_to_tango(name)
+
+
+def _from_name_to_tango(name):
 
     db = get_tango_db()
 
@@ -609,7 +618,9 @@ def _get_dev(dev_type):
         taurus_dev = getattr(spock_config, taurus_dev_var)
     if taurus_dev is None:
         # TODO: For Taurus 4 compatibility
-        dev_name = "tango://%s" % getattr(spock_config, dev_type + '_name')
+        dev_name = getattr(spock_config, dev_type + '_name')
+        if not dev_name.startswith("tango://"):
+            dev_name = "tango://%s" % dev_name
         factory = Factory()
         taurus_dev = factory.getDevice(dev_name)
         import PyTango


### PR DESCRIPTION
When spock is used with Taurus4 store in the spock configuration file
Door and MacroServer FQDN URI references.

This is resting part of #668.

@sardana-org/integrators can you take a look? I've tested it with Taurus 4 but now with Taurus 3.

Note this does not upgrade the already exiting configuration file. I would not block the release for that cause there is a backwards compatibility layer so old configuration files basically works.. If at some point we want to upgrade them we can add it a posteriori.

Also I've not implemented it for IPython < 1.0. It is not probable that someone will use Taurus 4 together with such version of IPython.