### PR TITLE
Do not detect events on MeasurementGroup's LatencyTime and NbStarts

### DIFF
--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -73,10 +73,14 @@ class MeasurementGroup(PoolGroupDevice):
     def init_device(self):
         PoolGroupDevice.init_device(self)
         # state and status are already set by the super class
-        detect_evts = "latencytime", "moveable", "synchronization", \
-                      "softwaresynchronizerinitialdomain", "nbstarts"
+        detect_evts = "moveable", "synchronization", \
+                      "softwaresynchronizerinitialdomain"
+        # TODO: nbstarts could be moved to detect events with
+        # abs_change criteria of 1, but be careful with
+        # tango-controls/pytango#302
         non_detect_evts = "configuration", "integrationtime", "monitorcount", \
-                          "acquisitionmode", "elementlist"
+                          "acquisitionmode", "elementlist", "latencytime", \
+                          "nbstarts"
         self.set_change_events(detect_evts, non_detect_evts)
 
         self.Elements = list(self.Elements)


### PR DESCRIPTION
Due to a bug in PyTango (or Tango) we need to be very carefull with not properly configured event system. Subscription to an attribute in stateless mode which constantly fails may collide with destruction of Attribute/DeviceProxy.

More details in [tango-controls/pytango#302](https://github.com/tango-controls/pytango/issues/302).

To be on the safe side don't check event criteria for LatencyTime neither NbStarts. While in the case of the
first one we would like to always receive the events, even if the change is extreamly low, the second one has sense only to send events if the difference is 1. But for the moment we don't even check the NbStarts criteria.

Fixes #1118 . At least I run it for several hours now and it works, I will continue overnight...
@dschick could you try it on your system (the changes should be easily portable to your code)
It could be even the reason for #1080: @amilan, @pjb671 could you verify that?

I suspect (not sure) that this bug was present since 2.7 (Jan19) for the NbStarts attribute which was affecting step scans and continuous scans. And since 2.6 (Jul18) affecting only continuous scans.

Also, I suspect that until the bug in PyTango (or Tango) gets fixed removing of the event system criteria for the following attributes:

- {CTExpChannel}/Value
- {IORegister}/Value
- {Motor}/Position
- {Motor}/DialPosition
- {PseudoCounter}/Value
- {PseudoMotor}/Position
- {ZeroDExpChannel}/Value

 may lead to similar hangs.