### PR TITLE
Emulate hardware triggering between dummy elements

### DIFF
--- a/src/sardana/macroserver/macros/demo.py
+++ b/src/sardana/macroserver/macros/demo.py
@@ -172,6 +172,11 @@ def sar_demo(self):
         self.print("Creating trigger element", tg_name, "...")
         self.defelem(tg_name, tg_ctrl_name, axis)
 
+    ct_ctrl = self.getController(ct_ctrl_name)
+    ct_ctrl.getAttribute("synchronizer").write(tg_name)
+    self.print("Connecting trigger/gate element", tg_name,
+               "with counter/timer controller", ct_ctrl_name)
+
     self.print("Creating IORegister controller", ior_ctrl_name, "...")
     self.defctrl("DummyIORController", ior_ctrl_name)
     for axis, ior_name in enumerate(ior_names, 1):

--- a/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
@@ -336,10 +336,10 @@ class DummyCounterTimerController(CounterTimerController):
         pool = pool_ctrl.pool
         try:
             synchronizer_obj = pool.get_element_by_name(synchronizer)
-        except:
+        except Exception:
             try:
                 synchronizer_obj = pool.get_element_by_full_name(synchronizer)
-            except:
+            except Exception:
                 msg = "Unknown synchronizer {0}".format(synchronizer)
                 raise ValueError(msg)
         self.__synchronizer_obj = synchronizer_obj

--- a/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
@@ -335,11 +335,11 @@ class DummyCounterTimerController(CounterTimerController):
         pool_ctrl = self._getPoolController()
         pool = pool_ctrl.pool
         try:
-            synchronizer_obj = pool.get_element(name=synchronizer)
-        except KeyError:
+            synchronizer_obj = pool.get_element_by_name(synchronizer)
+        except:
             try:
-                synchronizer_obj = pool.get_element(full_name=synchronizer)
-            except KeyError:
+                synchronizer_obj = pool.get_element_by_full_name(synchronizer)
+            except:
                 msg = "Unknown synchronizer {0}".format(synchronizer)
                 raise ValueError(msg)
         self.__synchronizer_obj = synchronizer_obj

--- a/src/sardana/pool/test/base.py
+++ b/src/sardana/pool/test/base.py
@@ -139,6 +139,8 @@ class BasePoolTestCase(object):
             ctrl_obj = self.createController(name,
                                              'DummyCounterTimerController',
                                              'DummyCounterTimerController.py')
+            # use the first trigger/gate element by default
+            ctrl_obj.set_ctrl_attr("synchronizer", "_test_tg_1_1")
             # Create nctelems CT elements for each ctrl
             for axis in range(1, self.nctelems + 1):
                 name = '_test_ct_%s_%s' % (ctrl, axis)

--- a/src/sardana/tango/pool/test/base_sartest.py
+++ b/src/sardana/tango/pool/test/base_sartest.py
@@ -23,6 +23,7 @@
 ##
 ##############################################################################
 
+import PyTango
 import taurus
 
 from sardana.tango.pool.test import BasePoolTestCase
@@ -85,6 +86,10 @@ class SarTestTestCase(BasePoolTestCase):
                 ctrl_name = prefix + "_ctrl_%s" % (postfix)
                 try:
                     self.pool.CreateController([sar_type, lib, cls, ctrl_name])
+                    if cls == "DummyCounterTimerController":
+                        ctrl = PyTango.DeviceProxy(ctrl_name)
+                        # use the first trigger/gate element by default
+                        ctrl.write_attribute("Synchronizer", "_test_tg_1_1")
                 except Exception, e:
                     print e
                     msg = 'Impossible to create ctrl: "%s"' % (ctrl_name)


### PR DESCRIPTION
Up to now hardware synchronization modes (trigger/gate/start) of dummy counter/timer works but these types of acquisitions starts already on `StartAll` method call. In case of the continuous scan this makes the acquisitions finish too early - not respecting the acceleration time of the moveable. This can be observed on ![this continuous scan trend of motor position and counter/timer state](https://user-images.githubusercontent.com/6735649/56325294-00da8e00-6172-11e9-9b1f-7945a2fabcd5.png).
This was ascanct of dummy motor (vel: 100, acc = 2, dec = 2, base_rate = 0) from 0 to 10 with 10 intervals and 0.1 second integration time. The measurement group contains just a dummy counter/timer synchronized by a dummy trigger/gate in either of trigger/gate/start synchronization modes.

Different approaches exist to emulate the medium of propagation of hardware synchronization events between the dummy trigger/gate element and dummy counter/timer element e.g. socket, Linux signal, or Sardana kernel events. The Linux signalling looks like not platform independent. The socket connection may require quite a lot of development if we would like to support multiple acquisitions running at the same time (managing the cache of port numbers for connections, etc). The Sardana kernel events would do the job equally good and these are the simplest to implement even if these require some hacks in the code. So I have chosen this last option and this PR proposes the implementation. The results can be observed on 
![the equivalent continuous scan trend](https://user-images.githubusercontent.com/6735649/56325604-12706580-6173-11e9-80f0-d5db82b69aff.png) - see how the counter/timer state changes back to on when the scan active range finishes.

Of course in the future we could change the medium of propagation of events and this will be totally transparent.

Summary of changes:
* add `Synchronizer` attribute to dummy counter/timer controller
* implement synchronization (real start of acquisition) on first active event (trigger)
* automatic connection of dummy counter/timer controller with dummy trigger/gate element in the `sar_demo` macro.

@sardana-org/integrators could you please take a look. This feature will help in SEP2 development.
