### PR TITLE
Fix limits protection in ascanct when Taurus 4 is used

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1482,6 +1482,12 @@ class CScan(GScan):
         pos_obj = motor.getPositionObj()
         min_pos, _ = pos_obj.getRange()
         try:
+            # Taurus 4 uses quantities however Sardana does not support them
+            # yet - use magnitude for the moment.
+            min_pos = min_pos.magnitude
+        except AttributeError:
+            pass
+        try:
             min_pos = float(min_pos)
         except ValueError:
             min_pos = float('-Inf')
@@ -1494,6 +1500,12 @@ class CScan(GScan):
         '''
         pos_obj = motor.getPositionObj()
         _, max_pos = pos_obj.getRange()
+        try:
+            # Taurus 4 uses quantities however Sardana does not support them
+            # yet - use magnitude for the moment.
+            max_pos = max_pos.magnitude
+        except AttributeError:
+            pass
         try:
             max_pos = float(max_pos)
         except ValueError:


### PR DESCRIPTION
Taurus 4 uses quantities as attribute values, range, etc. Sardana for
the moment does not support them, for example it is not possible to
pass macro parameters as quantities. In the continuous scan, when motor
limits are checked, it is better to use the position attribute limit
magnitudes. Fixes #989.

@sardana-org/integrators this is ready for review and eventual integration. Thanks!