### PR TITLE
Adapt to removal of "taurus popup menu" feature

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/common.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/common.py
@@ -276,6 +276,12 @@ class MacroExecutionWindow(TaurusMainWindow):
         self.splashScreen().finish(self)
         self.doorChanged.connect(self.onDoorChanged)
 
+    def contextMenuEvent(self, event):
+        """Reimplemented to show self.taurusMenu in as a context Menu
+        See https://github.com/taurus-org/taurus/pull/906
+        """
+        self.taurusMenu.exec_(event.globalPos())
+
     def doorName(self):
         return self._doorName
 


### PR DESCRIPTION
The PR https://github.com/taurus-org/taurus/pull/906 in taurus disables
the implicit showing of self.taurusMenu as a context menu.

This affects to MacroExecutionWindow (used by macroexecutor and
macrosequncer) since it relies on this feature to show its context menu.

Explicitly overwrite contextMenuEvent to provide the expected behaviour
in this case.

Note: at the moment of writing,  https://github.com/taurus-org/taurus/pull/906 is still pending integration.
However, this PRshould be harmless even if said taurus PR is not merged.