### PR TITLE
Show external changes pop-up in expconf when last measurement group is deleted remotelly

### DIFF
--- a/src/sardana/taurus/qt/qtcore/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/qt/qtcore/tango/sardana/macroserver.py
@@ -112,15 +112,15 @@ class QDoor(BaseDoor, Qt.QObject):
         mntgrps = self.macro_server.getElementsOfType("MeasurementGroup")
         # one or more measurement group was deleted
         mntgrp_changed = len(self._mntgrps_connected) > len(mntgrps)
-        new_mntgrp_connected = []
+        new_mntgrps_connected = []
         for name, mg in mntgrps.items():
             if name not in self._mntgrps_connected:
                 mntgrp_changed = True  # this measurement group is new
                 obj = mg.getObj()
                 obj.configurationChanged.connect(
                     self._onExperimentConfigurationChanged)
-            new_mntgrp_connected.append(name)
-        self._mntgrp_connected = new_mntgrp_connected
+            new_mntgrps_connected.append(name)
+        self._mntgrps_connected = new_mntgrps_connected
 
         if mntgrp_changed:
             self._onExperimentConfigurationChanged()

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -493,6 +493,8 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
         if activeMntGrpName in self._localConfig['MntGrpConfigs']:
             mgconfig = self._localConfig['MntGrpConfigs'][activeMntGrpName]
             self.ui.channelEditor.getQModel().setDataSource(mgconfig)
+        else:
+            self.ui.channelEditor.getQModel().setDataSource({})
 
         # set the measurement group ComboBox
         self.ui.activeMntGrpCB.clear()


### PR DESCRIPTION
This fixes case when the last measurement group is removed remotely and no pop-up with external
changes appears in expconf. It also clears the measusrement group configuration table when active meas group is deleted.

@sardana-org/integrators can you take a look on this? Thanks!