### PR TITLE
Adapt docs to python3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ In general, the contributions to Sardana should consider following:
 - The code must comply with the sardana coding conventions:
   - We try to follow the standard Python style conventions as
     described in [Style Guide for Python Code](http://www.python.org/peps/pep-0008.html)
-  - Code **must** be python 2.6 compatible
+  - Code **must** be python 3.5 compatible (python 2 is not supported)
   - Use 4 spaces for indentation
   - use ``lowercase`` for module names. If possible prefix module names with the
     word ``sardana`` (like :file:`sardanautil.py`) to avoid import mistakes.
@@ -79,7 +79,6 @@ The following code can be used as a template for writing new python modules to
 Sardana:
 
 ```python
-    #!/usr/bin/env python
     # -*- coding: utf-8 -*-
 
     ##############################################################################

--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -212,7 +212,7 @@ the macro function version of *Hello, World!*::
     
 .. note::
     If you already know a little about Python_ your are probably wondering why
-    not use ``print "Hello, World!"``?
+    not use ``print("Hello, World!")``?
 
     Remember that your macro will be executed by a Sardana server which may be
     running in a different computer than the computer you are working on.
@@ -225,9 +225,6 @@ the macro function version of *Hello, World!*::
     function (it is a bit more powerful than 
     :meth:`~sardana.macroserver.macro.Macro.output`\, and has a slightly
     different syntax) ::
-
-        # mandatory first line in your code if you use Python < 3.0
-        from __future__ import print_function
         
         from sardana.macroserver.macro import macro
         
@@ -582,7 +579,7 @@ messages with different levels:
     * :meth:`~Macro.output`
     
 As you've seen, the special :meth:`~Macro.output` function has the same effect
-as a print statement (with slightly different arguments).
+as a print function (with slightly different arguments).
 
 Log messages may have several destinations depending on how your sardana server
 is configured. At least, one destination of each log message is the client(s)
@@ -739,7 +736,7 @@ using :meth:`~Macro.data`:
         # and the result of the Macro.prepare method
         my_scan, _ = ret 
         self.runMacro(my_scan)
-        print len(my_scan.data)
+        self.print(len(my_scan.data))
 
 A set of macro call examples can be found
 :ref:`here <sardana-devel-macro-call-examples>`.
@@ -769,7 +766,7 @@ macro. So, without further delay, here is the *Hello, World!* example::
         """Hello, World! macro"""
         
         def run(self):
-            print "Hello, World!"
+            self.print("Hello, World!")
 
 .. _sardana-macro-add-parameters:
 
@@ -818,7 +815,7 @@ prepare HelloWorld to run only after year 1989:
                 raise Exception("HelloWorld can only run after year 1989")
     
         def run(self):
-            print "Hello, World!"
+            self.print("Hello, World!")
 
 .. _sardana-macro-handling-macro-stop-and-abort:
 
@@ -1537,10 +1534,11 @@ The second method is to use standard Python threading_ library.
 .. rubric:: Footnotes
 
 .. [#f1] To find the absolute path for sardana's source code type on the
-         command line ``python -c "import sys, sardana; sys.stdout.write(str(sardana.__path__))"``
+         command line ``python3 -c "import sys, sardana; sys.stdout.write
+         (str(sardana.__path__))"``
 
 .. [#f2] To check which version of Python_ you are using type on the command
-         line ``python -c "import sys; sys.stdout.write(sys.version)"``
+         line ``python3 -c "import sys; sys.stdout.write(sys.version)"``
 
 .. |input_integer| image:: ../../_static/macro_input_integer.png
     :align: middle

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -247,12 +247,12 @@ Glossary
         people unfamiliar with Python sometimes use a numerical counter instead::
 
             for i in range(len(food)):
-                print food[i]
+                print(food[i])
 
         As opposed to the cleaner, Pythonic method::
 
             for piece in food:
-                print piece
+                print(piece)
              
     sequence
         An :term:`iterable` which supports efficient element access using integer

--- a/doc/source/sphinxext/ipython_console_highlighting.py
+++ b/doc/source/sphinxext/ipython_console_highlighting.py
@@ -61,7 +61,7 @@ class IPythonConsoleLexer(Lexer):
       In [2]: a
       Out[2]: 'foo'
 
-      In [3]: print a
+      In [3]: print(a)
       foo
 
       In [4]: 1 / 0

--- a/doc/source/sphinxext/spock_console_highlighting.py
+++ b/doc/source/sphinxext/spock_console_highlighting.py
@@ -67,7 +67,7 @@ class SpockConsoleLexer(Lexer):
       LAB-01 [2]: a
       Result [2]: 'foo'
 
-      LAB-01 [3]: print a
+      LAB-01 [3]: print(a)
       foo
 
       LAB-01 [4]: 1 / 0

--- a/doc/source/users/getting_started/installing.rst
+++ b/doc/source/users/getting_started/installing.rst
@@ -10,13 +10,13 @@ Installing with pip [1]_ (platform-independent)
 
 Sardana can be installed using pip. The following command will
 automatically download and install the latest release of Sardana (see
-pip --help for options)::
+pip3 --help for options)::
 
-       pip install sardana
+       pip3 install sardana
 
 You can test the installation by running::
 
-       python -c "import sardana; print sardana.Release.version"
+       python3 -c "import sardana; print(sardana.Release.version)"
 
 
 Installing from PyPI manually [2]_ (platform-independent)
@@ -28,11 +28,11 @@ You may alternatively install from a downloaded release package:
 #. Extract the downloaded source into a temporary directory and change to it
 #. run::
 
-       python setup.py install
+       python3 setup.py install
 
 You can test the installation by running::
 
-       python -c "import sardana; print sardana.Release.version"
+       python3 -c "import sardana; print(sardana.Release.version)"
 
 Linux (Debian-based)
 --------------------
@@ -45,7 +45,7 @@ doing (as root)::
 
 You can test the installation by running::
 
-       python -c "import sardana; print sardana.Release.version"
+       python3 -c "import sardana; print(sardana.Release.version)"
 
 (see more detailed instructions in `this step-by-step howto
 <https://sourceforge.net/p/sardana/wiki/Howto-Sardana-on-Debian8/>`__)
@@ -58,7 +58,7 @@ Windows
 #. Run the installation executable
 #. test the installation::
 
-       C:\Python27\python -c "import sardana; print sardana.Release.version"
+       C:\Python35\python3 -c "import sardana; print(sardana.Release.version)"
 
 Windows installation shortcut
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -90,7 +90,7 @@ You can clone sardana from the main git repository::
 
 Then, to work in editable mode, just do::
 
-    pip install -e ./sardana
+    pip3 install -e ./sardana
 
 Note that you can also fork the git repository in github to get your own
 github-hosted clone of the sardana repository to which you will have full
@@ -107,39 +107,39 @@ Dependencies
 
 Sardana has dependencies on some python libraries:
 
-- Sardana uses Tango as the middleware so you need PyTango_ 7 or later
+- Sardana uses Tango as the middleware so you need PyTango_ 9.2.5 or later
   installed. You can check it by doing::
 
-    python -c 'import PyTango; print PyTango.Release.version'
+    python3 -c 'import tango; print(tango.__version__)'
 
-- Sardana clients are developed with Taurus so you need Taurus_ 3.6.0 or later
+- Sardana clients are developed with Taurus so you need Taurus_ 4.5.4 or later
   installed. You can check it by doing::
 
-      python -c 'import taurus; print taurus.Release.version'
+      python3 -c 'import taurus; print(taurus.Release.version)'
 
-- Sardana operate some data in the XML format and requires lxml_ library 2.1 or
+- Sardana operate some data in the XML format and requires lxml_ library 2.3 or
   later. You can check it by doing::
 
-      python -c 'import lxml.etree; print lxml.etree.LXML_VERSION'
+      python3 -c 'import lxml.etree; print(lxml.etree.LXML_VERSION)'
 
-- spock (Sardana CLI) requires itango 0.0.1 or later [3]_.
+- spock (Sardana CLI) requires itango 0.1.6 or later [3]_.
 
 
 .. rubric:: Footnotes
 
 .. [1] This command requires super user previledges on linux systems. If your
        user has them you can usually prefix the command with *sudo*:
-       ``sudo pip -U sardana``. Alternatively, if you don't have
+       ``sudo pip3 -U sardana``. Alternatively, if you don't have
        administrator previledges, you can install locally in your user
-       directory with: ``pip --user sardana``
+       directory with: ``pip3 --user sardana``
        In this case the executables are located at <HOME_DIR>/.local/bin. Make
        sure the PATH is pointing there or you execute from there.
 
 .. [2] *setup.py install* requires user previledges on linux systems. If your
        user has them you can usually prefix the command with *sudo*: 
-       ``sudo python setup.py install``. Alternatively, if you don't have
+       ``sudo python3 setup.py install``. Alternatively, if you don't have
        administrator previledges, you can install locally in your user directory
-       with: ``python setup.py install --user``
+       with: ``python3 setup.py install --user``
        In this case the executables are located at <HOME_DIR>/.local/bin. Make
        sure the PATH is pointing there or you execute from there.
 


### PR DESCRIPTION
After #1089, sardana only works with python3. The examples in the docs use
"python", "pip", print statement, etc. Change them to use python3 equivalents.

Fixes #1184.