### PR TITLE
Add backwards compatibility for measurement group plot configuration (fixes #1017)

### DIFF
--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -717,6 +717,7 @@ class MeasurementConfiguration(object):
                 else:
                     if to_fqdn:
                         ch_name = _to_fqdn(ch_name, logger=self._parent)
+                        ch_data['full_name'] = ch_name
                     channel = pool.get_element_by_full_name(ch_name)
                 ch_data = self._fill_channel_data(channel, ch_data)
                 user_config_channel[ch_name] = ch_data

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -439,7 +439,7 @@ class MeasurementConfiguration(object):
         self._master_monitor_sw_start = None
         self._label = None
         self._description = None
-        self._user_confg = {}
+        self._user_config = {}
         self._channel_acq_synch = {}
         self._ctrl_acq_synch = {}
         self.changed = False
@@ -584,7 +584,7 @@ class MeasurementConfiguration(object):
 
     def get_configuration_for_user(self):
         """Return measurement configuration serializable data structure."""
-        return self._user_confg
+        return self._user_config
 
     def set_configuration_from_user(self, cfg, to_fqdn=True):
         """Load measurement configuration from serializable data structure."""
@@ -802,7 +802,7 @@ class MeasurementConfiguration(object):
         self._master_monitor_sw = master_monitor_sw
         self._master_timer_sw_start = master_timer_sw_start
         self._master_monitor_sw_start = master_monitor_sw_start
-        self._user_confg = user_config
+        self._user_config = user_config
         self._channel_acq_synch = channel_acq_synch
         self._ctrl_acq_synch = ctrl_acq_synch
 


### PR DESCRIPTION
This PR fixes #1017 by adding back-comp for measurement group plotting configurations.

Measurement group plotting configurations created with sardana < 2.4.0 and taurus < 4.3.0 are not compatible after the upgrade. Fix it by using channel's full name URIs (tango scheme + FQDN).

@sardana-org/integrators it is ready to be reviewed, thanks!

@julianofjm, @kklmn your confirmation of the fix would speed up the integration process, thanks!
Do you need a hotfix release for sardana 2.4.0 or 2.5.0? Otherwise, soon we will release Jan19 milestone and the fix will be there anyway.