### PR TITLE
Fix wrong signal emit

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -405,7 +405,7 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
             self, 'Choose directory for saving files', self.ui.pathLE.text())
         if ret:
             self.ui.pathLE.setText(ret)
-            self.ui.pathLE.emit.textEdited.emit(ret)
+            self.ui.pathLE.textEdited.emit(ret)
 
     def onDialogButtonClicked(self, button):
         role = self.ui.buttonBox.buttonRole(button)


### PR DESCRIPTION
ExpDescriptionEditor.onChooseScanDirButtonClicked
has a wrong emit syntax.

Fix it.