### PR TITLE
Remove use of ParamRepeat

### DIFF
--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -30,7 +30,7 @@ __all__ = ["dumpenv", "load_env", "lsenv", "senv", "usenv",
 __docformat__ = 'restructuredtext'
 
 from taurus.console.list import List
-from sardana.macroserver.macro import Macro, Type, ParamRepeat
+from sardana.macroserver.macro import Macro, Type
 from sardana.macroserver.msexception import UnknownEnv
 
 ##########################################################################
@@ -128,8 +128,8 @@ class lsenv(Macro):
     """Lists the environment in alphabetical order"""
 
     param_def = [
-        ['macro_list',
-         ParamRepeat(['macro', Type.MacroClass, None, 'macro name'], min=0),
+        ['macro_list', [['macro', Type.MacroClass, None, 'macro name'],
+                        {'min': 0}],
          None, 'List of macros to show environment'],
     ]
 
@@ -174,17 +174,19 @@ class lsenv(Macro):
 class senv(Macro):
     """Sets the given environment variable to the given value"""
 
-    param_def = [['name', Type.Env, None,
-                  'Environment variable name. Can be one of the following:\n'
-                  ' - <name> - global variable\n'
-                  ' - <full door name>.<name> - variable value for a specific door\n'
-                  ' - <macro name>.<name> - variable value for a specific macro\n'
-                  ' - <full door name>.<macro name>.<name> - variable value for a specific macro running on a specific door'],
-                 ['value_list',
-                  ParamRepeat(['value', Type.String, None,
-                               'environment value item'], min=1),
-                  None, 'value(s). one item will eval to a single element. More than one item will eval to a tuple of elements'],
-                 ]
+    param_def = [
+        ['name', Type.Env, None,
+         'Environment variable name. Can be one of the following:\n'
+         ' - <name> - global variable\n'
+         ' - <full door name>.<name> - variable value for a specific door\n'
+         ' - <macro name>.<name> - variable value for a specific macro\n'
+         ' - <full door name>.<macro name>.<name> - variable value for a '
+         'specific macro running on a specific door'],
+        ['value_list', [['value', Type.String, None,
+                          'environment value item'], {'min': 1}],
+         None, 'value(s). one item will eval to a single element. More than '
+               'one item will eval to a tuple of elements'],
+    ]
 
     def run(self, env, value):
         if len(value) == 1:
@@ -199,9 +201,8 @@ class senv(Macro):
 class usenv(Macro):
     """Unsets the given environment variable"""
     param_def = [
-        ['environment_list',
-         ParamRepeat(
-             ['env', Type.Env, None, 'Environment variable name'], min=1),
+        ['environment_list', [['env', Type.Env, None,
+                               'Environment variable name'], {'min': 1}],
          None, 'List of environment items to be removed'],
     ]
 
@@ -379,8 +380,8 @@ class defgh(Macro):
     param_def = [
         ['macro_name', Type.String, None, ('Macro name with parameters. '
                                            'Ex.: "mv exp_dmy01 10"')],
-        ['hookpos_list',
-         ParamRepeat(['position', Type.String, None, 'macro name'], min=1),
+        ['hookpos_list', [['position', Type.String, None, 'macro name'],
+                          {'min': 1}],
          None, 'List of positions where the hook has to be executed'],
     ]
 

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -183,7 +183,7 @@ class senv(Macro):
          ' - <full door name>.<macro name>.<name> - variable value for a '
          'specific macro running on a specific door'],
         ['value_list', [['value', Type.String, None,
-                          'environment value item'], {'min': 1}],
+                         'environment value item'], {'min': 1}],
          None, 'value(s). one item will eval to a single element. More than '
                'one item will eval to a tuple of elements'],
     ]

--- a/src/sardana/macroserver/macros/examples/parameters.py
+++ b/src/sardana/macroserver/macros/examples/parameters.py
@@ -23,7 +23,7 @@
 
 """This module contains macros that demonstrate the usage of macro parameters"""
 
-from sardana.macroserver.macro import Macro, Type, ParamRepeat
+from sardana.macroserver.macro import Macro, Type
 
 __all__ = ["pt0", "pt1", "pt2", "pt3", "pt3d", "pt4", "pt5", "pt6", "pt7",
            "pt7d1", "pt7d2", "pt8", "pt9", "pt10", "pt11", "pt12", "pt13",
@@ -261,9 +261,9 @@ class pt9(Macro):
     """
 
     param_def = [
-        ['m_p_pair',
-         ParamRepeat(['motor', Type.Motor, None, 'Motor to move'],
-                     ['pos',  Type.Float, None, 'Position to move to'], min=1, max=2),
+        ['m_p_pair', [['motor', Type.Motor, None, 'Motor to move'],
+                      ['pos',  Type.Float, None, 'Position to move to'],
+                      {'min': 1, 'max': 2}],
          None, 'List of motor/position pairs'],
     ]
 

--- a/src/sardana/macroserver/macros/examples/scans.py
+++ b/src/sardana/macroserver/macros/examples/scans.py
@@ -38,7 +38,7 @@ __docformat__ = 'restructuredtext'
 
 import numpy
 
-from sardana.macroserver.macro import Macro, Hookable, Type, ParamRepeat
+from sardana.macroserver.macro import Macro, Hookable, Type
 from sardana.macroserver.scan import *
 
 
@@ -294,8 +294,9 @@ class regscan(Macro):
         ['integ_time', Type.Float,    None, 'Integration time'],
         ['start_pos',  Type.Float,    None, 'Start position'],
         ['step_region',
-         ParamRepeat(['next_pos',  Type.Float,   None, 'next position'],
-                     ['region_nr_intervals',  Type.Float,   None, 'Region number of intervals']),
+         [['next_pos',  Type.Float,   None, 'next position'],
+          ['region_nr_intervals',  Type.Float,   None,
+           'Region number of intervals']],
          None, 'List of tuples: (next_pos, region_nr_intervals']
     ]
 
@@ -355,8 +356,9 @@ class reg2scan(Macro):
         ['integ_time', Type.Float,    None, 'Integration time'],
         ['start_pos',  Type.Float,    None, 'Start position'],
         ['step_region',
-         ParamRepeat(['next_pos',  Type.Float,   None, 'next position'],
-                     ['region_nr_intervals',  Type.Float,   None, 'Region number of intervals']),
+         [['next_pos', Type.Float, None, 'next position'],
+          ['region_nr_intervals', Type.Float, None,
+           'Region number of intervals']],
          None, 'List of tuples: (next_pos, region_nr_intervals']
     ]
 
@@ -420,8 +422,9 @@ class reg3scan(Macro):
         ['integ_time', Type.Float,    None, 'Integration time'],
         ['start_pos',  Type.Float,    None, 'Start position'],
         ['step_region',
-         ParamRepeat(['next_pos',  Type.Float,   None, 'next position'],
-                     ['region_nr_intervals',  Type.Float,   None, 'Region number of intervals']),
+         [['next_pos',  Type.Float,   None, 'next position'],
+          ['region_nr_intervals',  Type.Float,   None,
+           'Region number of intervals']],
          None, 'List of tuples: (next_pos, region_nr_intervals']
     ]
 

--- a/src/sardana/macroserver/macros/examples/submacros.py
+++ b/src/sardana/macroserver/macros/examples/submacros.py
@@ -29,7 +29,7 @@ __all__ = ["call_wa", "call_wm", "subsubm", "subm", "mainmacro", "runsubs"]
 
 __docformat__ = 'restructuredtext'
 
-from sardana.macroserver.macro import Macro, Type, ParamRepeat
+from sardana.macroserver.macro import Macro, Type
 
 #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
 # First example:
@@ -47,8 +47,7 @@ class call_wa(Macro):
 class call_wm(Macro):
 
     param_def = [
-        ['motor_list',
-         ParamRepeat(['motor', Type.Motor, None, 'Motor to move']),
+        ['motor_list', [['motor', Type.Motor, None, 'Motor to move']],
          None, 'List of motor to show'],
     ]
 

--- a/src/sardana/macroserver/macros/expert.py
+++ b/src/sardana/macroserver/macros/expert.py
@@ -38,7 +38,7 @@ import array
 
 from sardana.macroserver.msexception import UnknownMacroLibrary
 from sardana.macroserver.msparameter import WrongParam
-from sardana.macroserver.macro import Macro, Type, ParamRepeat, Table, LibraryError
+from sardana.macroserver.macro import Macro, Type, Table, LibraryError
 
 ##########################################################################
 #
@@ -70,9 +70,8 @@ class defmeas(Macro):
 
     param_def = [
         ['name',  Type.String, None, 'Measurement group name'],
-        ['channel_list',
-            ParamRepeat(['channel', Type.String, None,
-                         'Measurement Channel'],),
+        ['channel_list', [['channel', Type.String, None,
+                           'Measurement Channel']],
             None, 'List of measurement channels'],
     ]
 
@@ -95,10 +94,9 @@ class udefmeas(Macro):
     """Deletes existing measurement groups"""
 
     param_def = [
-        ['mntgrps',
-         ParamRepeat(['mntgrp', Type.MeasurementGroup, None,
+        ['mntgrps', [['mntgrp', Type.MeasurementGroup, None,
                       'Measurement group name'],
-                     min=1),
+                     {'min': 1}],
          None, 'List of measurement group names'], ]
 
     def run(self, mntgrps):
@@ -143,8 +141,8 @@ class udefelem(Macro):
     """Deletes existing elements"""
 
     param_def = [
-        ['elements',
-         ParamRepeat(['element', Type.Element, None, 'element name'], min=1),
+        ['elements', [['element', Type.Element, None, 'element name'],
+                      {'min': 1}],
          None, 'List of element(s) name'],
     ]
 
@@ -174,9 +172,8 @@ class defctrl(Macro):
 
     param_def = [['class',  Type.ControllerClass, None, 'controller class'],
                  ['name',  Type.String, None, 'new controller name'],
-                 ['roles_props',
-                  ParamRepeat(['role_prop', Type.String, None,
-                               'a role or property item'], min=0),
+                 ['roles_props', [['role_prop', Type.String, None,
+                                   'a role or property item'], {'min': 0}],
                   None, 'roles and/or properties']]
 
     def run(self, ctrl_class, name, props):
@@ -189,9 +186,8 @@ class udefctrl(Macro):
     """Deletes existing controllers"""
 
     param_def = [
-        ['controllers',
-         ParamRepeat(['controller', Type.Controller, None, 'controller name'],
-                     min=1),
+        ['controllers', [['controller', Type.Controller, None,
+                          'controller name'], {'min': 1}],
          None, 'List of controller(s) name(s)'], ]
 
     def run(self, controllers):
@@ -218,9 +214,8 @@ class send2ctrl(Macro):
     """Sends the given data directly to the controller"""
 
     param_def = [['controller', Type.Controller, None, 'Controller name'],
-                 ['data',
-                  ParamRepeat(['string item', Type.String,
-                               None, 'a string item'],),
+                 ['data', [['string item', Type.String, None,
+                            'a string item']],
                   None, 'data to be sent']]
 
     def run(self, controller, data):

--- a/src/sardana/macroserver/macros/lists.py
+++ b/src/sardana/macroserver/macros/lists.py
@@ -34,7 +34,7 @@ __docformat__ = 'restructuredtext'
 
 from taurus.console import Alignment
 from taurus.console.list import List
-from sardana.macroserver.macro import Macro, Type, ParamRepeat, ViewOption
+from sardana.macroserver.macro import Macro, Type, ViewOption
 
 Left, Right, HCenter = Alignment.Left, Alignment.Right, Alignment.HCenter
 
@@ -47,9 +47,8 @@ class _ls(Macro):
     # TODO: duplication of the default value definition is a workaround
     # for #427. See commit message cc3331a for more details.
     param_def = [
-        ['filter',
-         ParamRepeat(['filter', Type.String, ".*",
-                      'a regular expression filter'], min=1),
+        ['filter', [['filter', Type.String, ".*",
+                     'a regular expression filter'], {'min': 1}],
          [".*"], 'a regular expression filter'],
     ]
 

--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -46,8 +46,7 @@ import numpy
 from taurus.core.util import SafeEvaluator
 
 from sardana.macroserver.msexception import UnknownEnv
-from sardana.macroserver.macro import Hookable, Macro, Type, ParamRepeat, \
-    Table, List
+from sardana.macroserver.macro import Hookable, Macro, Type, Table, List
 from sardana.macroserver.scan.gscan import SScan, CTScan, HScan, \
     MoveableDesc, CSScan, TScan
 from sardana.util.motion import MotionPath
@@ -491,9 +490,9 @@ class amultiscan(aNscan, Macro):
 
     param_def = [
         ['motor_start_end_list',
-         ParamRepeat(['motor', Type.Moveable, None, 'Moveable to move'],
-                     ['start', Type.Float, None, 'Starting position'],
-                     ['end', Type.Float, None, 'Final position']),
+         [['motor', Type.Moveable, None, 'Moveable to move'],
+          ['start', Type.Float, None, 'Starting position'],
+          ['end', Type.Float, None, 'Final position']],
          None, 'List of motor, start and end positions'],
         ['nr_interv', Type.Integer, None, 'Number of scan intervals'],
         ['integ_time', Type.Float, None, 'Integration time']
@@ -524,9 +523,9 @@ class dmultiscan(dNscan, Macro):
 
     param_def = [
         ['motor_start_end_list',
-         ParamRepeat(['motor', Type.Moveable, None, 'Moveable to move'],
-                     ['start', Type.Float, None, 'Starting position'],
-                     ['end', Type.Float, None, 'Final position']),
+         [['motor', Type.Moveable, None, 'Moveable to move'],
+          ['start', Type.Float, None, 'Starting position'],
+          ['end', Type.Float, None, 'Final position']],
          None, 'List of motor, start and end positions'],
         ['nr_interv', Type.Integer, None, 'Number of scan intervals'],
         ['integ_time', Type.Float, None, 'Integration time']
@@ -861,8 +860,8 @@ motor2 sqrt(y*x+3)
         ['indepvars', Type.String, None, 'Independent Variables'],
         ['integ_time', Type.String, None, 'Integration time'],
         ['motor_funcs',
-         ParamRepeat(['motor', Type.Moveable, None, 'motor'],
-                     ['func', Type.String, None, 'curve defining path']),
+         [['motor', Type.Moveable, None, 'motor'],
+          ['func', Type.String, None, 'curve defining path']],
          None, 'List of motor and path curves']
     ]
 

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -38,8 +38,8 @@ from taurus.console.table import Table
 import PyTango
 from PyTango import DevState
 
-from sardana.macroserver.macro import Macro, macro, Type, ParamRepeat, \
-    ViewOption, iMacro, Hookable
+from sardana.macroserver.macro import Macro, macro, Type, ViewOption, \
+    iMacro, Hookable
 from sardana.macroserver.msexception import StopException, UnknownEnv
 from sardana.macroserver.scan.scandata import Record
 from sardana.macroserver.macro import Optional
@@ -55,8 +55,7 @@ class _wm(Macro):
     """Show motor positions"""
 
     param_def = [
-        ['motor_list',
-         ParamRepeat(['motor', Type.Moveable, None, 'Motor to move']),
+        ['motor_list', [['motor', Type.Moveable, None, 'Motor to move']],
          None, 'List of motor to show'],
     ]
 
@@ -146,8 +145,7 @@ class _wum(Macro):
     """Show user motor positions"""
 
     param_def = [
-        ['motor_list',
-         ParamRepeat(['motor', Type.Moveable, None, 'Motor to move']),
+        ['motor_list', [['motor', Type.Moveable, None, 'Motor to move']],
          None, 'List of motor to show'],
     ]
 
@@ -206,9 +204,8 @@ class wa(Macro):
     # TODO: duplication of the default value definition is a workaround
     # for #427. See commit message cc3331a for more details.
     param_def = [
-        ['filter',
-         ParamRepeat(['filter', Type.String, '.*',
-                      'a regular expression filter'], min=1),
+        ['filter', [['filter', Type.String, '.*',
+                     'a regular expression filter'], {'min': 1}],
          ['.*'], 'a regular expression filter'],
     ]
 
@@ -239,9 +236,8 @@ class pwa(Macro):
     # TODO: duplication of the default value definition is a workaround
     # for #427. See commit message cc3331a for more details.
     param_def = [
-        ['filter',
-         ParamRepeat(['filter', Type.String, '.*',
-                      'a regular expression filter'], min=1),
+        ['filter', [['filter', Type.String, '.*',
+                     'a regular expression filter'], {'min': 1}],
          ['.*'], 'a regular expression filter'],
     ]
 
@@ -321,9 +317,8 @@ class wm(Macro):
     """Show the position of the specified motors."""
 
     param_def = [
-        ['motor_list',
-         ParamRepeat(['motor', Type.Moveable, None,
-                      'Motor to see where it is']),
+        ['motor_list', [['motor', Type.Moveable, None,
+                         'Motor to see where it is']],
          None, 'List of motor to show'],
     ]
 
@@ -412,9 +407,8 @@ class wum(Macro):
     """Show the user position of the specified motors."""
 
     param_def = [
-        ['motor_list',
-         ParamRepeat(['motor', Type.Moveable, None,
-                      'Motor to see where it is']),
+        ['motor_list', [['motor', Type.Moveable, None,
+                         'Motor to see where it is']],
          None, 'List of motor to show'],
     ]
 
@@ -449,8 +443,7 @@ class pwm(Macro):
     """Show the position of the specified motors in a pretty table"""
 
     param_def = [
-        ['motor_list',
-         ParamRepeat(['motor', Type.Moveable, None, 'Motor to move']),
+        ['motor_list', [['motor', Type.Moveable, None, 'Motor to move']],
          None, 'List of motor to show'],
     ]
 
@@ -463,8 +456,8 @@ class mv(Macro):
 
     param_def = [
         ['motor_pos_list',
-         ParamRepeat(['motor', Type.Moveable, None, 'Motor to move'],
-                     ['pos',   Type.Float, None, 'Position to move to']),
+         [['motor', Type.Moveable, None, 'Motor to move'],
+          ['pos',   Type.Float, None, 'Position to move to']],
          None, 'List of motor/position pairs'],
     ]
 
@@ -547,8 +540,8 @@ class mvr(Macro):
 
     param_def = [
         ['motor_disp_list',
-         ParamRepeat(['motor', Type.Moveable, None, 'Motor to move'],
-                     ['disp',  Type.Float, None, 'Relative displacement']),
+         [['motor', Type.Moveable, None, 'Motor to move'],
+          ['disp',  Type.Float, None, 'Relative displacement']],
          None, 'List of motor/displacement pairs'],
     ]
 
@@ -839,8 +832,8 @@ class settimer(Macro):
                 % timer)
 
 
-@macro([['message', ParamRepeat(['message_item', Type.String, None,
-                                 'message item to be reported']), None,
+@macro([['message',[['message_item', Type.String, None,
+                     'message item to be reported']], None,
          'message to be reported']])
 def report(self, message):
     """Logs a new record into the message report system (if active)"""

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -832,8 +832,8 @@ class settimer(Macro):
                 % timer)
 
 
-@macro([['message',[['message_item', Type.String, None,
-                     'message item to be reported']], None,
+@macro([['message', [['message_item', Type.String, None,
+                      'message item to be reported']], None,
          'message to be reported']])
 def report(self, message):
     """Logs a new record into the message report system (if active)"""


### PR DESCRIPTION
Remove use of `ParamRepeat` which is deprecated. It generates problem when is used on macro decorator `@macro` in openSuse 11.4 (python 2.6). I changed the code to use lists.