### PR TITLE
Warn when macros gets overridden

### DIFF
--- a/src/sardana/macroserver/macros/lists.py
+++ b/src/sardana/macroserver/macros/lists.py
@@ -108,6 +108,8 @@ class _lsobj(_ls):
     width = -1,     -1,           -1,     -1  # ,      -1
     align = Right,  Right,        Right,  Right  # ,   Right
 
+    show_overwritten_msg = False
+
     def objs(self, filter):
         return self.findObjs(filter, type_class=self.type, subtype=self.subtype,
                              reserve=False)
@@ -118,6 +120,13 @@ class _lsobj(_ls):
         for col in cols:
             if col == 'controller':
                 value = self.getController(o.controller).name
+            elif col == 'name':
+                isoverwritten = getattr(o, "isoverwritten", False)
+                value = getattr(o, col)
+                if isoverwritten is True:
+                    value = "[*] " + value
+                    if self.show_overwritten_msg is False:
+                        self.show_overwritten_msg = True
             else:
                 value = getattr(o, col)
                 if value is None:
@@ -148,8 +157,13 @@ class _lsobj(_ls):
                 out.appendRow(self.obj2Row(obj))
             except:
                 pass
+
         for line in out.genOutput():
             self.output(line)
+
+        if (self.show_overwritten_msg is True
+            and hasattr(self, "overwritten_msg")):
+            self.warning(self.overwritten_msg)
 
 
 class lsm(_lsobj):
@@ -260,6 +274,10 @@ class lsmac(_lsobj):
 
     type = Type.MacroCode
     cols = 'Name', ('Location', 'file_path')
+    overwritten_msg = ("\nNote: if [*] is present together with the macro "
+                       + "name means that a macro with the same name \nis "
+                       + "defined in other module with less precedence and "
+                       + "it has been overwritten.")
 
 
 class lsmaclib(_lsobj):

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -194,6 +194,11 @@ class MacroManager(MacroServerManager):
         # elements are absolute paths
         self._macro_path = []
 
+        # list<str>
+        # overwritten macros (macros with the same name defined in
+        # different modules)
+        self._overwritten_macros = []
+
         # dict<Door, <MacroExecutor>
         # key   - door
         # value - MacroExecutor object for the door
@@ -211,6 +216,7 @@ class MacroManager(MacroServerManager):
         self._macro_path = None
         self._macro_dict = None
         self._modules = None
+        self._overwritten_macros = None
 
         MacroServerManager.cleanUp(self)
 
@@ -536,7 +542,21 @@ class MacroManager(MacroServerManager):
                                           logger=self)
             for _, macro in inspect.getmembers(m, _is_macro):
                 try:
-                    self.addMacro(macro_lib, macro)
+                    isoverwritten = False
+                    macro_name = macro.__name__
+                    if macro_name in self._overwritten_macros:
+                        isoverwritten = True
+                    elif (macro_name in self._macro_dict.keys()
+                            and self._macro_dict[macro_name].lib != macro_lib):
+                        isoverwritten = True
+                        msg = ('Macro "{}" defined in "{}" macro library'
+                               + ' has been overwritten by "{}" macro library')
+                        old_lib_name = self._macro_dict[macro_name].lib.name
+                        self.debug(msg.format(macro_name, old_lib_name,
+                                              macro_lib.name))
+                        self._overwritten_macros.append(macro_name)
+
+                    self.addMacro(macro_lib, macro, isoverwritten)
                     count_correct_macros += 1
                 except Exception as e:
                     count_incorrect_macros += 1
@@ -568,30 +588,30 @@ class MacroManager(MacroServerManager):
                     msg += "\nUse relmaclib to reload the corrected macro(s)\n"
                 raise Exception(msg)
 
-    def addMacro(self, macro_lib, macro):
+    def addMacro(self, macro_lib, macro, isoverwritten=False):
         add = self.addMacroFunction
         if inspect.isclass(macro):
             add = self.addMacroClass
-        return add(macro_lib, macro)
+        return add(macro_lib, macro, isoverwritten)
 
-    def addMacroClass(self, macro_lib, klass):
+    def addMacroClass(self, macro_lib, klass, isoverwritten=False):
         macro_name = klass.__name__
         action = (macro_lib.has_macro(macro_name) and "Updating") or "Adding"
         self.debug("%s macro class %s" % (action, macro_name))
 
         params = dict(macro_server=self.macro_server, lib=macro_lib,
-                      klass=klass)
+                      klass=klass, isoverwritten=isoverwritten)
         macro_class = MacroClass(**params)
         macro_lib.add_macro_class(macro_class)
         self._macro_dict[macro_name] = macro_class
 
-    def addMacroFunction(self, macro_lib, func):
+    def addMacroFunction(self, macro_lib, func, isoverwritten=False):
         macro_name = func.func_name
         action = (macro_lib.has_macro(macro_name) and "Updating") or "Adding"
         self.debug("%s macro function %s" % (action, macro_name))
 
         params = dict(macro_server=self.macro_server, lib=macro_lib,
-                      function=func)
+                      function=func, isoverwritten=isoverwritten)
         macro_function = MacroFunction(**params)
         macro_lib.add_macro_function(macro_function)
         self._macro_dict[macro_name] = macro_function

--- a/src/sardana/sardanabase.py
+++ b/src/sardana/sardanabase.py
@@ -59,6 +59,7 @@ class SardanaBaseObject(EventGenerator, EventReceiver, Logger):
         Logger.__init__(self, self._name)
         self._manager = weakref.ref(kwargs.pop('manager'))
         self._parent = weakref.ref(kwargs.pop('parent', self.manager))
+        self.isoverwritten = kwargs.pop('isoverwritten', False)
 
     def get_manager(self):
         """Return the :class:`sardana.Manager` which *owns* this sardana


### PR DESCRIPTION
Add API in the server to identify if a macro is overwritten and report
a debug message.

Modify 'lsmac' macro to show if a macro has been overwritten.

Develop #930