### PR TITLE
Use PY_OBJECT for signal signatures

### DIFF
--- a/src/sardana/spock/inputhandler.py
+++ b/src/sardana/spock/inputhandler.py
@@ -34,7 +34,7 @@ from multiprocessing import Process, Pipe
 
 from taurus.core import TaurusManager
 from taurus.core.util.singleton import Singleton
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 from taurus.qt.qtgui.dialog import TaurusMessageBox, TaurusInputDialog
 
 from sardana.taurus.core.tango.sardana.macroserver import BaseInputHandler
@@ -71,7 +71,7 @@ class SpockInputHandler(BaseInputHandler):
 
 class MessageHandler(Qt.QObject):
 
-    messageArrived = Qt.pyqtSignal(object)
+    messageArrived = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self, conn, parent=None):
         Qt.QObject.__init__(self, parent)

--- a/src/sardana/taurus/qt/qtcore/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/qt/qtcore/tango/sardana/macroserver.py
@@ -30,7 +30,7 @@ __all__ = ["QDoor", "QMacroServer",
 
 import copy
 from taurus.core.taurusbasetypes import TaurusEventType
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 
 from sardana.taurus.core.tango.sardana.macroserver import BaseMacroServer, \
     BaseDoor
@@ -49,15 +49,15 @@ class QDoor(BaseDoor, Qt.QObject):
 
     # sometimes we emit None hence the type is object
     # (but most of the data are passed with type list)
-    resultUpdated = Qt.pyqtSignal(object)
-    recordDataUpdated = Qt.pyqtSignal(object)
-    macroStatusUpdated = Qt.pyqtSignal(object)
-    errorUpdated = Qt.pyqtSignal(object)
-    warningUpdated = Qt.pyqtSignal(object)
-    infoUpdated = Qt.pyqtSignal(object)
-    outputUpdated = Qt.pyqtSignal(object)
-    debugUpdated = Qt.pyqtSignal(object)
-    experimentConfigurationChanged = Qt.pyqtSignal(object)
+    resultUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
+    recordDataUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
+    macroStatusUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
+    errorUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
+    warningUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
+    infoUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
+    outputUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
+    debugUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
+    experimentConfigurationChanged = Qt.pyqtSignal(compat.PY_OBJECT)
     elementsChanged = Qt.pyqtSignal()
     environmentChanged = Qt.pyqtSignal()
 
@@ -172,7 +172,7 @@ class QMacroServer(BaseMacroServer, Qt.QObject):
     elementsUpdated = Qt.pyqtSignal()
     elementsChanged = Qt.pyqtSignal()
     macrosUpdated = Qt.pyqtSignal()
-    environmentChanged = Qt.pyqtSignal(object)
+    environmentChanged = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self, name, qt_parent=None, **kw):
         self.call__init__wo_kw(Qt.QObject, qt_parent)

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/favouriteseditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/favouriteseditor.py
@@ -28,7 +28,7 @@ favouriteseditor.py:
 """
 import copy
 
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 from taurus.qt.qtgui.resource import getIcon
 from taurus.qt.qtgui.container import TaurusWidget
 from taurus.qt.qtcore.configuration import BaseConfigurableClass
@@ -103,7 +103,7 @@ class FavouritesMacrosEditor(TaurusWidget):
 
 class FavouritesMacrosList(Qt.QListView, BaseConfigurableClass):
 
-    favouriteSelected = Qt.pyqtSignal(object)
+    favouriteSelected = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self, parent=None):
         Qt.QListView.__init__(self, parent)

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/historyviewer.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/historyviewer.py
@@ -28,7 +28,7 @@ historyviewer.py:
 """
 import copy
 
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 from taurus.qt.qtgui.resource import getIcon
 from taurus.qt.qtgui.container import TaurusWidget
 from taurus.qt.qtcore.configuration import BaseConfigurableClass
@@ -114,7 +114,7 @@ class HistoryMacrosViewer(TaurusWidget):
 
 class HistoryMacrosList(Qt.QListView, BaseConfigurableClass):
 
-    historySelected = Qt.pyqtSignal(object)
+    historySelected = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self, parent=None):
         Qt.QListView.__init__(self, parent)

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -37,7 +37,7 @@ import PyTango
 
 import taurus
 from taurus.core import TaurusEventType, TaurusDevice
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 from taurus.qt.qtgui.container import TaurusWidget
 from taurus.qt.qtgui.base import TaurusBaseWidget
 from taurus.qt.qtgui.button import TaurusCommandButton
@@ -53,7 +53,7 @@ class DoorStateListener(Qt.QObject):
 
     __pyqtSignals__ = ["doorStateChanged"]
 
-    doorStateChanged = Qt.pyqtSignal(object)
+    doorStateChanged = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def eventReceived(self, evt_src, evt_type, evt_value):
         if evt_type not in (TaurusEventType.Change, TaurusEventType.Periodic):
@@ -74,8 +74,8 @@ class MacroButton(TaurusWidget):
 
     __pyqtSignals__ = ['statusUpdated', 'resultUpdated']
 
-    statusUpdated = Qt.pyqtSignal(object)
-    resultUpdated = Qt.pyqtSignal(object)
+    statusUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
+    resultUpdated = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self, parent=None, designMode=False):
         TaurusWidget.__init__(self, parent, designMode)

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -32,7 +32,7 @@ from copy import deepcopy
 
 import PyTango
 
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 from taurus import Device
 from taurus.qt.qtgui.container import TaurusWidget, TaurusMainWindow, TaurusBaseContainer
 from taurus.qt.qtgui.display import TaurusLed
@@ -626,7 +626,7 @@ class TaurusMacroExecutorWidget(TaurusWidget):
     doorChanged = Qt.pyqtSignal('QString')
     macroNameChanged = Qt.pyqtSignal('QString')
     macroStarted = Qt.pyqtSignal('QString')
-    plotablesFilterChanged = Qt.pyqtSignal(object)
+    plotablesFilterChanged = Qt.pyqtSignal(compat.PY_OBJECT)
     shortMessageEmitted = Qt.pyqtSignal('QString')
 
     def __init__(self, parent=None, designMode=False):

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -85,7 +85,7 @@ class HookAction(Qt.QAction):
 class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
 
     macroNameChanged = Qt.pyqtSignal('QString')
-    macroChanged = Qt.pyqtSignal(object)
+    macroChanged = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self, parent=None):
         Qt.QTreeView.__init__(self, parent)
@@ -325,8 +325,8 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
 class TaurusSequencerWidget(TaurusWidget):
 
     macroStarted = Qt.pyqtSignal('QString')
-    plotablesFilterChanged = Qt.pyqtSignal(object)
-    currentMacroChanged = Qt.pyqtSignal(object)
+    plotablesFilterChanged = Qt.pyqtSignal(compat.PY_OBJECT)
+    currentMacroChanged = Qt.pyqtSignal(compat.PY_OBJECT)
     macroNameChanged = Qt.pyqtSignal('QString')
     shortMessageEmitted = Qt.pyqtSignal('QString')
     sequenceEmpty = Qt.pyqtSignal()

--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -28,7 +28,7 @@ import copy
 import PyTango
 import numpy
 
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 
 import taurus
 from taurus.core.util.colors import DEVICE_STATE_PALETTE
@@ -64,7 +64,7 @@ class LimitsListener(Qt.QObject):
     can do whatever with it.
     """
 
-    updateLimits = Qt.pyqtSignal(object)
+    updateLimits = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self):
         Qt.QObject.__init__(self)
@@ -812,7 +812,7 @@ class TaurusAttributeListener(Qt.QObject):
     If that is the case it emits a signal with the event's value.
     """
 
-    eventReceivedSignal = Qt.pyqtSignal(object)
+    eventReceivedSignal = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self):
         Qt.QObject.__init__(self)

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -29,7 +29,7 @@ __all__ = ["ExpDescriptionEditor"]
 
 
 import json
-from taurus.external.qt import Qt, QtCore, QtGui
+from taurus.external.qt import Qt, QtCore, QtGui, compat
 import copy
 import taurus
 import taurus.core
@@ -173,7 +173,7 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
     '''
 
     createExpConfChangedDialog = Qt.pyqtSignal()
-    experimentConfigurationChanged = Qt.pyqtSignal(object)
+    experimentConfigurationChanged = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self, parent=None, door=None, plotsButton=True,
                  autoUpdate=False):


### PR DESCRIPTION
Some signals use `object` in their signatures, but this may be
problematic when object is imported from builtins (futurize module).

To avoid it, use taurus.external.qt.compat.PY_OBJECT

This is related to https://github.com/taurus-org/taurus/pull/890