### PR TITLE
MNT: use variable defined above

### DIFF
--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -726,7 +726,7 @@ def prepare_server(args, tango_args):
     else:
         inst_name = tango_args[1].lower()
 
-    if "-nodb" in tango_args:
+    if nodb:
         return log_messages
 
     db = Database()


### PR DESCRIPTION
instead of re-checking if we are in a no-database environment.