### PR TITLE
Fix timescan (count_continuous method) 

### DIFF
--- a/src/sardana/macroserver/macros/test/test_scan.py
+++ b/src/sardana/macroserver/macros/test/test_scan.py
@@ -167,3 +167,9 @@ class MeshTest(RunStopMacroTestCase, unittest.TestCase):
     stoped. See :class:`.RunStopMacroTestCase` for requirements.
     """
     macro_name = 'mesh'
+
+
+@testRun(macro_params=['10', '0.1'], wait_timeout=30)
+class TimescanTest(RunStopMacroTestCase, unittest.TestCase):
+
+    macro_name = 'timescan'

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1857,7 +1857,7 @@ class MeasurementGroup(PoolElement):
         cfg.prepare()
         self.setSynchronization(synchronization)
         self.subscribeValueBuffer(value_buffer_cb)
-        self.count_raw(self)
+        self.count_raw(start_time)
         self.unsubscribeValueBuffer(value_buffer_cb)
         state = self.getStateEG().readValue()
         if state == Fault:


### PR DESCRIPTION
This PR fixes a bug introduced in the SEP18. The change is trivial, and since it was the integrators (my) mistake I will merge it as soon as we get green light from travis-ci.

I take a profit of this PR to add a test for the timescan macro and will push it in two steps in order to trigger twice the travis-ci. The first push and commit will add a test which should fail and the second push and commit should solve it. 