### PR TITLE
Adapt ct and uct to accept timerable channels

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -648,6 +648,15 @@ class tw(iMacro):
 ##########################################################################
 
 
+def _value_to_repr(data):
+    if data is None:
+        return "<nodata>"
+    elif np.rank(data) > 0:
+        return list(np.shape(data))
+    else:
+        return data
+
+
 class ct(Macro, Hookable):
     """Count for the specified time on the active measurement group"""
 
@@ -655,24 +664,23 @@ class ct(Macro, Hookable):
     hints = {'allowsHooks': ('pre-acq', 'post-acq')}
     param_def = [
         ['integ_time', Type.Float, 1.0, 'Integration time'],
-        ['mnt_grp', Type.MeasurementGroup, Optional, 'Measurement Group to '
-                                                     'use']
-
+        ['countable_elem', Type.Countable, Optional,
+         'Countable element e.g. MeasurementGroup or ExpChannel']
     ]
 
-    def prepare(self, integ_time, mnt_grp, **opts):
-        if mnt_grp is None:
-            self.mnt_grp_name = self.getEnv('ActiveMntGrp')
-            self.mnt_grp = self.getObj(self.mnt_grp_name,
+    def prepare(self, integ_time, countable_elem, **opts):
+        if countable_elem is None:
+            self.countable_elem_name = self.getEnv('ActiveMntGrp')
+            self.countable_elem = self.getObj(self.countable_elem_name,
                                        type_class=Type.MeasurementGroup)
         else:
-            self.mnt_grp_name = mnt_grp.name
-            self.mnt_grp = mnt_grp
+            self.countable_elem_name = countable_elem.name
+            self.countable_elem = countable_elem
 
-    def run(self, integ_time, mnt_grp):
-        if self.mnt_grp is None:
+    def run(self, integ_time, countable_elem):
+        if self.countable_elem is None:
             self.error('The MntGrp {} is not defined or has invalid '
-                       'value'.format(self.mnt_grp_name))
+                       'value'.format(self.countable_elem_name))
             return
         # integration time has to be accessible from with in the hooks
         # so declare it also instance attribute
@@ -685,21 +693,30 @@ class ct(Macro, Hookable):
         for preAcqHook in self.getHooks('pre-acq'):
             preAcqHook()
 
-        state, data = self.mnt_grp.count(integ_time)
+        state, data = self.countable_elem.count(integ_time)
 
         for postAcqHook in self.getHooks('post-acq'):
             postAcqHook()
 
         names, counts = [], []
-        for ch_info in self.mnt_grp.getChannelsEnabledInfo():
-            names.append('  %s' % ch_info.label)
-            ch_data = data.get(ch_info.full_name)
-            if ch_data is None:
-                counts.append("<nodata>")
-            elif ch_info.shape > [1]:
-                counts.append(list(ch_data.shape))
-            else:
-                counts.append(ch_data)
+        if self.countable_elem.type == Type.MeasurementGroup:
+            # TODO: check if possible to use _value_to_repr helper
+            meas_grp = self.countable_elem
+            for ch_info in meas_grp.getChannelsEnabledInfo():
+                names.append('  %s' % ch_info.label)
+                ch_data = data.get(ch_info.full_name)
+                if ch_data is None:
+                    counts.append("<nodata>")
+                elif ch_info.shape > [1]:
+                    counts.append(list(ch_data.shape))
+                else:
+                    counts.append(ch_data)
+        else:
+            channel = self.countable_elem
+            names.append("  %s" % channel.name)
+            value = channel.getValue()
+            counts.append(_value_to_repr(value))
+            data = {channel.full_name: value}
         self.setData(Record(data))
         table = Table([counts], row_head_str=names, row_head_fmt='%*s',
                       col_sep='  =  ')
@@ -714,48 +731,57 @@ class uct(Macro):
 
     param_def = [
         ['integ_time', Type.Float, 1.0, 'Integration time'],
-        ['mnt_grp', Type.MeasurementGroup, Optional, 'Measurement Group to '
+        ['countable_elem', Type.Countable, Optional, 'Measurement Group to '
                                                      'use']
 
     ]
 
-    def prepare(self, integ_time, mnt_grp, **opts):
+    def prepare(self, integ_time, countable_elem, **opts):
 
         self.print_value = False
 
-        if mnt_grp is None:
-            self.mnt_grp_name = self.getEnv('ActiveMntGrp')
-            self.mnt_grp = self.getObj(self.mnt_grp_name,
-                                       type_class=Type.MeasurementGroup)
+        if countable_elem is None:
+            self.countable_elem_name = self.getEnv('ActiveMntGrp')
+            self.countable_elem = self.getObj(self.countable_elem_name)
         else:
-            self.mnt_grp_name = mnt_grp.name
-            self.mnt_grp = mnt_grp
+            self.countable_elem_name = countable_elem.name
+            self.countable_elem = countable_elem
 
-        if self.mnt_grp is None:
+        if self.countable_elem is None:
             return
 
-        names = self.mnt_grp.getChannelLabels()
-        self.names = [[n] for n in names]
         self.channels = []
         self.values = []
-        for channel_info in self.mnt_grp.getChannels():
-            full_name = channel_info["full_name"]
-            channel = Device(full_name)
+        if self.countable_elem.type == Type.MeasurementGroup:
+            names = self.countable_elem.getChannelLabels()
+            self.names = [[n] for n in names]
+            for channel_info in self.countable_elem.getChannels():
+                full_name = channel_info["full_name"]
+                channel = Device(full_name)
+                self.channels.append(channel)
+                value = channel.getValue(force=True)
+                self.values.append([value])
+                valueObj = channel.getValueObj_()
+                valueObj.subscribeEvent(self.counterChanged, channel)
+        else:
+            channel = self.countable_elem
+            self.names = [[channel.getName()]]
+            channel = Device(channel.full_name)
             self.channels.append(channel)
             value = channel.getValue(force=True)
             self.values.append([value])
             valueObj = channel.getValueObj_()
             valueObj.subscribeEvent(self.counterChanged, channel)
 
-    def run(self, integ_time, mnt_grp):
-        if self.mnt_grp is None:
+    def run(self, integ_time, countable_elem):
+        if self.countable_elem is None:
             self.error('The MntGrp {} is not defined or has invalid '
-                       'value'.format(self.mnt_grp_name))
+                       'value'.format(self.countable_elem_name))
             return
 
         self.print_value = True
         try:
-            _, data = self.mnt_grp.count(integ_time)
+            _, data = self.countable_elem.count(integ_time)
             self.setData(Record(data))
         finally:
             self.finish()

--- a/src/sardana/sardanadefs.py
+++ b/src/sardana/sardanadefs.py
@@ -338,7 +338,7 @@ TYPE_ACQUIRABLE_ELEMENTS = set((ET.Motor, ET.CTExpChannel, ET.ZeroDExpChannel,
 #: a set containing the possible measure-able elements.
 #: Constant values belong to :class:`~sardana.sardanadefs.ElementType`
 TYPE_COUNTABLE_ELEMENTS = set((ET.CTExpChannel, ET.OneDExpChannel,
-                                ET.TwoDExpChannel, ET.MeasurementGroup))
+                               ET.TwoDExpChannel, ET.MeasurementGroup))
 
 #: a set containing the possible types of experimental channel elements.
 #: Constant values belong to :class:`~sardana.sardanadefs.ElementType`

--- a/src/sardana/sardanadefs.py
+++ b/src/sardana/sardanadefs.py
@@ -335,6 +335,11 @@ TYPE_ACQUIRABLE_ELEMENTS = set((ET.Motor, ET.CTExpChannel, ET.ZeroDExpChannel,
                                 ET.ComChannel, ET.IORegister, ET.PseudoMotor,
                                 ET.PseudoCounter))
 
+#: a set containing the possible measure-able elements.
+#: Constant values belong to :class:`~sardana.sardanadefs.ElementType`
+TYPE_COUNTABLE_ELEMENTS = set((ET.CTExpChannel, ET.OneDExpChannel,
+                                ET.TwoDExpChannel, ET.MeasurementGroup))
+
 #: a set containing the possible types of experimental channel elements.
 #: Constant values belong to :class:`~sardana.sardanadefs.ElementType`
 TYPE_EXP_CHANNEL_ELEMENTS = set((ET.CTExpChannel, ET.ZeroDExpChannel,
@@ -401,20 +406,25 @@ INTERFACES = {
     "Controller": (set(("PoolElement",)), "A controller"),
     "Moveable": (set(("PoolElement",)), "A moveable element"),
     "Acquirable": (set(("PoolElement",)), "An acquirable element"),
+    "Countable": (set(("PoolElement",)), "A countable element"),
     "Instrument": (set(("PoolElement",)), "An instrument"),
     "Motor": (set(("Moveable", "Acquirable")), "a motor"),
     "PseudoMotor": (set(("Moveable", "Acquirable")), "A pseudo motor"),
     "IORegister": (set(("Acquirable",)), "An IO register"),
     "ExpChannel": (set(("Acquirable",)), "A generic experimental channel"),
-    "CTExpChannel": (set(("ExpChannel",)), "A counter/timer experimental channel"),
+    "CTExpChannel": (set(("ExpChannel", "Countable")),
+                     "A counter/timer experimental channel"),
     "ZeroDExpChannel": (set(("ExpChannel",)), "A 0D experimental channel"),
-    "OneDExpChannel": (set(("ExpChannel",)), "A 1D experimental channel"),
-    "TwoDExpChannel": (set(("ExpChannel",)), "A 2D experimental channel"),
+    "OneDExpChannel": (set(("ExpChannel", "Countable")),
+                       "A 1D experimental channel"),
+    "TwoDExpChannel": (set(("ExpChannel", "Countable")),
+                       "A 2D experimental channel"),
     "TriggerGate": (set(("PoolElement",)), "A trigger/gate"),
     "PseudoCounter": (set(("ExpChannel",)), "A pseudo counter"),
     "ComChannel": (set(("PoolElement",)), "A communication channel"),
     "MotorGroup": (set(("PoolElement",),), "A motor group"),
-    "MeasurementGroup": (set(("PoolElement",),), "A measurement group"),
+    "MeasurementGroup": (set(("PoolElement", "Countable")),
+                         "A measurement group"),
     "ControllerLibrary": (set(("Library", "PoolObject")), "A controller library"),
     "ControllerClass": (set(("Class", "PoolObject")), "A controller class"),
     "Constraint": (set(("PoolObject",)), "A constraint"),


### PR DESCRIPTION
#997 introduced independent acquisition of experimental channels.
This PR allows to count them with `ct` and `uct` macros. Now one can do `ct 0.1 ct01` or `uct 0.4 twod01 `

An alternative solution would be to add a dedicated macro e.g. `cti` to be able to count in a manner similar to the `mv` macros e.g. `cti ct01 0.1` or `ucti twod01 0.4` (`i` from independent). But maybe this may introduce too many macros for similar purposes? What are your preferences?