### PR TITLE
Add scan macro example with a custom column with motor positions shifted to the middle of interval

### DIFF
--- a/src/sardana/macroserver/macros/examples/scans.py
+++ b/src/sardana/macroserver/macros/examples/scans.py
@@ -36,10 +36,9 @@ __all__ = ["ascan_demo", "ascanr", "toothedtriangle",
 
 __docformat__ = 'restructuredtext'
 
-import os
 import numpy
 
-from sardana.macroserver.macro import *
+from sardana.macroserver.macro import Macro, Hookable, Type, ParamRepeat
 from sardana.macroserver.scan import *
 
 


### PR DESCRIPTION
This macro demonstrates how to add an extra scan column with the shifted positions of the motor corresponding to the middle of the space interval.

Be aware that the space interval does not necessarily correspond to the middle of the acquisition interval
(remember about the latency time).

This macro does not export all the ascanct features e.g. hooks, ...