### PR TITLE
Add snapshot configuration macros

### DIFF
--- a/doc/source/users/standard_macro_catalog.rst
+++ b/doc/source/users/standard_macro_catalog.rst
@@ -117,6 +117,7 @@ list related macros
     * :class:`~sardana.macroserver.macros.lists.lsmac`
     * :class:`~sardana.macroserver.macros.lists.lsmaclib`
     * :class:`~sardana.macroserver.macros.env.lsgh`
+    * :class:`~sardana.macroserver.macros.env.lssnap`
 
 measurement configuration macros
 --------------------------------
@@ -126,6 +127,9 @@ measurement configuration macros
 
     * :class:`~sardana.macroserver.macros.expert.defmeas`
     * :class:`~sardana.macroserver.macros.expert.udefmeas`
+    * :class:`~sardana.macroserver.macros.expert.defsnap`
+    * :class:`~sardana.macroserver.macros.expert.udefsnap`
+    * :class:`~sardana.macroserver.macros.expert.lssnap`
 
 general hooks macros
 --------------------

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -451,7 +451,11 @@ class lssnap(Macro):
     """
 
     def run(self):
-        snapshot_items = self.getEnv("PreScanSnapshot")
+        try:
+            snapshot_items = self.getEnv("PreScanSnapshot")
+        except UnknownEnv:
+            self.output("No pre-scan snapshot")
+            return
         for full_name, label in snapshot_items:
             self.print("{} ({})".format(label, full_name))
 
@@ -484,8 +488,10 @@ class defsnap(Macro):
                 return item.fullname, item.label
             else:
                 return item.full_name, item.name
-
-        snap_items = self.getEnv("PreScanSnapshot")
+        try:
+            snap_items = self.getEnv("PreScanSnapshot")
+        except UnknownEnv:
+            snap_items = []
         snap_full_names = [item[0] for item in snap_items]
         new_snap_items = []
         for name in snap_names:

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -456,8 +456,11 @@ class lssnap(Macro):
         except UnknownEnv:
             self.output("No pre-scan snapshot")
             return
+        out = List(['Snap item', 'Snap item full name'])
         for full_name, label in snapshot_items:
-            self.print("{} ({})".format(label, full_name))
+            out.appendRow([label, full_name])
+        for line in out.genOutput():
+            self.output(line)
 
 
 class defsnap(Macro):

--- a/src/sardana/macroserver/macros/env.py
+++ b/src/sardana/macroserver/macros/env.py
@@ -456,8 +456,8 @@ class lssnap(Macro):
             self.print("{} ({})".format(label, full_name))
 
 
-class addsnap(Macro):
-    """Add item(s) to snapshot group. Accepts:
+class defsnap(Macro):
+    """Define snapshot group item(s). Accepts:
     - Pool moveables: motor, pseudo motor
     - Pool experimental channels: counter/timer, 0D, 1D, 2D, pseudo counter
     - Taurus attributes


### PR DESCRIPTION
For the moment two macros were developed: `lssnap` and `addsnap` macros. Of course the macro names, or anything else, can be changed. These are just suggestions...

Also the lssnap macro could be improved to print output in the table format. 

I would also add a macro to remove an alement from the snapshot.

I conservatively marked it as WIP. If someone wants to continue this development - feel free (I won't have time in the next month, or so). If you consider it can already go to develop branch, I think this is also ok since it adds value and is usable.

Thanks in advance for your feedback!