### PR TITLE
Asynchronous Logstash communication

### DIFF
--- a/doc/source/users/configuration/macroserver.rst
+++ b/doc/source/users/configuration/macroserver.rst
@@ -49,6 +49,9 @@ MacroServer integrates natively with the
 instance. In case Sardana is used with Tango this configuration is
 accessible via the ``LogstashHost`` and ``LogstashPort``
 :class:`~sardana.tango.macroserver.MacroServer.MacroServer` device properties.
+You can use the intermediate SQLite cache database configured with
+``LogstashCacheDbPath`` property, however this is discouraged due to logging
+performance problems.
 
 .. todo::
     Document RConsolePort

--- a/doc/source/users/configuration/pool.rst
+++ b/doc/source/users/configuration/pool.rst
@@ -20,6 +20,9 @@ Device Pool integrates natively with the
 instance. In case Sardana is used with Tango this configuration is
 accessible via the ``LogstashHost`` and ``LogstashPort``
 :class:`~sardana.tango.pool.Pool.Pool` device properties.
+You can use the intermediate SQLite cache database configured with
+``LogstashCacheDbPath`` property, however this is discouraged due to logging
+performance problems.
 
 
 .. todo::

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -936,12 +936,7 @@ def prepare_logstash(args):
             props = db.get_device_property(dev_name, "LogstashCacheDbPath")
             cache_db_path = props["LogstashCacheDbPath"][0]
         except IndexError:
-            if class_name == "Pool":
-                cache_db_path = "/tmp/sardana-pool-logstash-cache.db"
-            elif class_name == "MacroServer":
-                cache_db_path = "/tmp/sardana-ms-logstash-cache.db"
-            else:
-                cache_db_path = "/tmp/sardana-logstash-cache.db"
+            cache_db_path = None
         return host, port, cache_db_path
 
     db = Database()

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -914,7 +914,7 @@ def prepare_logstash(args):
     log_messages = []
 
     try:
-        import logstash
+        from logstash_async.handler import AsynchronousLogstashHandler
     except ImportError:
         msg = ("Unable to import logstash. Skipping logstash "
                + "configuration...", )
@@ -953,7 +953,8 @@ def prepare_logstash(args):
 
     if host is not None:
         root = Logger.getRootLog()
-        handler = logstash.TCPLogstashHandler(host, port, version=1)
+        handler = AsynchronousLogstashHandler(host, port,
+                  database_path="/tmp/sardana-logstash-cache.db")
         root.addHandler(handler)
         msg = ("Log is being sent to logstash listening on %s:%d",
                host, port)

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -947,7 +947,7 @@ def prepare_logstash(args):
     if bin_name in ["Pool", "MacroServer"]:
         class_name = bin_name
         dev_name = get_dev_from_class_server(db, class_name, server_name)[0]
-        host, port, cache = get_logstash_conf(dev_name, class_name)
+        host, port, cache = get_logstash_conf(dev_name)
     else:
         dev_name = get_dev_from_class_server(db, "Pool", server_name)[0]
         host, port, cache = get_logstash_conf(dev_name)

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -916,7 +916,7 @@ def prepare_logstash(args):
     try:
         from logstash_async.handler import AsynchronousLogstashHandler
     except ImportError:
-        msg = ("Unable to import logstash. Skipping logstash "
+        msg = ("Unable to import logstash_async. Skipping logstash "
                + "configuration...", )
         log_messages.append(msg,)
         return log_messages

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -931,7 +931,7 @@ def prepare_logstash(args):
             props = db.get_device_property(dev_name, "LogstashPort")
             port = int(props["LogstashPort"][0])
         except IndexError:
-            port = 12345
+            port = None
         try:
             props = db.get_device_property(dev_name, "LogstashCacheDbPath")
             cache_db_path = props["LogstashCacheDbPath"][0]

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -921,7 +921,7 @@ def prepare_logstash(args):
         log_messages.append(msg,)
         return log_messages
 
-    def get_logstash_conf(dev_name, class_name=None):
+    def get_logstash_conf(dev_name):
         try:
             props = db.get_device_property(dev_name, "LogstashHost")
             host = props["LogstashHost"][0]

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -955,6 +955,9 @@ def prepare_logstash(args):
         root = Logger.getRootLog()
         handler = AsynchronousLogstashHandler(host, port,
                   database_path="/tmp/sardana-logstash-cache.db")
+        # don't use full path for program_name
+        handler._create_formatter_if_necessary()
+        _, handler.formatter._program_name = os.path.split(handler.formatter._program_name)
         root.addHandler(handler)
         msg = ("Log is being sent to logstash listening on %s:%d",
                host, port)

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -934,7 +934,7 @@ def prepare_logstash(args):
             port = 12345
         try:
             props = db.get_device_property(dev_name, "LogstashCacheDbPath")
-            cache_db_path = int(props["LogstashCacheDbPath"][0])
+            cache_db_path = props["LogstashCacheDbPath"][0]
         except IndexError:
             if class_name == "Pool":
                 cache_db_path = "/tmp/sardana-pool-logstash-cache.db"

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -392,12 +392,12 @@ class MacroServerClass(SardanaDeviceClass):
              None],
         'LogstashPort':
             [DevLong,
-             "Port on which Logstash will listen on events. "
+             "Port on which Logstash will listen on events [default: 12345]. "
              "This property has been included in Sardana on a provisional "
              "basis. Backwards incompatible changes (up to and including "
              "its removal) may occur if deemed necessary by the "
              "core developers.",
-             None],
+             12345],
         'LogstashCacheDbPath':
             [DevString,
              "Path to the Logstash cache database [default: None]. "

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -407,7 +407,7 @@ class MacroServerClass(SardanaDeviceClass):
              "basis. Backwards incompatible changes (up to and including "
              "its removal) may occur if deemed necessary by the "
              "core developers.",
-             "/tmp/sardana-ms-logstash-cache.db"]
+             None]
     }
 
     #    Command definitions

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -400,8 +400,9 @@ class MacroServerClass(SardanaDeviceClass):
              None],
         'LogstashCacheDbPath':
             [DevString,
-             "Path to the Logstash cache database [default: "
-             "/tmp/sardana-ms-logstash-cache.db]. "
+             "Path to the Logstash cache database [default: None]. "
+             "It is advised not to use the database cache, as it may "
+             "have negative effects on logging performance. See #895. "
              "This property has been included in Sardana on a provisional "
              "basis. Backwards incompatible changes (up to and including "
              "its removal) may occur if deemed necessary by the "

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -397,7 +397,16 @@ class MacroServerClass(SardanaDeviceClass):
              "basis. Backwards incompatible changes (up to and including "
              "its removal) may occur if deemed necessary by the "
              "core developers.",
-             None]
+             None],
+        'LogstashCacheDbPath':
+            [DevString,
+             "Path to the Logstash cache database [default: "
+             "/tmp/sardana-ms-logstash-cache.db]. "
+             "This property has been included in Sardana on a provisional "
+             "basis. Backwards incompatible changes (up to and including "
+             "its removal) may occur if deemed necessary by the "
+             "core developers.",
+             "/tmp/sardana-ms-logstash-cache.db"]
     }
 
     #    Command definitions

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -1390,7 +1390,7 @@ class PoolClass(PyTango.DeviceClass):
              "basis. Backwards incompatible changes (up to and including "
              "its removal) may occur if deemed necessary by the "
              "core developers.",
-             "/tmp/sardana-pool-logstash-cache.db"]
+             None]
     }
 
     #    Command definitions

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -1383,8 +1383,9 @@ class PoolClass(PyTango.DeviceClass):
              None],
         'LogstashCacheDbPath':
             [PyTango.DevString,
-             "Path to the Logstash cache database [default: "
-             "/tmp/sardana-pool-logstash-cache.db]. "
+             "Path to the Logstash cache database [default: None]. "
+             "It is advised not to use the database cache, as it may "
+             "have negative effects on logging performance. See #895. "
              "This property has been included in Sardana on a provisional "
              "basis. Backwards incompatible changes (up to and including "
              "its removal) may occur if deemed necessary by the "

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -1380,7 +1380,16 @@ class PoolClass(PyTango.DeviceClass):
              "basis. Backwards incompatible changes (up to and including "
              "its removal) may occur if deemed necessary by the "
              "core developers.",
-             None]
+             None],
+        'LogstashCacheDbPath':
+            [PyTango.DevString,
+             "Path to the Logstash cache database [default: "
+             "/tmp/sardana-pool-logstash-cache.db]. "
+             "This property has been included in Sardana on a provisional "
+             "basis. Backwards incompatible changes (up to and including "
+             "its removal) may occur if deemed necessary by the "
+             "core developers.",
+             "/tmp/sardana-pool-logstash-cache.db"]
     }
 
     #    Command definitions

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -1375,12 +1375,12 @@ class PoolClass(PyTango.DeviceClass):
              None],
         'LogstashPort':
             [PyTango.DevLong,
-             "Port on which Logstash will listen on events. "
+             "Port on which Logstash will listen on events [default: 12345]. "
              "This property has been included in Sardana on a provisional "
              "basis. Backwards incompatible changes (up to and including "
              "its removal) may occur if deemed necessary by the "
              "core developers.",
-             None],
+             12345],
         'LogstashCacheDbPath':
             [PyTango.DevString,
              "Path to the Logstash cache database [default: None]. "


### PR DESCRIPTION
This is a follow-up to #699 and an attempt to make Logstash communication asynchronous.

Things changed so far:
* use `python-logstash-async` instead of `python-logstash`
* add `LogstashCacheDbPath` property for both Pool and MacroServer

There is no need to define two Logstash endpoints with tagging (see [example configuration](https://github.com/reszelaz/sardana-elastic/blob/master/logstash/conf.d/sardana.conf)) since the `python-logstash-async` automatically adds `program` field. It's value is taken from the executable name, which in case of single Sardana instance is correctly recognized as `Sardana` and not `Pool`.

The asynchronous library uses caching in local SQLite database, path of which is configured by `LogstashCacheDbPath` property. This caching however causes problems when logs are produced at high speed (e.g. during a scan). Since all messages are logged first to the cache and then from cache to Logstash, it seems that with high message rate it is impossible to push messages to Logstash and record new ones in the cache simultaneously. The messages will end up in Logstash after some time, but a 1000 point scan is able to completely prevent any message from reaching Logstash for scan duration + a few minutes.
Other issue is the database file size, it needs to be manually cleaned (SQLite `VACUUM` command) and can grow significantly even when empty.