### PR TITLE
Separate DynamiPlotManager from the expconf

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -441,8 +441,6 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
         for tg_info in tg_elements.values():
             avail_triggers[tg_info.full_name] = tg_info.getData()
         self.ui.channelEditor.getQModel().setAvailableTriggers(avail_triggers)
-        self.experimentConfigurationChanged.emit(copy.deepcopy(conf))
-
 
     def _setDirty(self, dirty):
         self._dirty = dirty
@@ -537,7 +535,6 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
         self._dirtyMntGrps = set()
         self.ui.channelEditor.getQModel().setDataChanged(False)
         self._setDirty(False)
-        self.experimentConfigurationChanged.emit(copy.deepcopy(conf))
         return True
 
     @Qt.pyqtSlot('QString')
@@ -669,11 +666,7 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
                 DynamicPlotManager
             self.__plotManager = DynamicPlotManager(self)
             self.__plotManager.setModel(self.getModelName())
-            self.experimentConfigurationChanged.connect(
-                self.__plotManager.onExpConfChanged)
         else:
-            self.experimentConfigurationChanged.disconnect(
-                self.__plotManager.onExpConfChanged)
             self.__plotManager.removePanels()
             self.__plotManager.setModel(None)
             self.__plotManager = None

--- a/src/sardana/taurus/qt/qtgui/macrolistener/macrolistener.py
+++ b/src/sardana/taurus/qt/qtgui/macrolistener/macrolistener.py
@@ -104,6 +104,9 @@ class DynamicPlotManager(Qt.QObject, TaurusBaseComponent):
         expconf = door.getExperimentConfiguration()
         self.onExpConfChanged(expconf)
 
+        # Connect experiment configuration changes
+        door.experimentConfigurationChanged.connect(self.onExpConfChanged)
+
     def _checkJsonRecorder(self):
         '''Checks if JsonRecorder env var is set and offers to set it'''
         door = self.getModelObj()


### PR DESCRIPTION
Before this PR, the scan trends react to "experimentConfigurationChanged" Qt signal comming from the ExpDescriptionEditor widget.

With the changes in this PR the scan trends (DynamiPlotManager) are connected to the "experimentConfigurationChanged" Qt signal coming from the QDoor directly, emitting signals regardless of the client who made the changes.

Therefore, the scan trends are completely separated from the expconf widget.

**NOTE:**
This PR has been tested with Taurus TEP18 version using the **new QT signals.**