### PR TITLE
Fix general hooks broken by #781

### DIFF
--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -45,7 +45,7 @@ a macro class you can benefit from all advantages of object-oriented
 programming. This means that, in theory:
 
     - it would reduce the amount of code you need to write
-    - reduce the complexity of your code y by dividing it into small,
+    - reduce the complexity of your code by dividing it into small,
       reasonably independent and re-usable components, that talk to each other
       using only well-defined interfaces
     - Improvement of productivity by using easily adaptable pre-defined

--- a/src/sardana/macroserver/macros/test/test_gh.py
+++ b/src/sardana/macroserver/macros/test/test_gh.py
@@ -45,7 +45,7 @@ class GeneralHooksTest(BaseMacroServerTestCase, RunMacroTestCase,
     def test_gh(self):
         self.macro_runs(macro_name="defgh", macro_params=["lsm", "pre-acq"],
                         wait_timeout=1)
-        self.macro_runs(macro_name="ct", macro_params=[".1"], wait_timeout=1)
+        self.macro_runs(macro_name="ct", macro_params=[".1"], wait_timeout=3)
         self.macro_runs(macro_name="udefgh", macro_params=["lsm", "pre-acq"],
                         wait_timeout=1)
 

--- a/src/sardana/macroserver/macros/test/test_gh.py
+++ b/src/sardana/macroserver/macros/test/test_gh.py
@@ -35,7 +35,7 @@ from sardana.tango.macroserver.test import BaseMacroServerTestCase
          wait_timeout=1)
 @testRun(macro_name="udefgh", wait_timeout=1)
 class GeneralHooksTest(BaseMacroServerTestCase, RunMacroTestCase,
-                  unittest.TestCase):
+                       unittest.TestCase):
 
     def setUp(self):
         unittest.TestCase.setUp(self)

--- a/src/sardana/macroserver/macros/test/test_gh.py
+++ b/src/sardana/macroserver/macros/test/test_gh.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+from taurus.external import unittest
+
+from sardana.macroserver.macros.test import RunMacroTestCase, testRun
+from sardana.tango.macroserver.test import BaseMacroServerTestCase
+
+
+@testRun(macro_name="lsgh", wait_timeout=1)
+@testRun(macro_name="defgh", macro_params=["lsm", "pre-acq"], wait_timeout=1)
+@testRun(macro_name="udefgh", wait_timeout=1)
+class GeneralHooksTest(BaseMacroServerTestCase, RunMacroTestCase,
+                  unittest.TestCase):
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        BaseMacroServerTestCase.setUp(self)
+        RunMacroTestCase.setUp(self)
+
+    def test_gh(self):
+        self.macro_runs(macro_name="defgh", macro_params=["lsm", "pre-acq"],
+                        wait_timeout=1)
+        self.macro_runs(macro_name="ct", macro_params=[".1"], wait_timeout=1)
+        self.macro_runs(macro_name="udefgh", macro_params=["lsm", "pre-acq"],
+                        wait_timeout=1)
+
+    def tearDown(self):
+        BaseMacroServerTestCase.tearDown(self)
+        RunMacroTestCase.tearDown(self)
+        unittest.TestCase.tearDown(self)

--- a/src/sardana/macroserver/macros/test/test_gh.py
+++ b/src/sardana/macroserver/macros/test/test_gh.py
@@ -31,6 +31,8 @@ from sardana.tango.macroserver.test import BaseMacroServerTestCase
 
 @testRun(macro_name="lsgh", wait_timeout=1)
 @testRun(macro_name="defgh", macro_params=["lsm", "pre-acq"], wait_timeout=1)
+@testRun(macro_name="defgh", macro_params=["lsm mot.*", "pre-acq"],
+         wait_timeout=1)
 @testRun(macro_name="udefgh", wait_timeout=1)
 class GeneralHooksTest(BaseMacroServerTestCase, RunMacroTestCase,
                   unittest.TestCase):

--- a/src/sardana/macroserver/macros/test/test_gh.py
+++ b/src/sardana/macroserver/macros/test/test_gh.py
@@ -27,6 +27,8 @@ from taurus.external import unittest
 
 from sardana.macroserver.macros.test import RunMacroTestCase, testRun
 from sardana.tango.macroserver.test import BaseMacroServerTestCase
+from sardana.tango.pool.test.test_measurementgroup import MeasSarTestTestCase
+from sardana.macroserver.macros.test.test_scanct import mg_config4
 
 
 @testRun(macro_name="lsgh", wait_timeout=1)
@@ -34,22 +36,32 @@ from sardana.tango.macroserver.test import BaseMacroServerTestCase
 @testRun(macro_name="defgh", macro_params=["lsm mot.*", "pre-acq"],
          wait_timeout=1)
 @testRun(macro_name="udefgh", wait_timeout=1)
-class GeneralHooksTest(BaseMacroServerTestCase, RunMacroTestCase,
-                       unittest.TestCase):
+class GeneralHooksTest(MeasSarTestTestCase, BaseMacroServerTestCase,
+                       RunMacroTestCase, unittest.TestCase):
 
     def setUp(self):
-        unittest.TestCase.setUp(self)
+        MeasSarTestTestCase.setUp(self)
         BaseMacroServerTestCase.setUp(self)
         RunMacroTestCase.setUp(self)
+        unittest.TestCase.setUp(self)
+
+    def create_meas(self, config):
+        MeasSarTestTestCase.create_meas(self, config)
+        self.macro_executor.run(macro_name='senv',
+                                macro_params=['ActiveMntGrp', '_test_mg_1'],
+                                sync=True, timeout=1.)
 
     def test_gh(self):
         self.macro_runs(macro_name="defgh", macro_params=["lsm", "pre-acq"],
                         wait_timeout=1)
-        self.macro_runs(macro_name="ct", macro_params=[".1"], wait_timeout=3)
+        self.create_meas(mg_config4)
+        self.macro_runs(macro_name="ct", macro_params=[".1"], wait_timeout=1)
         self.macro_runs(macro_name="udefgh", macro_params=["lsm", "pre-acq"],
                         wait_timeout=1)
 
     def tearDown(self):
-        BaseMacroServerTestCase.tearDown(self)
-        RunMacroTestCase.tearDown(self)
         unittest.TestCase.tearDown(self)
+        RunMacroTestCase.tearDown(self)
+        BaseMacroServerTestCase.tearDown(self)
+        MeasSarTestTestCase.tearDown(self)
+

--- a/src/sardana/macroserver/macros/test/test_gh.py
+++ b/src/sardana/macroserver/macros/test/test_gh.py
@@ -64,4 +64,3 @@ class GeneralHooksTest(MeasSarTestTestCase, BaseMacroServerTestCase,
         RunMacroTestCase.tearDown(self)
         BaseMacroServerTestCase.tearDown(self)
         MeasSarTestTestCase.tearDown(self)
-

--- a/src/sardana/macroserver/macros/test/test_macro.py
+++ b/src/sardana/macroserver/macros/test/test_macro.py
@@ -1,3 +1,28 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
 import os
 
 from taurus.external import unittest

--- a/src/sardana/macroserver/macros/test/test_scanct.py
+++ b/src/sardana/macroserver/macros/test/test_scanct.py
@@ -1,4 +1,28 @@
 #!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
 """Tests for continuous scans (ct-like)"""
 import time
 import PyTango

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1198,7 +1198,16 @@ class MacroExecutor(Logger):
         if len(general_hooks) == 0:
             return
         for hook_info_raw, hook_places in general_hooks:
-            hook_info = ParamParser().parse(hook_info_raw)
+            hook_info_tokens = hook_info_raw.split(" ", 1)
+            hook_name = hook_info_tokens[0]
+            hook_info = [hook_name]
+            if len(hook_info_tokens) == 2:
+                hook_params_raw = hook_info_tokens[1]
+                hook_param_def = self.macro_manager.getMacro(
+                    hook_name).get_parameter()
+                param_parser = ParamParser(hook_param_def)
+                hook_params = param_parser.parse(hook_params_raw)
+                hook_info += hook_params
             hook = ExecMacroHook(macro_obj, hook_info)
             macro_obj.appendHook((hook, hook_places))
 

--- a/src/sardana/tango/macroserver/test/base.py
+++ b/src/sardana/tango/macroserver/test/base.py
@@ -27,11 +27,15 @@
 
 __all__ = ['BaseMacroServerTestCase']
 
+import os
+
 import PyTango
+from taurus.core.util import whichexecutable
 from taurus.core.tango.starter import ProcessStarter
+
 from sardana import sardanacustomsettings
 from sardana.tango.core.util import (get_free_server, get_free_device)
-from taurus.core.util import whichexecutable
+from sardana.tango.macroserver.MacroServer import MacroServerClass
 
 
 class BaseMacroServerTestCase(object):
@@ -56,9 +60,9 @@ class BaseMacroServerTestCase(object):
             # Discover the MS launcher script
             msExec = whichexecutable.whichfile("MacroServer")
             # register MS server
-            ms_ds_name = "MacroServer/" + self.ms_ds_name
-            ms_free_ds_name = get_free_server(db, ms_ds_name)
-            self._msstarter = ProcessStarter(msExec, ms_free_ds_name)
+            ms_ds_name_base = "MacroServer/" + self.ms_ds_name
+            self.ms_ds_name = get_free_server(db, ms_ds_name_base)
+            self._msstarter = ProcessStarter(msExec, self.ms_ds_name)
             # register MS device
             dev_name_parts = self.ms_name.split('/')
             prefix = '/'.join(dev_name_parts[0:2])
@@ -88,10 +92,17 @@ class BaseMacroServerTestCase(object):
     def tearDown(self):
         """Remove the Pool instance.
         """
+        dft_ms_properties = os.path.join(MacroServerClass.DefaultEnvBaseDir,
+                                         MacroServerClass.DefaultEnvRelDir)
+        ds_inst_name = self.ms_ds_name.split("/")[1]
+        ms_properties = dft_ms_properties % {"ds_exec_name": "MacroServer",
+                                             "ds_inst_name": ds_inst_name}
+        os.remove(ms_properties)
         self._msstarter.cleanDb(force=True)
         self._msstarter = None
         self.macroserver = None
         self.door = None
+
 
 if __name__ == '__main__':
     bms = BaseMacroServerTestCase()


### PR DESCRIPTION
#781 made `ParamParser` aware of the parameters definition. General hooks use the `ParamParser`. Adapt geral hooks implementation to pass the parameters definition to the `ParamParser`.

Also add some unit tests.

@sardana-org/integrators it is ready fore review. Thanks!