### PR TITLE
Create instruments and associate elements to them in sar_demo

### DIFF
--- a/src/sardana/macroserver/macros/demo.py
+++ b/src/sardana/macroserver/macros/demo.py
@@ -85,6 +85,11 @@ def clear_sar_demo(self):
     for ctrl in SAR_DEMO.get("controllers", ()):
         self.udefctrl(ctrl)
 
+    self.print("Removing instruments...")
+    pool = self.getPools()[0]
+    for instrument in SAR_DEMO.get("instruments", ()):
+        pool.DeleteElement(instrument)
+
     self.unsetEnv(_ENV)
 
     self.print("DONE!")
@@ -192,14 +197,29 @@ def sar_demo(self):
         self.print("Setting %s as ActiveMntGrp" % mg_name)
         self.setEnv("ActiveMntGrp", mg_name)
 
+    self.print("Creating instruments: /slit, /mirror and /monitor ...")
+    pool.createInstrument('/slit', 'NXcollimator')
+    pool.createInstrument('/mirror', 'NXmirror')
+    pool.createInstrument('/monitor', 'NXmonitor')
+
+    self.print("Assigning elements to instruments...")
+    self.getMotor(motor_names[0]).setInstrumentName('/slit')
+    self.getMotor(motor_names[1]).setInstrumentName('/slit')
+    self.getPseudoMotor(gap).setInstrumentName('/slit')
+    self.getPseudoMotor(offset).setInstrumentName('/slit')
+    self.getMotor(motor_names[2]).setInstrumentName('/mirror')
+    self.getMotor(motor_names[3]).setInstrumentName('/mirror')
+    self.getCounterTimer(ct_names[0]).setInstrumentName('/monitor')
+
     controllers = pm_ctrl_name, mot_ctrl_name, ct_ctrl_name, \
         zerod_ctrl_name, oned_ctrl_name, twod_ctrl_name, \
         tg_ctrl_name, ior_ctrl_name
     elements = [gap, offset] + motor_names + ct_names + \
         zerod_names + oned_names + twod_names + tg_names + \
         ior_names
+    instruments = ["/slit", "/mirror", "/monitor"]
     d = dict(controllers=controllers, elements=elements,
-             measurement_groups=[mg_name])
+             measurement_groups=[mg_name], instruments=instruments)
 
     self.setEnv(_ENV, d)
 

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -454,6 +454,9 @@ class PoolElement(BaseElement, TangoDevice):
         # instr_name = instr_name[:instr_name.index('(')]
         return instr_name
 
+    def setInstrumentName(self, instr_name):
+        self.getInstrumentObj().write(instr_name)
+
     def getInstrument(self):
         instr_name = self.getInstrumentName()
         if not instr_name:

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -2505,6 +2505,11 @@ class Pool(TangoDevice, MoveableSource):
     def deleteController(self, name):
         return self.deleteElement(name)
 
+    def createInstrument(self, full_name, class_name):
+        self.command_inout("CreateInstrument", [full_name, class_name])
+        elements_info = self.getElementsInfo()
+        return self._wait_for_element_in_container(elements_info, full_name)
+
 
 def registerExtensions():
     factory = Factory()


### PR DESCRIPTION
This is useful for TaurusGUI demonstration (instrument panels are automatically populaated with elements).
Also we were doing this step in the release tests manually. Programt this in `sar_demo` and `clear_sar_demo` now.

@sardana-org/integrators can you take a look on this? Thanks!