### PR TITLE
Improve macroexecutor error msg when loading settings

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -1114,8 +1114,11 @@ class BaseMacroServer(MacroServerDevice):
         macroName = macroNode.name()
         macroInfoObj = self.getMacroInfoObj(macroName)
         if macroInfoObj is None:
-            raise Exception(
-                "It was not possible to get information about %s macro.\nCheck if MacroServer is alive and if this macro exist." % macroName)
+            msg = "It was not possible to get information about {0} " \
+                  "macro. Check if MacroServer is alive and if this macro " \
+                  "exist.".format(macroName)
+            self.info(msg)
+            raise Exception("no info about macro {0}".format(macroName))
         allowedHookPlaces = []
         hints = macroInfoObj.hints or {}
         for hook in hints.get("allowsHooks", []):


### PR DESCRIPTION
This is a cosmetic change about the way we show to the user problems with loading settings in the macroexecutor. The best is to evaluate it with the following eventual changes in Taurus [taurus-org/taurus#855](https://github.com/taurus-org/taurus/pull/855).

Before:
![image](https://user-images.githubusercontent.com/6735649/52114254-df0a4a00-260b-11e9-98e4-254c59a389a7.png)


After:
![image](https://user-images.githubusercontent.com/6735649/52114109-7d49e000-260b-11e9-882b-7ccf0c5c7822.png)

Hint on checking if the MacroServer is alive or if the macro is loaded was moved to the logging message.
