### PR TITLE
Expconf prevents the user in case of Pool down

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -224,6 +224,7 @@ class ExperimentConfiguration(object):
                     codec.decode(('json', reply.get_data().value),
                                  ensure_ascii=True)[1]
             except Exception, e:
+                mnt_grp_configs[mnt_grp] = None
                 from taurus.core.util.log import warning
                 warning('Cannot load Measurement group "%s": %s',
                         repr(mnt_grp), repr(e))


### PR DESCRIPTION
This PR is proposed to solve the issue-958. It substitutes PR1097 by
applying Option2 of @reszelaz  comments:
""
If it is not possible to read MeasurementGroup Configuration attribute fill the MntGrpConfigs for the affected MeasurementGroup with None.
""

If Sardana Pool is down, expconf widget pops up a warning message,
informing that the measurement groups are not available.

The 'Keep' button of the change config dialog, is disabled
the first time that the Pool is up again.