### PR TITLE
Make effective raw counts for each scan point if this is deterministic (fix SEP18)

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1006,6 +1006,7 @@ class SScan(GScan):
         macro = self.macro
         scream = False
 
+        self._deterministic_scan = False
         if hasattr(macro, "nr_points"):
             nr_points = float(macro.nr_points)
             if hasattr(macro, "integ_time"):
@@ -1013,6 +1014,7 @@ class SScan(GScan):
                 self.measurement_group.putIntegrationTime(integ_time)
                 self.measurement_group.setNbStarts(nr_points)
                 self.measurement_group.prepare()
+                self._deterministic_scan = True
             scream = True
         else:
             yield 0.0
@@ -1097,7 +1099,10 @@ class SScan(GScan):
         integ_time = step['integ_time']
         # Acquire data
         self.debug("[START] acquisition")
-        state, data_line = mg.count(integ_time)
+        if self._deterministic_scan:
+            state, data_line = mg.count_raw()
+        else:
+            state, data_line = mg.count(integ_time)
         for ec in self._extra_columns:
             data_line[ec.getName()] = ec.read()
         self.debug("[ END ] acquisition")

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -288,7 +288,6 @@ class PoolAcquisition(PoolAction):
         self._0d_acq_args = None
         self._hw_acq_args = None
         self._synch_args = None
-        self._prepared = False
         self._sw_acq = PoolAcquisitionSoftware(main_element, name=swname)
         self._sw_start_acq = PoolAcquisitionSoftwareStart(
             main_element, name=sw_start_name)
@@ -368,7 +367,6 @@ class PoolAcquisition(PoolAction):
         self._0d_acq_args = None
         self._hw_acq_args = None
         self._synch_args = None
-        self._prepared = False
         ctrls_hw = []
         ctrls_sw = []
         ctrls_sw_start = []
@@ -481,7 +479,6 @@ class PoolAcquisition(PoolAction):
         repetitions = 1
         self._prepare_ctrls(ctrls_sw, value, repetitions, latency,
                             nb_starts)
-        self._prepared = True
 
     @staticmethod
     def _prepare_ctrls(ctrls, value, repetitions, latency, nb_starts):
@@ -504,9 +501,6 @@ class PoolAcquisition(PoolAction):
 
     def run(self, *args, **kwargs):
         """Runs acquisition according to previous preparation."""
-        if not self._prepared:
-            raise RuntimeError('You must call first "prepare" method.')
-
         if self._hw_acq_args is not None:
             self._hw_acq.run(*self._hw_acq_args.args,
                              **self._hw_acq_args.kwargs)
@@ -519,8 +513,6 @@ class PoolAcquisition(PoolAction):
         if self._synch_args is not None:
             self._synch.run(*self._synch_args.args,
                             **self._synch_args.kwargs)
-
-        self._prepared = False
 
     def _get_action_for_element(self, element):
         elem_type = element.get_type()


### PR DESCRIPTION
[SEP18](https://github.com/sardana-org/sardana/blob/develop/doc/source/sep/SEP18.md) implementation forgot to make a different counts depending whether the scan is deterministic (knowns a priori nr of points and integration times) or non-deterministic (number of points as well as integration times may vary depending on scan generator execution). In the first case a `count_raw` should be called, and in the second case a `count` should be called.

This is something what was agreed by acceptance of SEP18 so if there are no negative voices I will integrate it tomorrow. 