### PR TITLE
Compose default DataSource value pointing to Value Tango attribute

### DIFF
--- a/src/sardana/tango/pool/TwoDExpChannel.py
+++ b/src/sardana/tango/pool/TwoDExpChannel.py
@@ -133,6 +133,12 @@ class TwoDExpChannel(PoolTimerableDevice):
 
             if name == "timer" and value is None:
                 value = "None"
+            elif name == "datasource" and value is None:
+                full_name = self.get_full_name()
+                # for Taurus 3/4 compatibility
+                if not full_name.startswith("tango://"):
+                    full_name = "tango://{0}".format(full_name)
+                value = "{0}/value".format(full_name)
             elif name == "value":
                 state = self.twod.get_state()
                 if state == State.Moving:


### PR DESCRIPTION
This was discovered when testing SEP2 in: https://github.com/sardana-org/sardana/pull/775#issuecomment-494749686.

Default behavior of 2D controllers, if not overridden, is to return
None as data source. However it is not possible to push Tango events with
DevString type with None as value. Compose the default data source as it
is done in read_DataSource.