### PR TITLE
Document RConsolePort

### DIFF
--- a/doc/source/users/configuration/macroserver.rst
+++ b/doc/source/users/configuration/macroserver.rst
@@ -50,5 +50,22 @@ instance. In case Sardana is used with Tango this configuration is
 accessible via the ``LogstashHost`` and ``LogstashPort``
 :class:`~sardana.tango.macroserver.MacroServer.MacroServer` device properties.
 
-.. todo::
-    Document RConsolePort
+You can debug the MacroServer at runtime using the Python remote
+console - ``rconsole`` (part of the `rfoo <https://pypi.org/project/rfoo/>`_
+project). First, you need to specify at which port the MacroServer will
+accept connections. For that, simply set the ``RConsolePort``
+:class:`~sardana.tango.macroserver.MacroServer.MacroServer` property.
+Second, in order to open a connection to a MacroServer just type::
+
+    $> rconsole -p <port>
+
+The most convenient way to debug the MacroServer internals is to use the
+`Tango Util <https://pytango.readthedocs.io/en/stable/server_api/util
+.html#util>`_ singleton object. It is used to store Tango device server
+process data and to provide the user with a set of utilities method.
+For example, to access the MacroServer Sardana core object, in the a rconsole
+session, just type::
+
+    >>> import tango
+    >>> util = tango.Util.instance()
+    >>> ms = util.get_device_by_name("<ms_device_name>").macro_server

--- a/doc/source/users/configuration/macroserver.rst
+++ b/doc/source/users/configuration/macroserver.rst
@@ -62,8 +62,8 @@ Second, in order to open a connection to a MacroServer just type::
 The most convenient way to debug the MacroServer internals is to use the
 `Tango Util <https://pytango.readthedocs.io/en/stable/server_api/util
 .html#util>`_ singleton object. It is used to store Tango device server
-process data and to provide the user with a set of utilities method.
-For example, to access the MacroServer Sardana core object, in the a rconsole
+process data and to provide the user with a set of utility methods.
+For example, to access the MacroServer Sardana core object, in the rconsole
 session, just type::
 
     >>> import tango


### PR DESCRIPTION
This PR complements the MacroServer configuration docs. Eventually, we could add in the future a dedicated chapter for Sardana debugging and a part of this information could be moved there.
@sardana-org/integrators could you please take a look and eventually integrate it? Thansk!