### PR TITLE
Fix #1209: Crash on spock startup on buster

### DIFF
--- a/src/sardana/spock/inputhandler.py
+++ b/src/sardana/spock/inputhandler.py
@@ -148,7 +148,7 @@ class InputHandler(Singleton, BaseInputHandler):
         self._conn = conn
         app = Qt.QApplication.instance()
         if app is None:
-            app = Qt.QApplication([])
+            app = Qt.QApplication(['spock'])
         app.setQuitOnLastWindowClosed(False)
         self._msg_handler = MessageHandler(conn)
         TaurusManager().addJob(self.run_forever, None)


### PR DESCRIPTION
Some PyQt5 versions don't like that QApplication
is created with empty list argument.

This should close #1209.