### PR TITLE
Change mapping of Integer data type to Tango DevLong64

### DIFF
--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -51,7 +51,7 @@ import itertools
 
 import PyTango
 from PyTango import Util, Database, WAttribute, DbDevInfo, DevFailed, \
-    DevVoid, DevLong, DevBoolean, DevString, DevDouble, \
+    DevVoid, DevLong64, DevBoolean, DevString, DevDouble, \
     DevState, SCALAR, SPECTRUM, IMAGE, FMT_UNKNOWN, \
     READ_WRITE, READ, Attr, SpectrumAttr, ImageAttr, \
     DeviceClass, Except
@@ -384,7 +384,7 @@ def from_tango_state_to_state(state):
 
 #: dictionary dict<:class:`sardana.DataType`, :class:`PyTango.CmdArgType`>
 TTYPE_MAP = {
-    DataType.Integer: DevLong,
+    DataType.Integer: DevLong64,
     DataType.Double: DevDouble,
     DataType.String: DevString,
     DataType.Boolean: DevBoolean,


### PR DESCRIPTION
Integer mapped to DevLong allows to pass integer numbers of 2^31 - 1.
Change mapping to DevLong64 to allow passing numbers of 2^63-1.

This change does have a slight memory footprint effect on py2 32 bits.
There DevLong is simply int and DevLong64 is long. On py2 64 bits
both are int. On py3, regardless of 32 or 64 bits arch, there are only int,
so there is no effect.

This change does have a slight network footprint effect. Tango read
of DevLong attribute requires 160 bytes frame to be transfered while
DevLong64 attribute requries 168 bytes frame. Tango event (ZMQ) of
DevLong attribute requires 226 bytes frame to be transfered and
DevLong64 requires 230 bytes frame to be transfered.

---

One could also think of parametrizing this in `sardanacustomsettings` or even adding new data type to sardana... But I think that the network transfer oeverheads in range of 5% in case of read and 2% in case of event are very small and it is not worth. But if you have another opinion just comment! Thanks in advance!

This is needed for #1081 