### PR TITLE
Avoid memory errors on testsuite execution

### DIFF
--- a/src/sardana/pool/test/base.py
+++ b/src/sardana/pool/test/base.py
@@ -139,7 +139,7 @@ class BasePoolTestCase(object):
             ctrl_obj = self.createController(name,
                                              'DummyCounterTimerController',
                                              'DummyCounterTimerController.py')
-            # Create nelems CT elements for each ctrl
+            # Create nctelems CT elements for each ctrl
             for axis in range(1, self.nctelems + 1):
                 name = '_test_ct_%s_%s' % (ctrl, axis)
                 self.createCTElement(ctrl_obj, name, axis)
@@ -149,7 +149,7 @@ class BasePoolTestCase(object):
             ctrl_obj = self.createController(name,
                                              'DummyZeroDController',
                                              'DummyZeroDController.py')
-            # Create nelems ZeroD elements for each ctrl
+            # Create nzerodelems ZeroD elements for each ctrl
             for axis in range(1, self.nzerodelems + 1):
                 name = '_test_0d_%s_%s' % (ctrl, axis)
                 self.createZeroDElement(ctrl_obj, name, axis)
@@ -159,7 +159,7 @@ class BasePoolTestCase(object):
             ctrl_obj = self.createController(name,
                                              'DummyTwoDController',
                                              'DummyTwoDController.py')
-            # Create nelems TwoD elements for each ctrl
+            # Create ntwodelems TwoD elements for each ctrl
             for axis in range(1, self.ntwodelems + 1):
                 name = '_test_2d_%s_%s' % (ctrl, axis)
                 self.createTwoDElement(ctrl_obj, name, axis)
@@ -170,17 +170,17 @@ class BasePoolTestCase(object):
             ctrl_obj = self.createController(name,
                                              'DummyTriggerGateController',
                                              'DummyTriggerGateController.py')
-            # Create nelems CT elements for each ctrl
+            # Create ntgelems TG elements for each ctrl
             for axis in range(1, self.ntgelems + 1):
                 name = '_test_tg_%s_%s' % (ctrl, axis)
                 self.createTGElement(ctrl_obj, name, axis)
-        # Create nctrls MOT ctrls
+        # Create nmotctrls MOT ctrls
         for ctrl in range(1, self.nmotctrls + 1):
             name = '_test_mot_ctrl_%s' % ctrl
             ctrl_obj = self.createController(name,
                                              'DummyMotorController',
                                              'DummyMotorController.py')
-            # Create nelems CT elements for each ctrl
+            # Create nmotelems MOT elements for each ctrl
             for axis in range(1, self.nmotelems + 1):
                 name = '_test_mot_%s_%s' % (ctrl, axis)
                 self.createMotorElement(ctrl_obj, name, axis)

--- a/src/sardana/pool/test/base.py
+++ b/src/sardana/pool/test/base.py
@@ -114,10 +114,14 @@ class BasePoolTestCase(object):
     def setUp(self):
         """Create a collection of controllers and elements.
         """
-        self.nctctrls = self.nzerodctrls = self.ntwodctrls = self.ntgctrls = \
-            self.nmotctrls = 4
-        self.nctelems = self.nzerodelems = self.ntwodelems = self.ntgelems = \
-            self.nmotelems = 5
+        self.nctctrls = self.nzerodctrls = self.ntgctrls = self.nmotctrls = 4
+        # dummy controller generates an array of zeros (1024x1024) for each
+        # axis, many axes may increase the memory consumption of testsuite
+        self.ntwodctrls = 1
+        self.nctelems = self.nzerodelems = self.ntgelems = self.nmotelems = 5
+        # dummy controller generates an array of zeros (1024x1024) for each
+        # axis, many axes may increase the memory consumption of testsuite
+        self.ntwodelems = 1
         self.pool = FakePool(self.POOLPATH, self.LOGLEVEL)
         # Use debug mode
 

--- a/src/sardana/pool/test/base.py
+++ b/src/sardana/pool/test/base.py
@@ -175,13 +175,13 @@ class BasePoolTestCase(object):
                 name = '_test_tg_%s_%s' % (ctrl, axis)
                 self.createTGElement(ctrl_obj, name, axis)
         # Create nctrls MOT ctrls
-        for ctrl in range(1, self.nctctrls + 1):
+        for ctrl in range(1, self.nmotctrls + 1):
             name = '_test_mot_ctrl_%s' % ctrl
             ctrl_obj = self.createController(name,
                                              'DummyMotorController',
                                              'DummyMotorController.py')
             # Create nelems CT elements for each ctrl
-            for axis in range(1, self.nctelems + 1):
+            for axis in range(1, self.nmotelems + 1):
                 name = '_test_mot_%s_%s' % (ctrl, axis)
                 self.createMotorElement(ctrl_obj, name, axis)
 
@@ -190,7 +190,7 @@ class BasePoolTestCase(object):
         tgs = len(self.tgs.keys())
         mots = len(self.mots.keys())
 
-        expected_cts = self.ntgelems * self.ntgctrls
+        expected_cts = self.nctelems * self.nctctrls
         msg = 'Something happened during the creation of CT elements.\n' + \
               'Expected %s and there are %s, %s' % \
               (expected_cts, cts, self.cts.keys())


### PR DESCRIPTION
Dummy 2D controller generates an array of zeros (1024x1024) for each
axis, many axes may increase the VM memory consumption of testsuite and
this apparently causes OSError: [Errno 12] Cannot allocate memory on
the os.fork() call. Avoid this by just creating one axis of dummy 2D.

Fixes #1067.