### PR TITLE
Allow changes of pseudo counter data format (shape)

### DIFF
--- a/doc/source/devel/howto_controllers/howto_controller.rst
+++ b/doc/source/devel/howto_controllers/howto_controller.rst
@@ -404,6 +404,33 @@ spock), sardana assignes the default value
 has no default value, if it is not specified by the user, sardana will complain
 and fail to create and instance of SpringfieldMotorController.
 
+.. _sardana-controller-howto-change-default-interface:
+
+Changing default interface
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Elements instantiated from your controller will have a default interface
+corresponding to the controller's type. For example a moveable will have a
+*position* attribute or an experimental channel will have a *value*
+attribute. However this default interface can be changed if necessary.
+
+For example, the default type of a moveable's *position* attribute ``float``
+can be changed to ``long`` if the given axis only allows discrete positions.
+To do that simple override the
+:class:`~sardana.pool.controller.Controller.GetAxisAttributes` where you can
+apply the necessary changes.
+
+Here is an example of how to change motor's *position* attribute to ``long``:
+
+.. code-block:: python
+
+    def GetAxisAttributes(self, axis):
+        axis_attrs = MotorController.GetAxisAttributes(self, axis)
+        axis_attrs = dict(axis_attrs)
+        axis_attrs['Position']['type'] = float
+        return axis_attrs
+
+
 .. _sardana-controller-howto-error-handling:
 
 Error handling

--- a/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
@@ -86,7 +86,7 @@ and specify its maximum dimension of 1024 x 1024 pixels:
         def GetAxisAttributes(self, axis):
         axis_attrs = PseudoCounterController.GetAxisAttributes(self, axis)
         axis_attrs = dict(axis_attrs)
-        axis_attrs['Value'][Type] = (float, float)
+        axis_attrs['Value'][Type] = ((float, ), )
         axis_attrs['Value'][MaxDimSize] = (1024, 1024)
         return axis_attrs
 

--- a/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
@@ -76,7 +76,7 @@ is feed with the result of the
 default it expects values of ``float`` type and scalar shape. You can easily
 :ref:`change the default interface <sardana-controller-howto-change-default-interface>`.
 This way you could program a pseudo counter to obtain an image :term:`ROI`
-of a :ref:`2D experimental channel <sardana-2d-overview2D>`.
+of a :ref:`2D experimental channel <sardana-2d-overview>`.
 
 Here is an example of how to change *value* attribute's shape to an image
 and specify its maximum dimension of 1024 x 1024 pixels:

--- a/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
@@ -66,6 +66,31 @@ negative. The value close to the zero indicates the beam centered in the middle.
 Similarly behaves the horizontal pseudo counter. The total pseudo counter is
 the mean value of all the four sensors and indicates the beam intensity.
 
+Changing default interface
+--------------------------
+
+Pseudo counters instantiated from your controller will have a default
+interface, which among others, comprises the *value* attribute. This attribute
+is feed with the result of the
+:meth:`~sardana.pool.controller.PseudoCounterController.calc` method and by
+default it expects values of ``float`` type and scalar shape. You can easily
+:ref:`change the default interface <sardana-controller-howto-change-default-interface>`.
+This way you could program a pseudo counter to obtain an image :term:`ROI`
+of a :ref:`2D experimental channel <sardana-2d-overview2D>`.
+
+Here is an example of how to change *value* attribute's shape to an image
+and specify its maximum dimension of 1024 x 1024 pixels:
+
+.. code-block:: python
+
+        def GetAxisAttributes(self, axis):
+        axis_attrs = PseudoCounterController.GetAxisAttributes(self, axis)
+        axis_attrs = dict(axis_attrs)
+        axis_attrs['Value'][Type] = (float, float)
+        axis_attrs['Value'][MaxDimSize] = (1024, 1024)
+        return axis_attrs
+
+
 Including external variables in the calculation
 -----------------------------------------------
 

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -420,6 +420,10 @@ Glossary
     
     dial
         See :term:`dial position`
+
+    ROI
+        *Region of interest* are samples within a data set identified for a
+        particular purpose.
         
 .. _plug-in: http://en.wikipedia.org/wiki/Plug-in_(computing)
 .. _CCD: http://en.wikipedia.org/wiki/Charge-coupled_device

--- a/src/sardana/tango/pool/PoolDevice.py
+++ b/src/sardana/tango/pool/PoolDevice.py
@@ -647,7 +647,14 @@ class PoolElementDevice(PoolDevice):
         """
 
         if hasattr(self, "_dynamic_attributes_cache"):
-            return self._standard_attributes_cache, self._dynamic_attributes_cache
+            return self._standard_attributes_cache, \
+                   self._dynamic_attributes_cache
+        std_attrs, dyn_attrs = self._get_dynamic_attributes()
+        self._standard_attributes_cache = std_attrs
+        self._dynamic_attributes_cache = dyn_attrs
+        return std_attrs, dyn_attrs
+
+    def _get_dynamic_attributes(self):
         ctrl = self.ctrl
         if ctrl is None:
             self.warning("no controller: dynamic attributes NOT created")
@@ -656,8 +663,8 @@ class PoolElementDevice(PoolDevice):
             self.warning("controller offline: dynamic attributes NOT created")
             return PoolDevice.get_dynamic_attributes(self)
 
-        self._dynamic_attributes_cache = dyn_attrs = CaselessDict()
-        self._standard_attributes_cache = std_attrs = CaselessDict()
+        dyn_attrs = CaselessDict()
+        std_attrs = CaselessDict()
         dev_class = self.get_device_class()
         axis_attrs = ctrl.get_axis_attributes(self.element.axis)
 

--- a/src/sardana/tango/pool/PseudoCounter.py
+++ b/src/sardana/tango/pool/PseudoCounter.py
@@ -224,7 +224,7 @@ class PseudoCounter(PoolExpChannelDevice):
         state = pseudo_counter.get_state(cache=use_cache, propagate=0)
         if state == State.Moving:
             quality = AttrQuality.ATTR_CHANGING
-        timestamp = value_attr.value
+        timestamp = value_attr.timestamp
         self.set_attribute(attr, value=value, quality=quality,
                            priority=0, timestamp=timestamp)
 

--- a/src/sardana/tango/pool/PseudoCounter.py
+++ b/src/sardana/tango/pool/PseudoCounter.py
@@ -175,9 +175,9 @@ class PseudoCounter(PoolExpChannelDevice):
             PoolExpChannelDevice.get_dynamic_attributes(self)
 
         if not cache_built:
-        # For value attribute, listen to what the controller says for data
-        # type (between long and float) and data format (scalar, spectrum or
-        # image)
+            # For value attribute, listen to what the controller says for data
+            # type (between long and float) and data format (scalar, spectrum
+            # or image)
             value = std_attrs.get('value')
             if value is not None:
                 _, data_info, attr_info = value


### PR DESCRIPTION
This feature was initiated by the #982 discussion. Now it is possible to define pseudo counters which returns a scalar, a spectrum or an image.

I tested it with the following trivial example:

```python

class ROI(PseudoCounterController):
    """A simple pseudo counter which receives an image from a 2D experimental
       channel and returns 1D of its first row"""

    counter_roles = "2D",

    def GetAxisAttributes(self, axis):
        axis_attrs = PseudoCounterController.GetAxisAttributes(self, axis)
        axis_attrs = dict(axis_attrs)
        axis_attrs['Value'][Type] = (float,)
        axis_attrs['Value'][MaxDimSize] = (1024,)
        return axis_attrs

    def Calc(self, axis, counter_values):
        i = counter_values[0]
        s = i[0]
        return s
```

It is very trivial, and assumes image of 1024 x 1024 pixels (for example the one provided by the `DummyTwoDController`).

This PR also includes the necessary documentation.

@sardana-org/integrators it is ready for the review and eventual integration.
Don't hesitate to ask if something does not work at first try. I made it in rush and tested it just with this simple example. Thanks!