### PR TITLE
Change order on the CScan do_restore

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1440,8 +1440,8 @@ class CScan(GScan):
                 raise ScanException(msg)
 
     def do_restore(self):
-        super(CScan, self).do_restore()
         self._restore_motors()
+        super(CScan, self).do_restore()
 
     def _setFastMotions(self, motors=None):
         '''make given motors go at their max speed and accel'''

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1440,6 +1440,10 @@ class CScan(GScan):
                 raise ScanException(msg)
 
     def do_restore(self):
+        # Restore motor backups (vel, acc, ...) first so the macro's
+        # do_restore finds the system as before GSF found it.
+        # This is especially important for dscan macros which must return
+        # to inital position at nominal speed even after user stop.
         self._restore_motors()
         super(CScan, self).do_restore()
 


### PR DESCRIPTION
Restore the motor configuration before to run the base class method, because the dNscanct macros goes to the starting position with the scan configuration instead of the backup configuration when it is aborted.