### PR TITLE
Warn when hooks gets overridden

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -265,7 +265,7 @@ class Hookable(Logger):
             return
 
         if len(self.hooks) > 0:
-            self.warning("previously set hooks, these may include general"
+            self.warning("previously set hooks, these may include general "
                          "hooks, are being overridden now")
         # store self._hooks, making sure it is of type:
         # list<callable,list<str>>

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -264,6 +264,9 @@ class Hookable(Logger):
                 'the hooks must be passed as a list<callable,list<str>>')
             return
 
+        if len(self.hooks) > 0:
+            self.warning("previously set hooks, these may include general"
+                         "hooks, are being overridden now")
         # store self._hooks, making sure it is of type:
         # list<callable,list<str>>
         self._hooks = []

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -265,8 +265,11 @@ class Hookable(Logger):
             return
 
         if len(self.hooks) > 0:
-            self.warning("previously set hooks, these may include general "
-                         "hooks, are being overridden now")
+            msg = ("This macro defines its own hooks. Previously defined "
+                   "hooks, including the general ones, would be only called "
+                   "if these own hooks were added using the appendHook "
+                   "method or appended to the self.hooks.")
+            self.warning(msg)
         # store self._hooks, making sure it is of type:
         # list<callable,list<str>>
         self._hooks = []


### PR DESCRIPTION
This is related to #962 and #1013.
On one of the internal meetings at Alba @srgblnch commented that the `Hookable.hooks` property setter could warn about the fact of overriding general hooks. What is your opinion to add it?

I already created a PR for that, the output looks like this:

```
Door_zreszela_1 [12]: defgh ct pre-acq
Defining general hook
ct

Door_zreszela_1 [13]: lsgh
   Hook place   Hook(s)
 ------------ ---------
      pre-acq        ct

Door_zreszela_1 [14]: captain_hook 0 10 1
previously set hooks, these may include general hooks, are being overridden now
Starting loop
At step 0
running hook with hints=['pre-acq']
        hook execution
At step 1
running hook with hints=['pre-acq']
        hook execution
At step 2
running hook with hints=['pre-acq']
        hook execution
At step 3
running hook with hints=['pre-acq']
        hook execution
At step 4
running hook with hints=['pre-acq']
        hook execution
At step 5
running hook with hints=['pre-acq']
        hook execution
At step 6
running hook with hints=['pre-acq']
        hook execution
At step 7
running hook with hints=['pre-acq']
        hook execution
At step 8
running hook with hints=['pre-acq']
        hook execution
At step 9
running hook with hints=['pre-acq']
        hook execution
Finished loop
```

