### PR TITLE
Add auto-update action (context menu) in expconf widget.

### DIFF
--- a/doc/source/users/taurus/experimentconfiguration.rst
+++ b/doc/source/users/taurus/experimentconfiguration.rst
@@ -9,7 +9,7 @@ Experiment Configuration user interface
 
 .. contents::
 
-Experiment Configuration widget a.k.a. expconf is a complete interface to
+Experiment Configuration widget a.k.a. ``expconf`` is a complete interface to
 define the experiment configuration. It consists of three main groups of
 parameters organized in tabs:
 
@@ -22,7 +22,9 @@ will be maintained as pending to apply until either applied or reset by the
 user.
 
 This widget is usually present in sardana-aware Taurus GUIs and is also invoked
-by the `expconf` command in :ref:`Spock<sardana-spock>`
+by the ``expconf`` command in :ref:`Spock<sardana-spock>`.
+
+
 
 .. _expconf_ui_measurementgroup:
 

--- a/doc/source/users/taurus/experimentconfiguration.rst
+++ b/doc/source/users/taurus/experimentconfiguration.rst
@@ -21,6 +21,19 @@ The parameters may be modified in an arbitrary order, at any of the tabs, and
 will be maintained as pending to apply until either applied or reset by the
 user.
 
+.. important::
+  While editing configuration in the ``expconf`` widget, the experiment
+  configuration on the server may have changed, for example, another
+  ``expconf`` instance applied changes or a running macro changed it
+  programmatically. This is notified to the user with a pop-up dialog
+  offering the user to either keep the local version of the experiment
+  configuration or to load the new configuration from the server. Be aware that
+  the second option will **override all your local changes**. It is also
+  possible to use the ``expconf`` widget in *slave* mode and automatically
+  update on the server changes. You can enable/disable the "Auto update" mode
+  from the context menu.
+
+
 This widget is usually present in sardana-aware Taurus GUIs and is also invoked
 by the ``expconf`` command in :ref:`Spock<sardana-spock>`.
 

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -238,7 +238,7 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
             self.onChooseScanDirButtonClicked)
 
         self.__plotManager = None
-        tooltip = "Show/Hide plots"
+        tooltip = None
 
         # TODO: Disable show scan button since scan plot have to be
         # adapted to support QT5
@@ -252,7 +252,9 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
 
         icon = resource.getIcon(":/actions/view.svg")
         measGrpTab = self.ui.tabWidget.widget(0)
-        self.togglePlotsAction = Qt.QAction(icon, tooltip, self)
+        self.togglePlotsAction = Qt.QAction(icon, "Show/Hide plots", self)
+        if tooltip is not None:
+            self.togglePlotsAction.setToolTip(tooltip)
         self.togglePlotsAction.setCheckable(True)
         self.togglePlotsAction.setChecked(False)
         self.togglePlotsAction.setEnabled(plotsButton)

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -206,8 +206,7 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
         self.setContextMenuPolicy(Qt.Qt.ActionsContextMenu)
         self._autoUpdateAction = Qt.QAction("Auto update", self)
         self._autoUpdateAction.setCheckable(True)
-        self.connect(self._autoUpdateAction, Qt.SIGNAL(
-            "toggled(bool)"), self.setAutoUpdate)
+        self._autoUpdateAction.toggled.connect(self.setAutoUpdate)
         self.addAction(self._autoUpdateAction)
         self.registerConfigProperty(
             self.isAutoUpdate, self.setAutoUpdate, "autoUpdate")

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -202,12 +202,12 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
 
         self._warningWidget = None
         self._autoUpdate = False
-        self.setAutoUpdate(autoUpdate)
         self.setContextMenuPolicy(Qt.Qt.ActionsContextMenu)
         self._autoUpdateAction = Qt.QAction("Auto update", self)
         self._autoUpdateAction.setCheckable(True)
         self._autoUpdateAction.toggled.connect(self.setAutoUpdate)
         self.addAction(self._autoUpdateAction)
+        self._autoUpdateAction.setChecked(autoUpdate)
         self.registerConfigProperty(
             self.isAutoUpdate, self.setAutoUpdate, "autoUpdate")
 

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -203,11 +203,17 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
         self._dirty = False
         self._dirtyMntGrps = set()
 
-        # Add warning message to the Widget
-        self._autoUpdate = autoUpdate
-        if self._autoUpdate:
-            w = self._getWarningWidget()
-            self.ui.verticalLayout_3.insertWidget(0, w)
+        self._warningWidget = None
+        self._autoUpdate = False
+        self.setAutoUpdate(autoUpdate)
+        self.setContextMenuPolicy(Qt.Qt.ActionsContextMenu)
+        self._autoUpdateAction = Qt.QAction("Auto update", self)
+        self._autoUpdateAction.setCheckable(True)
+        self.connect(self._autoUpdateAction, Qt.SIGNAL(
+            "toggled(bool)"), self.setAutoUpdate)
+        self.addAction(self._autoUpdateAction)
+        self.registerConfigProperty(
+            self.isAutoUpdate, self.setAutoUpdate, "autoUpdate")
 
         # Pending event variables
         self._expConfChangedDialog = None
@@ -262,6 +268,19 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
 
         # Taurus Configuration properties and delegates
         self.registerConfigDelegate(self.ui.channelEditor)
+
+    def setAutoUpdate(self, auto_update):
+        if auto_update and not self._autoUpdate:
+            self._warningWidget = self._getWarningWidget()
+            self.ui.verticalLayout_3.insertWidget(0, self._warningWidget)
+        if not auto_update and self._autoUpdate:
+            self.ui.verticalLayout_3.removeWidget(self._warningWidget)
+            self._warningWidget.deleteLater()
+            self._warningWidget = None
+        self._autoUpdate = auto_update
+
+    def isAutoUpdate(self):
+        return self._autoUpdate
 
     def _getWarningWidget(self):
         w = Qt.QWidget()

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -243,11 +243,14 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
 
         self.__plotManager = None
         icon = resource.getIcon(":/actions/view.svg")
-        self.togglePlotsAction = Qt.QAction(icon, "Show/Hide plots", self)
+        measGrpTab = self.ui.tabWidget.widget(0)
+        self.togglePlotsAction = Qt.QAction(icon, "Show/Hide plots",
+                                            measGrpTab)
         self.togglePlotsAction.setCheckable(True)
         self.togglePlotsAction.setChecked(False)
         self.togglePlotsAction.setEnabled(plotsButton)
-        self.addAction(self.togglePlotsAction)
+        measGrpTab.addAction(self.togglePlotsAction)
+        measGrpTab.setContextMenuPolicy(Qt.Qt.ActionsContextMenu)
         self.connect(self.togglePlotsAction, Qt.SIGNAL("toggled(bool)"),
                      self.onPlotsButtonToggled)
         self.ui.plotsButton.setDefaultAction(self.togglePlotsAction)


### PR DESCRIPTION
As stated in #961 an access to the auto-update feature of expconf from the graphical interface is missing. Note that it is available when starting expconf in spock (--auto-update).

This PR adds a context menu to the expconf (also fixing some context menu issues of the measurement group tab) with an action to enable/disable auto update. Also a short documentation is added.

The autoupdate feature is saved in the applications settings, so in case of setting it in a TaurusGUI this setting will persist (it will be reapplied on the GUI restart). It is pending to add the same feature when expconf is started from spock.

I tested it both on Qt4 and Qt5 and it worked fine for me and I see it ready for review and eventual integration. I see it quite important to be included in the Debian10 release and the Jan19 milestone. @sardana-org/integrators any volunteers? Thanks!