### PR TITLE
clear the event set, before macro commnads

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -555,6 +555,10 @@ class BaseDoor(MacroServerDevice):
         evt_wait.lock()
         try:
             evt_wait.waitEvent(self.Running, equal=False, timeout=timeout)
+            # Clear event set to not confuse the value coming from the
+            # connection with the event of of end of the macro execution
+            # in the next wait event. This was observed on Windows where
+            # the time stamp resolution is not better than 1 ms.
             evt_wait.clearEventSet()
             ts = time.time()
             result = self.command_inout("RunMacro", [etree.tostring(xml)])

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -457,8 +457,8 @@ class BaseDoor(MacroServerDevice):
         evt_wait = AttributeEventWait(self.getAttribute("state"))
         evt_wait.lock()
         try:
-            time_stamp = time.time()
             evt_wait.clearEventSet()
+            time_stamp = time.time()
             self.command_inout("AbortMacro")
             evt_wait.waitEvent(self.Running, equal=False, after=time_stamp,
                                timeout=self.InteractiveTimeout)
@@ -474,8 +474,8 @@ class BaseDoor(MacroServerDevice):
         evt_wait = AttributeEventWait(self.getAttribute("state"))
         evt_wait.lock()
         try:
-            time_stamp = time.time()
             evt_wait.clearEventSet()
+            time_stamp = time.time()
             self.command_inout("StopMacro")
             evt_wait.waitEvent(self.Running, equal=False, after=time_stamp,
                                timeout=self.InteractiveTimeout)
@@ -557,8 +557,8 @@ class BaseDoor(MacroServerDevice):
         evt_wait.lock()
         try:
             evt_wait.waitEvent(self.Running, equal=False, timeout=timeout)
-            ts = time.time()
             evt_wait.clearEventSet()
+            ts = time.time()
             result = self.command_inout("RunMacro", [etree.tostring(xml)])
             evt_wait.waitEvent(self.Running, after=ts, timeout=timeout)
             if synch:

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -457,7 +457,6 @@ class BaseDoor(MacroServerDevice):
         evt_wait = AttributeEventWait(self.getAttribute("state"))
         evt_wait.lock()
         try:
-            evt_wait.clearEventSet()
             time_stamp = time.time()
             self.command_inout("AbortMacro")
             evt_wait.waitEvent(self.Running, equal=False, after=time_stamp,
@@ -474,7 +473,6 @@ class BaseDoor(MacroServerDevice):
         evt_wait = AttributeEventWait(self.getAttribute("state"))
         evt_wait.lock()
         try:
-            evt_wait.clearEventSet()
             time_stamp = time.time()
             self.command_inout("StopMacro")
             evt_wait.waitEvent(self.Running, equal=False, after=time_stamp,

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -458,6 +458,7 @@ class BaseDoor(MacroServerDevice):
         evt_wait.lock()
         try:
             time_stamp = time.time()
+            evt_wait.clearEventSet()
             self.command_inout("AbortMacro")
             evt_wait.waitEvent(self.Running, equal=False, after=time_stamp,
                                timeout=self.InteractiveTimeout)
@@ -474,6 +475,7 @@ class BaseDoor(MacroServerDevice):
         evt_wait.lock()
         try:
             time_stamp = time.time()
+            evt_wait.clearEventSet()
             self.command_inout("StopMacro")
             evt_wait.waitEvent(self.Running, equal=False, after=time_stamp,
                                timeout=self.InteractiveTimeout)
@@ -556,6 +558,7 @@ class BaseDoor(MacroServerDevice):
         try:
             evt_wait.waitEvent(self.Running, equal=False, timeout=timeout)
             ts = time.time()
+            evt_wait.clearEventSet()
             result = self.command_inout("RunMacro", [etree.tostring(xml)])
             evt_wait.waitEvent(self.Running, after=ts, timeout=timeout)
             if synch:


### PR DESCRIPTION
Clear the event set before running execution and before
macro stop/abort.

This is solving bugs found in Windows, where the spock prompt was
returned before expected, as events arrived with the same
timestamp, cause of poor time resolution of python on windows.