### PR TITLE
Fix PC broken in SEP18 - clear buffers before each acquisition

### DIFF
--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -371,21 +371,6 @@ class PoolAcquisition(PoolAction):
         ctrls_sw = []
         ctrls_sw_start = []
 
-        for elem in self.get_elements():
-            elem.put_state(None)
-            # TODO: temporarily clear value buffers at the beginning of the
-            # acquisition instead of doing it in the finish hook of each
-            # acquisition sub-actions. See extensive explanation in the
-            # constructor of PoolAcquisitionBase.
-            try:
-                elem.clear_value_buffer()
-            except AttributeError:
-                continue
-            # clean also the pseudo counters, even the ones that do not
-            # participate directly in the acquisition
-            for pseudo_elem in elem.get_pseudo_elements():
-                pseudo_elem.clear_value_buffer()
-
         repetitions = synchronization.repetitions
         latency = synchronization.passive_time
         # Prepare controllers synchronized by hardware
@@ -501,6 +486,22 @@ class PoolAcquisition(PoolAction):
 
     def run(self, *args, **kwargs):
         """Runs acquisition according to previous preparation."""
+
+        for elem in self.get_elements():
+            elem.put_state(None)
+            # TODO: temporarily clear value buffers at the beginning of the
+            # acquisition instead of doing it in the finish hook of each
+            # acquisition sub-actions. See extensive explanation in the
+            # constructor of PoolAcquisitionBase.
+            try:
+                elem.clear_value_buffer()
+            except AttributeError:
+                continue
+            # clean also the pseudo counters, even the ones that do not
+            # participate directly in the acquisition
+            for pseudo_elem in elem.get_pseudo_elements():
+                pseudo_elem.clear_value_buffer()
+
         if self._hw_acq_args is not None:
             self._hw_acq.run(*self._hw_acq_args.args,
                              **self._hw_acq_args.kwargs)

--- a/src/sardana/sardanabuffer.py
+++ b/src/sardana/sardanabuffer.py
@@ -128,7 +128,7 @@ class SardanaBuffer(EventGenerator):
         try:
             return self._buffer[idx]
         except KeyError:
-            msg = "value with %s index is not in buffer"
+            msg = "value with %s index is not in buffer" % idx
             if self.next_idx > idx:
                 raise LateValueException(msg)
             else:
@@ -191,7 +191,7 @@ class SardanaBuffer(EventGenerator):
         try:
             return self._buffer.pop(idx)
         except KeyError:
-            msg = "value with %s index is not in buffer"
+            msg = "value with %s index is not in buffer" % idx
             raise KeyError(msg)
 
     def fire_add_event(self, propagate=1):


### PR DESCRIPTION
Physical elements of the pseudo counters need to clear the buffers before each acquisition. In SEP18 this was moved to the acqusition preparation but needs to be done in the acqusition start. Otherwise
step scans does not works.

This solves the issue reported by @dschick in https://github.com/sardana-org/sardana/issues/1011#issuecomment-453490070 .
Since this was broken in SEP18 I assume it as the integrator's (my) mistake and will integrate it as soon as travis-ci is green.