### PR TITLE
[WIP] Fix auto upload to pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - docker
 
 python:
-  - "3.5"
+  - "3.6"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,15 @@ doctr:
   sync: true
   built-docs: build/sphinx/html/
 
+before_deploy:
+  # build source dist, otherwise deploy to PyPI does not work
+  - if [ $TEST == "testsuite" ]; then docker exec -t sardana-test /bin/bash -c "cd /sardana ; python3 setup.py sdist"; fi
+
 deploy:
   # deploy to pypi when a version tag is pushed to the official repo
   - provider: pypi
     user: sardana_bot
+    skip_existing: true
     password:
       secure: "HvZGtw8qFlacssi7FE92+gFgQPRRPvurpPxi/Gq74TeKWU0X4EbWVT3XMdi7sb7yA7JQlOGIGtY3ofzEdrKgKcEsrxxKbeSW7foDf3+AlmMF7c31ePxkqBCGMSAxsaCjKJR2sVtBNiycp0I7LWYeKlzFNY2W8aZW9dnpkC9aD/oGdNRJlCVGq912xaTnXRxmUrh+2IeUqsXKqfih7E0Qw99VXOLFdHIHtoPGN5ka+tvLp+zNFMi1q2HUyix4P/aQ10BwE5t1onfdSBBh7bzZTINoUVuN1bstNXYcoqfVMAbOoeArIIr7z41eYd8G8WMTXJp2MFrO61AW6xK8htB07RX2eaEWq7KT4zazG5vP/Skayr7ofnB/d3Rs1BOre9ttScJIxwyQLhL60WeM9NyCoHVjNdKYK5gNHX4se/6FOzmHm1VgQgI9bzyfIIAoSSyUL/5KOGdOwhMPSij5AT1YIy8RSe7efm+xw3md+wcmEsbaMX9VEy2YgTL0/nmFHrEA+9HV0I5xkFBQ8BHuK0YFubQ9rG99B1GwF0Vl85M+Ylp5D1/p70sXCHEUk3SbOcg9Kz0TTisDMuDT2ajJYGylg7/OskI5OwOBbEndP8OUPesm62V1ciQcKjH2L81yWajRPSfd/OPjoMwG+XdaG5rR7m2FACXvyhEOIeK1Mt41MvM="
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,6 @@ deploy:
     password:
       secure: "HvZGtw8qFlacssi7FE92+gFgQPRRPvurpPxi/Gq74TeKWU0X4EbWVT3XMdi7sb7yA7JQlOGIGtY3ofzEdrKgKcEsrxxKbeSW7foDf3+AlmMF7c31ePxkqBCGMSAxsaCjKJR2sVtBNiycp0I7LWYeKlzFNY2W8aZW9dnpkC9aD/oGdNRJlCVGq912xaTnXRxmUrh+2IeUqsXKqfih7E0Qw99VXOLFdHIHtoPGN5ka+tvLp+zNFMi1q2HUyix4P/aQ10BwE5t1onfdSBBh7bzZTINoUVuN1bstNXYcoqfVMAbOoeArIIr7z41eYd8G8WMTXJp2MFrO61AW6xK8htB07RX2eaEWq7KT4zazG5vP/Skayr7ofnB/d3Rs1BOre9ttScJIxwyQLhL60WeM9NyCoHVjNdKYK5gNHX4se/6FOzmHm1VgQgI9bzyfIIAoSSyUL/5KOGdOwhMPSij5AT1YIy8RSe7efm+xw3md+wcmEsbaMX9VEy2YgTL0/nmFHrEA+9HV0I5xkFBQ8BHuK0YFubQ9rG99B1GwF0Vl85M+Ylp5D1/p70sXCHEUk3SbOcg9Kz0TTisDMuDT2ajJYGylg7/OskI5OwOBbEndP8OUPesm62V1ciQcKjH2L81yWajRPSfd/OPjoMwG+XdaG5rR7m2FACXvyhEOIeK1Mt41MvM="
     on:
-      repo: sardana-org/sardana
-      tags: true
-      condition: "$TEST == testsuite && $DOCKER_IMG == reszelaz/sardana-test && $TRAVIS_TAG =~ ^[0-9]+.[0-9]+.[0-9]+$"
+      repo: reszelaz/sardana
+      all_branches: true
+      condition: "$TEST == testsuite && $DOCKER_IMG == reszelaz/sardana-test"


### PR DESCRIPTION
Based on the https://github.com/sardana-org/sardana/issues/1166#issuecomment-522724917 I have tried to do the same in Sardana (make a sdist build before the deploy). However I did not manage to make it work.

Furthermore, I'm not even able to upload the egg file which used to work - see [2.8.1 upload](https://pypi.org/project/sardana/2.8.1/#files) done by sardana_bot.

The error which we get seems to have to do with the authentication:

```
Deploying application
running sdist
running egg_info
/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/setuptools/dist.py:474: UserWarning: Normalizing '3.0.0-alpha' to '3.0.0a0'
  normalized_version,
error: [Errno 13] Permission denied
Uploading distributions to https://upload.pypi.org/legacy/
Uploading sardana-3.0.0a0-py3.5.egg
100%|██████████| 2.13M/2.13M [00:00<00:00, 4.87MB/s]
NOTE: Try --verbose to see response content.
HTTPError: 403 Client Error: Invalid or non-existent authentication information. for url: https://upload.pypi.org/legacy/

build/lib/sardana/__init__.py already exists, no checkout
build/lib/sardana/macroserver/__init__.py already exists, no checkout
[...]
src/sardana.egg-info/top_level.txt already exists, no checkout
src/sardana/__pycache__/release.cpython-35.pyc already exists, no checkout
Could not restore untracked files from stash entry
PyPI upload failed.
```

I have it leave it for now - lack of time. If someone is willing to try more, go ahead. Otherwise we will deal with that during the next release process.

IMPORTANT: Remember to revert the a34bfe0 before integration.

Fixes #1166.

