### PR TITLE
Remove setting of global measurement group synchronizer

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
@@ -590,7 +590,6 @@ class BaseMntGrpChannelModel(TaurusBaseModel):
             self.beginResetModel()
             ctrl_data = self.getPyData(ctrlname=ctrlname)
             ctrl_data[key] = qvalue
-            self._mgconfig[key] = qvalue
             self.endResetModel()
             return True
         # for the rest, we use the regular TaurusBaseModel item-oriented approach


### PR DESCRIPTION
Global measurement group synchronizer (even if not a bad idea) is
not used. Remove its random setting (to the last selected synchronizer)
so it does not raise a pop-up with external changes in expconf.

@sardana-org/integrators can you take a look, please?