### PR TITLE
Fix measurement group configuration

### DIFF
--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -858,11 +858,8 @@ class MeasurementConfiguration(object):
         channel_data['conditioning'] = channel_data.get('conditioning', '')
         channel_data['normalization'] = channel_data.get('normalization',
                                                          Normalization.No)
-        # TODO use real values
-        channel_data['data_type'] = channel_data.get('data_type', 'float64')
-        channel_data['data_units'] = channel_data.get('data_units', 'No unit')
-        channel_data['nexus_path'] = channel_data.get('nexus_path', '')
-        channel_data['shape'] = channel_data.get('shape', [])
+        # TODO: think of filling other keys: data_type, data_units, nexus_path
+        # shape here instead of feeling them on the Taurus extension level
 
         if ctype != ElementType.External:
             ctrl_name = channel.controller.full_name


### PR DESCRIPTION
This PR fixes measurement group configuration broken with SEP18.

It simply comes back to the solution where the following channel's default configurations: `data_type`, `data_units`, `nexus_path` and `shape` were obtained on the client side (Taurus extension) if not explicitelly set by the user.

An alternative to that could be to generate them on the server side (this is what SEP18 left as a TODO) at the measurement group creation time. For example the `data_type` together with the `shape` could be taken from the controller's axis attribute's definition. The resting two: `nexus_path` and `data_units` could be simply set to empty string.

I have done a proof-of-concept of that and paste it here just in case it is usefull in the future (it may be usefull already in SEP2).

First of all, the `Value` attribute of any experimental channel, or even any attribute from the controller's element shoud have this method:

```python
from sardana.pool.poolmetacontroller import DataInfo

def get_info(self):
    """Get attribute info from its definition in the controller

    ..todo:: Think about storing this info in the attribute object itself
    or about more generic way of extracting this info. Maybe a new class
    for the controller's attributes?
    """
    obj = self.obj
    attr_info = obj.controller.get_axis_attributes(obj.axis)[self.name]
    info = DataInfo.toDataInfo(self.name, attr_info)
    return info
```

Then, in the measurement group configuration, one could extract the necessary configurations with the following helpers:

```python
from sardana import DataFormat, DataType

def get_ndim(attr_info):
    dformat = attr_info.dformat
    if dformat == DataFormat.Scalar:
        ndim = 0
    elif dformat == DataFormat.OneD:
        ndim = 1
    elif dformat == DataFormat.TwoD:
        ndim = 2
    return ndim


def get_type(attr_info):
    dtype = attr_info.dtype
    if dtype == DataType.Double:
        return "float"
    else:
        msg = "{0} data type is not implemented".format(dtype)
        raise NotImplementedError(msg)


def get_shape(attr_info):
    try:
        shape = attr_info.maxdimsize
    except AttributeError:
        shape = tuple()
    return shape

value_info = channel.get_value_attribute().get_info()
ndim = get_ndim(value_info)
data_type = get_type(value_info)
shape = get_shape(value_info)
```

Menwhile, in order to fix the bug, which for example affects the HDF5 recorder when using 1D or 2D experimental channels, I propose to come to the previous solution and do not fill the said four channels configurations on the server side at all.

I consider it as a mistake of the SEP18 integrators (myself) and will integrate it as soon as travis-ci let me do that:) Feel free to comment.