### PR TITLE
Prepare channel in independent acquisition

### DIFF
--- a/src/sardana/pool/poolbasechannel.py
+++ b/src/sardana/pool/poolbasechannel.py
@@ -408,6 +408,18 @@ class PoolTimerableChannel(PoolBaseChannel):
             self._configure_timer()
         self.controller.set_ctrl_par("synchronization",
                                      AcqSynch.SoftwareTrigger)
+        self._prepare()
         ctrls, master = get_timerable_items(
             [self._conf_ctrl], self._conf_timer, AcqMode.Timer)
         self.acquisition.run(ctrls, self.integration_time, master, None)
+
+    def _prepare(self):
+        # TODO: think of implementing the preparation in the software
+        # acquisition action, similarly as it is done for the global
+        # acquisition action
+        axis = self._conf_timer.axis
+        repetitions = 1
+        latency = 0
+        nb_starts = 1
+        self.controller.ctrl.PrepareOne(axis, self.integration_time,
+                                        repetitions, latency, nb_starts)


### PR DESCRIPTION
Measurement preparation (introduced in SEP18) is not executed
in independent acquisition of experimental channels. Do it.

One can test it by adding a dummy `PrepareOne` methodn to a controller, executing the independent acquisition and observing if it was called:

```python
def PrepareOne(self, axis, value, repetitions, latency, nb_starts):
    self._log.debug("PrepareOne")
```
@sardana-org/integrators can you take a look please?