### PR TITLE
ExpConf -  Emit 'experimentConfigurationChanged' on external changes

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -441,6 +441,8 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
         for tg_info in tg_elements.values():
             avail_triggers[tg_info.full_name] = tg_info.getData()
         self.ui.channelEditor.getQModel().setAvailableTriggers(avail_triggers)
+        self.emit(Qt.SIGNAL('experimentConfigurationChanged'),
+                  copy.deepcopy(conf))
 
     def _setDirty(self, dirty):
         self._dirty = dirty


### PR DESCRIPTION
This solves the issue #1012.
The scan plot only received 'experimentConfigurationChanged' when the changes were made in the expconf widget.
With this fix, the event is also propagated when the measurement group is modified from external client, in this case Macros.