### PR TITLE
Fix expconf when empty (unspecified) DataType

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
@@ -330,7 +330,9 @@ class MntGrpChannelItem(BaseMntGrpChannelItem):
         return ret
 
     def setData(self, index, qvalue):
+        ch_name, ch_data = self.itemData()
         taurus_role = index.model().role(index.column())
+        key = self.itemdata_keys_map[taurus_role]
         if taurus_role in (ChannelView.Channel, ChannelView.Conditioning,
                            ChannelView.NXPath, ChannelView.DataType,
                            ChannelView.Enabled, ChannelView.Output):
@@ -353,8 +355,6 @@ class MntGrpChannelItem(BaseMntGrpChannelItem):
                 data = ()
         else:
             raise NotImplementedError('Unknown role')
-        ch_name, ch_data = self.itemData()
-        key = self.itemdata_keys_map[taurus_role]
         ch_data[key] = data
 
     def role(self):

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
@@ -340,7 +340,10 @@ class MntGrpChannelItem(BaseMntGrpChannelItem):
         elif taurus_role == ChannelView.DataType:
             if len(qvalue.strip()) == 0:
                 # empty strings are considered as unspecified data type
-                ch_data.pop(key)
+                try:
+                    ch_data.pop(key)
+                except KeyError:
+                    pass  # data_type key may not be there if not specified
                 return
         elif taurus_role == ChannelView.PlotType:
             data = PlotType[qvalue]

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
@@ -334,9 +334,14 @@ class MntGrpChannelItem(BaseMntGrpChannelItem):
         taurus_role = index.model().role(index.column())
         key = self.itemdata_keys_map[taurus_role]
         if taurus_role in (ChannelView.Channel, ChannelView.Conditioning,
-                           ChannelView.NXPath, ChannelView.DataType,
-                           ChannelView.Enabled, ChannelView.Output):
+                           ChannelView.NXPath, ChannelView.Enabled,
+                           ChannelView.Output):
             data = qvalue
+        elif taurus_role == ChannelView.DataType:
+            if len(qvalue.strip()) == 0:
+                # empty strings are considered as unspecified data type
+                ch_data.pop(key)
+                return
         elif taurus_role == ChannelView.PlotType:
             data = PlotType[qvalue]
         elif taurus_role == ChannelView.Normalization:

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
@@ -345,6 +345,8 @@ class MntGrpChannelItem(BaseMntGrpChannelItem):
                 except KeyError:
                     pass  # data_type key may not be there if not specified
                 return
+            else:
+                data = qvalue
         elif taurus_role == ChannelView.PlotType:
             data = PlotType[qvalue]
         elif taurus_role == ChannelView.Normalization:


### PR DESCRIPTION
Empty _DataType_ field in expconf is considered as unspecified `data_type` configuration. Pop this configuration key so the _downstream_ software can consider it as unspecified and eventually use default values. Setting it to `None` could be reserved for unknown or erroneous conditions.

Fixes #1070.

@julianofjm could confirm that it fixes your problem? How important is this bug to you? Do you need it in an official release? Or merging into develop would be enough?