### PR TITLE
Don't use theme icon for "Add to favourites" in macroexecutor

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -625,8 +625,8 @@ class TaurusMacroExecutorWidget(TaurusWidget):
         self.setLayout(Qt.QVBoxLayout())
         self.layout().setContentsMargins(0, 0, 0, 0)
 
-        self.addToFavouritesAction = Qt.QAction(getThemeIcon(
-            "software-update-available"), "Add to favourites", self)
+        self.addToFavouritesAction = Qt.QAction(getIcon(
+            ":/status/software-update-available.svg"), "Add to favourites", self)
         self.addToFavouritesAction.triggered.connect(self.onAddToFavourites)
         self.addToFavouritesAction.setToolTip("Add to favourites")
         self.stopMacroAction = Qt.QAction(

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -625,8 +625,9 @@ class TaurusMacroExecutorWidget(TaurusWidget):
         self.setLayout(Qt.QVBoxLayout())
         self.layout().setContentsMargins(0, 0, 0, 0)
 
-        self.addToFavouritesAction = Qt.QAction(getIcon(
-            ":/status/software-update-available.svg"), "Add to favourites", self)
+        self.addToFavouritesAction = Qt.QAction(
+            getIcon(":/status/software-update-available.svg"),
+            "Add to favourites", self)
         self.addToFavouritesAction.triggered.connect(self.onAddToFavourites)
         self.addToFavouritesAction.setToolTip("Add to favourites")
         self.stopMacroAction = Qt.QAction(


### PR DESCRIPTION
software-update-available is not accessible when using taurus-org/taurus#1012
via theme (on Debian Buster with KDE). Use directly the icon.
This works correctly on Debian Stretch and Debian Buster (both with KDE).