### PR TITLE
Fix 1027

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -570,7 +570,7 @@ class SingleParamNode(ParamNode):
         Empty list indicates default value."""
         if isinstance(v, list):
             if len(v) == 0:
-                v = self.defValue()
+                v = str(self.defValue())
             elif not isinstance(self.parent(), RepeatNode):
                 msg = "Only members of repeat parameter allow list values"
                 raise ValueError(msg)

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -511,9 +511,7 @@ class SingleParamNode(ParamNode):
         self._value = value
 
     def defValue(self):
-        if self._defValue is None:
-            return None
-        return str(self._defValue)
+        return self._defValue
 
     def setDefValue(self, defValue):
         if defValue == "None":
@@ -532,7 +530,7 @@ class SingleParamNode(ParamNode):
         # set value attribute only if it is different than the default value
         # the server will assign the default value anyway.
         if value is not None or str(value).lower() != 'none':
-            if value != self.defValue():
+            if value != str(self.defValue()):
                 paramElement.set("value", value)
         return paramElement
 

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -287,17 +287,14 @@ class SpockCommandWidget(Qt.QLineEdit, TaurusBaseContainer):
                     message = "<b>" + txt + "</b> " + e[0]
                     problems.append(message)
             except IndexError:
-                param_info = macro_params_info[counter-1]
-                # Skip validation in case of optional parameters
-                if param_info['default_value'] == Optional:
-                    self.model().setData(self.currentIndex, None)
-                else:
-                    txt = str(ix.sibling(ix.row(), 0).data())
-                    problems.append("<b>" + txt + "</b> is missing!")
+                txt = str(ix.sibling(ix.row(), 0).data())
+                problems.append("<b>" + txt + "</b> is missing!")
 
-                    data = str(ix.data())
-                    if data != 'None':
-                        self.model().setData(self.currentIndex, 'None')
+                data = str(ix.data())
+                if data != 'None':
+                    self.model().setData(self.currentIndex, 'None')
+                else:
+                    self.model().setData(self.currentIndex, None)
             counter += 1
             ix = self.getIndex()
             self.currentIndex = ix

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -265,17 +265,7 @@ class SpockCommandWidget(Qt.QLineEdit, TaurusBaseContainer):
         self.currentIndex = ix
         counter = 1
 
-        # Get the parameters information to check if there are optional
-        # paramters
-        ms_obj = self.getModelObj()
-        macro_obj = ms_obj.getElementInfo(mlist[0])
-        macro_params_info = None
-        if macro_obj is not None:
-            macro_params_info = macro_obj.parameters
-
         while not ix == Qt.QModelIndex():
-            if macro_params_info is None:
-                break
             try:
                 propValue = mlist[counter]
                 try:

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroparameterseditor/model.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroparameterseditor/model.py
@@ -181,7 +181,10 @@ class ParamEditorModel(Qt.QAbstractItemModel):
             if index.column() == 0:
                 return node.name()
             elif index.column() == 1:
-                return str(node.value())
+                value = node.value()
+                if value is None:
+                    value = node.defValue()
+                return str(value)
         return None
 
     def setData(self, index, value, role=Qt.Qt.EditRole):

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroparameterseditor/model.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroparameterseditor/model.py
@@ -34,6 +34,7 @@ from taurus.external.qt import Qt
 
 from sardana.taurus.core.tango.sardana import macro
 from sardana.taurus.qt.qtgui.extra_macroexecutor import globals
+from sardana.macroserver.msparameter import Optional
 
 
 class ParamEditorModel(Qt.QAbstractItemModel):
@@ -184,6 +185,9 @@ class ParamEditorModel(Qt.QAbstractItemModel):
                 value = node.value()
                 if value is None:
                     value = node.defValue()
+                    if value == Optional:
+                        # TODO: treat optional parameters
+                        value = None
                 return str(value)
         return None
 


### PR DESCRIPTION
Fix issue #1027 
Fix bug with command editor in macroexecutor (yellow line)
Improve the behaviour with default values (Now the param tree shows the default value instead none).