### PR TITLE
Fix AcqSynchType broken in SEP18

### DIFF
--- a/doc/source/devel/api/sardana/pool/pooldefs.rst
+++ b/doc/source/devel/api/sardana/pool/pooldefs.rst
@@ -9,13 +9,13 @@
 
 .. autodata:: sardana.pool.pooldefs.ControllerAPI
 
-.. rubric:: Classes
+.. rubric:: Enumerations
 
 .. hlist::
     :columns: 3
 
     * :class:`~AcqSynch`
-    * :class:`~AcqSynchType`
+    * :data:`~AcqSynchType`
     * :class:`~SynchParam`
     * :class:`~SynchDomain`
 
@@ -34,13 +34,7 @@ AcqSynch
 AcqSynchType
 ------------
 
-.. inheritance-diagram:: AcqSynchType
-    :parts: 1
-
-.. autoclass:: AcqSynchType
-    :show-inheritance:
-    :members:
-    :undoc-members:
+.. autodata:: AcqSynchType
 
 
 SynchParam

--- a/src/sardana/pool/pooldefs.py
+++ b/src/sardana/pool/pooldefs.py
@@ -111,21 +111,22 @@ class SynchParam(SynchEnum):
     Initial = 4
 
 
-class AcqSynchType(Enumeration):
+AcqSynchType = Enumeration("AcqSynchType", ["Trigger", "Gate", "Start"])
+AcqSynchType.__doc__ = \
     """Enumeration of synchronization types.
+
+    Options:
+
+    - Trigger - Start each acquisition (experimental channel will decide on
+      itself when to end, based on integration time / monitor count)
+    - Gate - Start and end each acquisition
+    - Start - Start only the first acquisition (experimental channel will
+      drive the acquisition based on integration time / monitor count, latency
+      time and number of repetitions)
 
     .. todo:: convert to python enums, but having in mind problems with
              JSON serialization: https://bugs.python.org/issue18264
     """
-    #: Start each acquisition (experimental channel will decide on
-    #: itself when to end - based on integration time / monitor count)
-    Trigger = 0
-    #: Start and end each acquisition
-    Gate = 1
-    #: Start only the first acquisition (experimental channel will drive
-    #: the acquisition based on integration time / monitor count, latency
-    #: time and number of repetitions)
-    Start = 2
 
 
 class AcqSynch(Enumeration):

--- a/src/sardana/pool/pooldefs.py
+++ b/src/sardana/pool/pooldefs.py
@@ -129,17 +129,14 @@ AcqSynchType.__doc__ = \
     """
 
 
-class AcqSynch(Enumeration):
+class AcqSynch(IntEnum):
     """Enumeration of synchronization options.
 
     Uses software/hardware naming to refer to internal (software
     synchronizer) or external (hardware synchronization device)
-    synchronization modes. See :class:`~sardana.pool.pooldefs.AcqSynchType`
+    synchronization modes. See :obj:`~sardana.pool.pooldefs.AcqSynchType`
     to get more details about the synchronization type e.g. trigger, gate or
     start.
-
-    .. todo:: convert to python enums, but having in mind problems with
-             JSON serialization: https://bugs.python.org/issue18264
     """
     #: Internal (software) trigger
     SoftwareTrigger = 0


### PR DESCRIPTION
SEP18 improved documentation of `AcqSynchType` and `AcqSynch` enumerations. At the same time it broke the `AcqSynchType`. This could be observed when using the expconf and viewing the *Synchronization* column - the following traceback was logged and the values in the columnt were not shown

```
Traceback (most recent call last):
  File "/home/zreszela/workspace/sardana/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py", line 515, in data
    return Qt.QVariant(AcqSynchType[synchronization])
TypeError: 'type' object has no attribute '__getitem__'
```

I consider it as the integrators (my) mistake and will integrate it as soon as CI is green. Please comment if you don't agree. Thanks!