### PR TITLE
[WIP] Use TangoSerial mode for Elements and Environment attributes

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -785,13 +785,21 @@ class BaseMacroServer(MacroServerDevice):
         self.call__init__(MacroServerDevice, name, **kw)
 
         self.__elems_attr = self.getAttribute("Elements")
-        self.__elems_attr.setSerializationMode(TaurusSerializationMode.Serial)
+        try:
+            serialization_mode = TaurusSerializationMode.TangoSerial
+        except AttributeError:
+            serialization_mode = TaurusSerializationMode.Serial
+        self.__elems_attr.setSerializationMode(serialization_mode)
         self.__elems_attr.addListener(self.on_elements_changed)
         self.__elems_attr.setSerializationMode(
             TaurusSerializationMode.Concurrent)
 
         self.__env_attr = self.getAttribute('Environment')
-        self.__env_attr.setSerializationMode(TaurusSerializationMode.Serial)
+        try:
+            serialization_mode = TaurusSerializationMode.TangoSerial
+        except AttributeError:
+            serialization_mode = TaurusSerializationMode.Serial
+        self.__env_attr.setSerializationMode(serialization_mode)
         self.__env_attr.addListener(self.on_environment_changed)
         self.__env_attr.setSerializationMode(
             TaurusSerializationMode.Concurrent)


### PR DESCRIPTION
taurus-org/taurus#738 changed meaning of TaurusSerializationMode.Serial.
Use TaurusSerializationMode.TangoSerial to maintain the previous behavior.

This still does not work for me. Just checking if it works better on travis. In my case it solved problems of the environment attribute, this could be the same thing that @dschick explained in #882 about unresponsive expconf).

But the testsuite always hangs on test_dscan_macro_runs (sardana.macroserver.macros.test.test_scan.DscanTest).

I even changed the tauruscustomsetting.TANGO_SERIALIZATION_MODE = 'TangoSerial' but still without success.