### PR TITLE
Allow applying kept configuration

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -365,6 +365,8 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
         self._expConfChangedDialog = None
         if result == Qt.QMessageBox.Ok:
             self._reloadConf(force=True)
+        elif result == Qt.QMessageBox.Cancel:
+            self.ui.buttonBox.setEnabled(True)
 
     @QtCore.pyqtSlot()
     def _experimentConfigurationChanged(self):


### PR DESCRIPTION
Allow to apply a configuration that has been kept, in expconf.

As the kept local configuration in expconf can be different than
the server configuration, the button Apply shall be active;
allowing in such a way, to apply the local configuration if
desired.