### PR TITLE
Fix independent acquisition when timer is set to __self

### DIFF
--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -206,6 +206,16 @@ class ControllerConfiguration(ConfigurationItem):
                 self._channels_disabled = []
             self._channels_disabled.append(channel_item)
 
+    def remove_channel(self, channel_item):
+        """Remove a channel configuration item."""
+        self._channels.remove(channel_item)
+        if channel_item.enabled:
+            self._channels_enabled.remove(channel_item)
+            if len(self._channels_enabled) == 0:
+                self.enabled = False
+        else:
+            self._channels_disabled.remove(channel_item)
+
     def update_state(self):
         """Update internal state based on the aggregated channels."""
         self.enabled = False


### PR DESCRIPTION
This was discovered yesterday on the follow-up meeting when doing a demo.

One can reproduce in `itango` where ct02 is a second axis of the dummy counter/timer controller:
```
In [13]: c = CTExpChannel("ct02")
In [14]: c.integrationtime = 0.1
In [15]: c.start()
In [16]: c.timer = "__self"
PyDs_PythonError: AttributeError: 'PoolController' object has no attribute 'remove_channel'

(For more detailed information type: tango_error)

In [17]: tango_error
Last tango error:
DevFailed[
DevError[
    desc = AttributeError: 'PoolController' object has no attribute 'remove_channel'
           
  origin =   File "/home/zreszela/workspace/sardana/src/sardana/tango/pool/PoolDevice.py", line 954, in write_Timer
    self.element.timer = timer
  File "/home/zreszela/workspace/sardana/src/sardana/pool/poolbasechannel.py", line 364, in set_timer
    self._conf_ctrl.remove_channel(self._conf_timer)
  File "/home/zreszela/workspace/sardana/src/sardana/pool/poolmeasurementgroup.py", line 161, in __getattr__
    return getattr(self.element, item)

  reason = PyDs_PythonError
severity = ERR]

DevError[
    desc = Failed to write_attribute on device expchan/ctctrl01/2, attribute timer
  origin = DeviceProxy::write_attribute()
  reason = API_AttributeFailed
severity = ERR]
]
```