### PR TITLE
Check motor limits before starting the scan

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -384,6 +384,10 @@ class GScan(Logger):
             except ValueError:
                 low = None
             for pos in (m.min_value, m.max_value):
+                if pos is None:
+                    self._macro.warning("Macro did not define position for %s. "
+                        "Limit check was not possible." % m.moveable.getName())
+                    continue
                 if high is not None:
                     if float(pos) > high:
                         raise RuntimeError(

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -385,8 +385,9 @@ class GScan(Logger):
                 low = None
             for pos in (m.min_value, m.max_value):
                 if pos is None:
-                    self._macro.warning("Macro did not define position for %s. "
-                        "Limit check was not possible." % m.moveable.getName())
+                    self._macro.warning("Macro did not define position for %s."
+                                        " Limit check was not possible."
+                                        % m.moveable.getName())
                     continue
                 if high is not None:
                     if float(pos) > high:

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -373,14 +373,19 @@ class GScan(Logger):
 
     def _check_moveables_limits(self):
         for m in self._moveables:
-            config = PyTango.AttributeProxy(
-                m.moveable.getName() + '/position').get_config()
+            pos_range = m.moveable.getAttribute("Position").range
             try:
-                high = float(config.max_value)
+                if type(pos_range[1]) == str:
+                    high = float(pos_range[1])              # Taurus 3
+                else:
+                    high = float(pos_range[1].magnitude)    # Taurus 4
             except ValueError:
                 high = None
             try:
-                low = float(config.min_value)
+                if type(pos_range[0]) == str:
+                    low = float(pos_range[0])               # Taurus 3
+                else:
+                    low = float(pos_range[0].magnitude)     # Taurus 4
             except ValueError:
                 low = None
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -375,19 +375,19 @@ class GScan(Logger):
         for m in self._moveables:
             pos_range = m.moveable.getAttribute("Position").range
             try:
-                if type(pos_range[1]) == str:
-                    high = float(pos_range[1])              # Taurus 3
-                else:
-                    high = float(pos_range[1].magnitude)    # Taurus 4
-            except ValueError:
-                high = None
+                high = float(pos_range[1].magnitude)    # Taurus 4
+            except AttributeError:
+                try:
+                    high = float(pos_range[1])          # Taurus 3
+                except ValueError:
+                    high = None
             try:
-                if type(pos_range[0]) == str:
-                    low = float(pos_range[0])               # Taurus 3
-                else:
-                    low = float(pos_range[0].magnitude)     # Taurus 4
-            except ValueError:
-                low = None
+                low = float(pos_range[0].magnitude)     # Taurus 4
+            except AttributeError:
+                try:
+                    low = float(pos_range[0])           # Taurus 3
+                except ValueError:
+                    low = None
 
             if any((high, low)) and not any((m.min_value, m.max_value)):
                 self._macro.info("Scan range is not defined for %s and could "

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -383,11 +383,14 @@ class GScan(Logger):
                 low = float(config.min_value)
             except ValueError:
                 low = None
+
+            if any((high, low)) and not any((m.min_value, m.max_value)):
+                self._macro.info("Scan range is not defined for %s and could "
+                                 "not be verified against motor limits."
+                                 % m.moveable.getName())
+
             for pos in (m.min_value, m.max_value):
                 if pos is None:
-                    self._macro.warning("Macro did not define position for %s."
-                                        " Limit check was not possible."
-                                        % m.moveable.getName())
                     continue
                 if high is not None:
                     if float(pos) > high:

--- a/src/sardana/tango/pool/test/base_sartest.py
+++ b/src/sardana/tango/pool/test/base_sartest.py
@@ -23,9 +23,10 @@
 ##
 ##############################################################################
 
-import PyTango
+import taurus
+
 from sardana.tango.pool.test import BasePoolTestCase
-from sardana.tango.core.util import get_free_alias
+
 
 __all__ = ['SarTestTestCase']
 
@@ -130,13 +131,28 @@ class SarTestTestCase(BasePoolTestCase):
         """
         dirty_elems = []
         dirty_ctrls = []
+        f = taurus.Factory()
         for elem_name in self.elem_list:
+            # Cleanup eventual taurus devices. This is especially important
+            # if the sardana-taurus extensions are in use since this
+            # devices are created and destroyed within the testsuite.
+            # Persisting taurus device may react on API_EventTimeouts, enabled
+            # polling, etc.
+            if elem_name in f.tango_alias_devs:
+                taurus.Device(elem_name).cleanUp()
             try:
                 self.pool.DeleteElement(elem_name)
             except:
                 dirty_elems.append(elem_name)
 
         for ctrl_name in self.ctrl_list:
+            # Cleanup eventual taurus devices. This is especially important
+            # if the sardana-taurus extensions are in use since this
+            # devices are created and destroyed within the testsuite.
+            # Persisting taurus device may react on API_EventTimeouts, enabled
+            # polling, etc.
+            if elem_name in f.tango_alias_devs:
+                taurus.Device(elem_name).cleanUp()
             try:
                 self.pool.DeleteElement(ctrl_name)
             except:

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1528,6 +1528,11 @@ class MeasurementGroup(PoolElement):
         self._value_buffer_cb = None
         self._codec = CodecFactory().getCodec("json")
 
+    def cleanUp(self):
+        PoolElement.cleanUp(self)
+        f = self.factory()
+        f.removeExistingAttribute(self.__cfg_attr)
+
     def _create_str_tuple(self):
         channel_names = ", ".join(self.getChannelNames())
         return self.getName(), self.getTimerName(), channel_names

--- a/src/sardana/taurus/core/tango/sardana/test/test_pool.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_pool.py
@@ -63,21 +63,21 @@ class TestMeasurementGroup(SarTestTestCase, TestCase):
 
     def setUp(self):
         SarTestTestCase.setUp(self)
-        self.mg_name = str(uuid.uuid1())
         registerExtensions()
 
     def count(self, elements):
-        argin = [self.mg_name] + elements
+        mg_name = str(uuid.uuid1())
+        argin = [mg_name] + elements
         self.pool.CreateMeasurementGroup(argin)
         try:
-            self.mg = Device(self.mg_name)
-            _, values = self.mg.count(1)
+            mg = Device(mg_name)
+            _, values = mg.count(1)
             for channel, value in values.iteritems():
                 msg = "Value for %s is not numerical" % channel
                 self.assertTrue(is_numerical(value), msg)
         finally:
-            self.mg.cleanUp()
-            self.pool.DeleteElement(self.mg_name)
+            mg.cleanUp()
+            self.pool.DeleteElement(mg_name)
 
     def tearDown(self):
         SarTestTestCase.tearDown(self)

--- a/src/sardana/taurus/core/tango/sardana/test/test_pool.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_pool.py
@@ -76,6 +76,7 @@ class TestMeasurementGroup(SarTestTestCase, TestCase):
                 msg = "Value for %s is not numerical" % channel
                 self.assertTrue(is_numerical(value), msg)
         finally:
+            self.mg.cleanUp()
             self.pool.DeleteElement(self.mg_name)
 
     def tearDown(self):

--- a/src/sardana/taurus/core/tango/sardana/test/test_pool.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_pool.py
@@ -95,6 +95,3 @@ class TestMotor(SarTestTestCase, TestCase):
 
     def tearDown(self):
         SarTestTestCase.tearDown(self)
-        # TODO: This sleep is just to demonstrate API_EventTimeout. Remove it!
-        import time
-        time.sleep(20)

--- a/src/sardana/taurus/core/tango/sardana/test/test_pool.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_pool.py
@@ -80,3 +80,20 @@ class TestMeasurementGroup(SarTestTestCase, TestCase):
 
     def tearDown(self):
         SarTestTestCase.tearDown(self)
+
+
+class TestMotor(SarTestTestCase, TestCase):
+
+    def setUp(self):
+        SarTestTestCase.setUp(self)
+        registerExtensions()
+
+    def test_move(self):
+        mot = Device("_test_mt_1_1")
+        _, values = mot.move(1)
+
+    def tearDown(self):
+        SarTestTestCase.tearDown(self)
+        # TODO: This sleep is just to demonstrate API_EventTimeout. Remove it!
+        import time
+        time.sleep(20)


### PR DESCRIPTION
This PR adds limit checking for start and final position to `GScan`.
The implementation is similar to #560 and #704.
It's still a WIP, because so far it was only tested for step scans, and it will **not** go through the pseudomotor hierarchy to check limits, it will check only the moveables explicitly passed to the scan.