### PR TITLE
Fix pseudo counters in continuous acquisition.

### DIFF
--- a/src/sardana/pool/poolpseudocounter.py
+++ b/src/sardana/pool/poolpseudocounter.py
@@ -62,11 +62,13 @@ class ValueBuffer(ValueBuffer_):
                     return
                 except LateValueException:
                     self.remove_physical_values(idx)
-                    return
+                    break
                 physical_values.append(value)
-            value = self.obj.calc(physical_values)
-            self.append(value, idx)
-            self.remove_physical_values(idx)
+            else:
+                # loop collected all values so we can proceed to calculate
+                value = self.obj.calc(physical_values)
+                self.append(value, idx)
+                self.remove_physical_values(idx)
 
     def remove_physical_values(self, idx, force=False):
         for value_buf in self.obj.get_physical_value_buffer_iterator():


### PR DESCRIPTION
Let's consider the folowing example. A pseudo coutner is based on two
counters. If counter#1 reported value of index 1 and 3 in separate
chunks and then counter#2 reported values 1, 2 and 3 in the same chunk,
the pseudo counter won't calculate the index 3. This is because the
LateValueException is returning from the on_change callback, ignoring
all the following indexes. Fix it by continuing the loop and just
skipping calculation for late values.

@sardana-org/integrators this is ready to be reviewed