### PR TITLE
Add auto-deploy to PyPI with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,3 +73,14 @@ doctr:
   require-master: false
   sync: true
   built-docs: build/sphinx/html/
+
+deploy:
+  # deploy to pypi when a version tag is pushed to the official repo
+  - provider: pypi
+    user: sardana_bot
+    password:
+      secure: "HvZGtw8qFlacssi7FE92+gFgQPRRPvurpPxi/Gq74TeKWU0X4EbWVT3XMdi7sb7yA7JQlOGIGtY3ofzEdrKgKcEsrxxKbeSW7foDf3+AlmMF7c31ePxkqBCGMSAxsaCjKJR2sVtBNiycp0I7LWYeKlzFNY2W8aZW9dnpkC9aD/oGdNRJlCVGq912xaTnXRxmUrh+2IeUqsXKqfih7E0Qw99VXOLFdHIHtoPGN5ka+tvLp+zNFMi1q2HUyix4P/aQ10BwE5t1onfdSBBh7bzZTINoUVuN1bstNXYcoqfVMAbOoeArIIr7z41eYd8G8WMTXJp2MFrO61AW6xK8htB07RX2eaEWq7KT4zazG5vP/Skayr7ofnB/d3Rs1BOre9ttScJIxwyQLhL60WeM9NyCoHVjNdKYK5gNHX4se/6FOzmHm1VgQgI9bzyfIIAoSSyUL/5KOGdOwhMPSij5AT1YIy8RSe7efm+xw3md+wcmEsbaMX9VEy2YgTL0/nmFHrEA+9HV0I5xkFBQ8BHuK0YFubQ9rG99B1GwF0Vl85M+Ylp5D1/p70sXCHEUk3SbOcg9Kz0TTisDMuDT2ajJYGylg7/OskI5OwOBbEndP8OUPesm62V1ciQcKjH2L81yWajRPSfd/OPjoMwG+XdaG5rR7m2FACXvyhEOIeK1Mt41MvM="
+    on:
+      repo: sardana-org/sardana
+      tags: true
+      condition: "$TRAVIS_TAG =~ ^[0-9]+.[0-9]+.[0-9]+$"


### PR DESCRIPTION
Make Travis deploy to PyPI when a version tag (major.minor.patch) is pushed. It uses an ad-hoc PyPI account (sardana_bot) which is given Maintainer permisions in PyPI. The sardana_bot password is encrypted (using [travis-encrypt](https://pypi.org/project/travis-encrypt/)) with the sardana-org/sardana Travis public key so that Travis can decrypt it for deployment.