### PR TITLE
Remove ms properties file in tests correctly on Windows

### DIFF
--- a/src/sardana/tango/macroserver/test/base.py
+++ b/src/sardana/tango/macroserver/test/base.py
@@ -97,6 +97,7 @@ class BaseMacroServerTestCase(object):
         ds_inst_name = self.ms_ds_name.split("/")[1]
         ms_properties = dft_ms_properties % {"ds_exec_name": "MacroServer",
                                              "ds_inst_name": ds_inst_name}
+        ms_properties = os.path.normpath(ms_properties)
         os.remove(ms_properties)
         self._msstarter.cleanDb(force=True)
         self._msstarter = None


### PR DESCRIPTION
@mrosanes discovered this in #1058. @mrosanes could you verify if this works on Windows and still on Linux, plese?