### PR TITLE
Do not fill missing records if timescan is stopped

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2662,6 +2662,7 @@ class TScan(GScan, CAcquisition):
         self.debug("Waiting for value buffer events to be processed")
         self.wait_value_buffer()
         self.join_thread_pool()
+        self.macro.checkPoint()
         self._fill_missing_records()
         yield 100
 


### PR DESCRIPTION
Add a check point in order to avoid filling missing records when
timescan is aborted by the user. Fix #869. @cmft can you check that?