### PR TITLE
Fix expconf for Qt 4.4 (signal style compatibility)

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -173,7 +173,7 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
     '''
 
     try:
-        #TODO: For Taurus 4 compatibility
+        # TODO: For Taurus 4 compatibility
         createExpConfChangedDialog = Qt.pyqtSignal()
     except AttributeError:
         pass

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -172,6 +172,12 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
     using the `ExperimentConfiguration` environmental variable for that Door.
     '''
 
+    try:
+        #TODO: For Taurus 4 compatibility
+        createExpConfChangedDialog = Qt.pyqtSignal()
+    except AttributeError:
+        pass
+
     def __init__(self, parent=None, door=None, plotsButton=True,
                  autoUpdate=False):
         Qt.QWidget.__init__(self, parent)
@@ -205,7 +211,7 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
 
         # Pending event variables
         self._expConfChangedDialog = None
-        self.createExpConfChangedDialog = Qt.pyqtSignal()
+
         self.connect(self, Qt.SIGNAL('createExpConfChangedDialog'),
                      self._createExpConfChangedDialog)
 
@@ -351,6 +357,9 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
             else:
                 if self._expConfChangedDialog is None:
                     self.emit(Qt.SIGNAL('createExpConfChangedDialog'))
+                    # TODO: For Taurus 4 compatibility
+                    if hasattr(self, 'createExpConfChangedDialog'):
+                        self.createExpConfChangedDialog.emit()
                 else:
                     msg_details = self._getDetialsText()
                     msg_info = self._getResumeText()


### PR DESCRIPTION
#882 made expconf incompatible with Qt 4.4 (old style signals). This PR fixes it.

@sardana-org/integrators this is ready for review and eventual integration. Thanks in advance!
I have tested it both on Qt 4.4 and Qt 4.8 and for me both works.
