### PR TITLE
Add protection on parameter info reading

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -265,10 +265,15 @@ class SpockCommandWidget(Qt.QLineEdit, TaurusBaseContainer):
 
         # Get the parameters information to check if there are optional
         # paramters
-        macro_obj = self.getModelObj()
-        macro_params_info = macro_obj.getElementInfo(mlist[0]).parameters
+        ms_obj = self.getModelObj()
+        macro_obj = ms_obj.getElementInfo(mlist[0])
+        macro_params_info = None
+        if macro_obj is not None:
+            macro_params_info = macro_obj.parameters
 
         while not ix == Qt.QModelIndex():
+            if macro_params_info is None:
+                break
             try:
                 propValue = mlist[counter]
                 try:


### PR DESCRIPTION
Avoid exception raising during the macro typing on the macroexecutor widget. It resolves #941 