### PR TITLE
Separate GH tests into two classes

### DIFF
--- a/src/sardana/macroserver/macros/test/test_gh.py
+++ b/src/sardana/macroserver/macros/test/test_gh.py
@@ -36,6 +36,10 @@ from sardana.macroserver.macros.test.test_scanct import mg_config4
 @testRun(macro_name="defgh", macro_params=["lsm mot.*", "pre-acq"],
          wait_timeout=1)
 @testRun(macro_name="udefgh", wait_timeout=1)
+class GeneralHooksMacrosTest(RunMacroTestCase, unittest.TestCase):
+    pass
+
+
 class GeneralHooksTest(MeasSarTestTestCase, BaseMacroServerTestCase,
                        RunMacroTestCase, unittest.TestCase):
 


### PR DESCRIPTION
Some general hook tests refer just to the configuration macros
and some others also execute the macro to which the general hook
was attached in order to check if it could be executed.

Split the tests in two groups cause the setUp and tearDown should
be different. This avoids problems of deletion of the measurement
group when it was never created.

This fixes:

```
Impossible to delete MeasurementGroup: _test_mg_1
DevFailed[
DevError[
    desc = KeyError: "There is no element with name '_test_mg_1'"
           
  origin =   File "/home/zreszela/workspace/sardana/src/sardana/tango/pool/Pool.py", line 920, in DeleteElement
    elem = self.pool.get_element(name=name)
  File "/home/zreszela/workspace/sardana/src/sardana/sardanacontainer.py", line 144, in get_element
    return self.get_element_by_name(name, **kwargs)
  File "/home/zreszela/workspace/sardana/src/sardana/sardanacontainer.py", line 159, in get_element_by_name
    raise KeyError("There is no element with name '%s'" % name)

  reason = PyDs_PythonError
severity = ERR]

DevError[
    desc = Failed to execute command_inout on device pool/demo1/2, command DeleteElement
  origin = Connection::command_inout()
  reason = API_CommandFailed
severity = ERR]
]
```

appearing when running: `python -m unittest sardana.macroserver.macros.test.test_gh`