### PR TITLE
Fix setting of env. vars. in py37

### DIFF
--- a/src/sardana/macroserver/msenvmanager.py
+++ b/src/sardana/macroserver/msenvmanager.py
@@ -32,6 +32,7 @@ __docformat__ = 'restructuredtext'
 
 import os
 import shelve
+from itertools import zip_longest
 import operator
 
 from taurus.core.util.containers import CaselessDict
@@ -407,13 +408,13 @@ class EnvironmentManager(MacroServerManager):
 
         return ret
 
-    def _pairwise(self, iterable):
-        itnext = iter(iterable).__next__
-        while True:
-            yield itnext(), itnext()
+    def _grouper(self, iterable):
+        # https://docs.python.org/3/library/itertools.html#itertools-recipes
+        args = [iter(iterable)] * 2
+        return zip_longest(*args)
 
     def _dictFromSequence(self, seq):
-        return dict(self._pairwise(seq))
+        return dict(self._grouper(seq))
 
     def _encode(self, d):
         ret = {}


### PR DESCRIPTION
Construction of dict from a generator changed in py37 making the _pairwise method failing with "RuntimeError: generator raised StopIteration".

The following code demonstrates that:

```python
# python 3.5
In [28]: s = [1, "a", 2, "b", 3, "c"]

In [29]: def pairwise(it):
    ...:     itnext = iter(it).__next__
    ...:     while True:
    ...:         yield itnext(), itnext()
    ...:         
    ...:         

In [30]: dict(pairwise(s))
Out[30]: {1: 'a', 2: 'b', 3: 'c'}
```

```python
# python 3.7
In [6]: s = [1, 'a', 2, 'b', 3, 'c']

In [7]: def pairwise(it):
   ...:     itnext = iter(it).__next__
   ...:     while True:
   ...:         yield itnext(), itnext()
   ...:         
   ...:         

In [8]: dict(pairwise(s))
---------------------------------------------------------------------------
StopIteration                             Traceback (most recent call last)
<ipython-input-7-431d046daf58> in pairwise(it)
      3     while True:
----> 4         yield itnext(), itnext()
      5 

StopIteration: 

The above exception was the direct cause of the following exception:

RuntimeError                              Traceback (most recent call last)
<ipython-input-8-a6daa20e6d88> in <module>()
----> 1 dict(pairwise(s))

RuntimeError: generator raised StopIteration
```

Use grouper solution from [Python Itertools Recipies](https://docs.python.org/3/library/itertools.html#itertools-recipes) instead which is py35 and higher compatible.

@sardana-org/integrators can you please take a look on that. Thanks!