### PR TITLE
Better macro exception message

### DIFF
--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1618,8 +1618,8 @@ class MacroExecutor(Logger):
             if isinstance(macro_exp, MacroServerException):
                 if macro_obj.parent_macro is None:
                     door.debug(macro_exp.traceback)
-                    door.error("An error occurred while running %s:\n%s" %
-                               (macro_obj.description, macro_exp.msg))
+                    door.error("An error occurred while running %s:\n%r" %
+                               (macro_obj.description, macro_exp))
             self._popMacro()
             raise macro_exp
         self.debug("[ END ] runMacro %s" % desc)

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1618,8 +1618,11 @@ class MacroExecutor(Logger):
             if isinstance(macro_exp, MacroServerException):
                 if macro_obj.parent_macro is None:
                     door.debug(macro_exp.traceback)
-                    door.error("An error occurred while running %s:\n%r" %
-                               (macro_obj.description, macro_exp))
+                    msg = ("An error occurred while running {}:\n"
+                           "{!r}").format(macro_obj.getName(), macro_exp)
+                    door.error(msg)
+                    msg = "Hint: in Spock execute `www`to get more details"
+                    door.info(msg)
             self._popMacro()
             raise macro_exp
         self.debug("[ END ] runMacro %s" % desc)


### PR DESCRIPTION
When an exception occurs in a macro the error message being displayed is non informative.

If, for example, a macro tries to access a non existing member ('hello') of a dict, the message is:
```
An error occurred while running Macro 'demo() -> f3e7b818-d0a1-11e9-a9ca-00':
hello
```

This PR proposes a better error message. Something like
```
An error occurred while running Macro 'demo() -> f3e7b818-d0a1-11e9-a9ca-00':
KeyError: hello
```

