### PR TITLE
Fix bug on exception popups at macroexecutor

### DIFF
--- a/src/sardana/taurus/qt/qtcore/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/qt/qtcore/tango/sardana/macroserver.py
@@ -241,8 +241,8 @@ class MacroServerMessageErrorHandler(TaurusMessageErrorHandler):
         msg = "<html><body><pre>%s</pre></body></html>" % err_value
         msgbox.setDetailedHtml(msg)
 
-        html_orig = """<html><head><style type="text/css">{
-        style}</style></head><body>"""
+        html_orig = """<html><head><style type="text/css">{style}
+            </style></head><body>"""
         exc_info = "".join(err_traceback)
         style = ""
         try:


### PR DESCRIPTION
Popups are not showing up at macroexecutor when an exception
is occurring. Commit 2db28769 was introducing this bug.

The current commit fixes it.