### PR TITLE
Write missing default attribute values when pool starts

### DIFF
--- a/src/sardana/pool/poolmetacontroller.py
+++ b/src/sardana/pool/poolmetacontroller.py
@@ -227,9 +227,9 @@ class DataInfo(object):
         return kwargs
 
     def __repr__(self):
-        return "{0}(name={1}, type={2}, format={3}, access={4})".format(
+        return "{0}(name={1}, type={2}, format={3}, access={4}, default_value={5})".format(
             self.__class__.__name__, self.name, DataType[self.dtype],
-            DataFormat[self.dformat], DataAccess[self.access])
+            DataFormat[self.dformat], DataAccess[self.access], self.default_value)
 
 # class PropertyInfo(DataInfo):
 

--- a/src/sardana/tango/pool/Controller.py
+++ b/src/sardana/tango/pool/Controller.py
@@ -233,11 +233,16 @@ class Controller(PoolDevice):
             self.warning(
                 "Controller %s doesn't have any information", self.ctrl)
             return PoolDevice.get_dynamic_attributes(self)
+        # print stuff
+        print self.ctrl
+        print info
         self._dynamic_attributes_cache = dyn_attrs = CaselessDict()
         self._standard_attributes_cache = std_attrs = CaselessDict()
         for attr_name, attr_data in info.ctrl_attributes.items():
             name, tg_info = to_tango_attr_info(attr_name, attr_data)
             dyn_attrs[attr_name] = attr_name, tg_info, attr_data
+        print std_attrs
+        print dyn_attrs
         return std_attrs, dyn_attrs
 
     def read_DynamicAttribute(self, attr):

--- a/src/sardana/tango/pool/Controller.py
+++ b/src/sardana/tango/pool/Controller.py
@@ -234,15 +234,11 @@ class Controller(PoolDevice):
                 "Controller %s doesn't have any information", self.ctrl)
             return PoolDevice.get_dynamic_attributes(self)
         # print stuff
-        print self.ctrl
-        print info
         self._dynamic_attributes_cache = dyn_attrs = CaselessDict()
         self._standard_attributes_cache = std_attrs = CaselessDict()
         for attr_name, attr_data in info.ctrl_attributes.items():
             name, tg_info = to_tango_attr_info(attr_name, attr_data)
             dyn_attrs[attr_name] = attr_name, tg_info, attr_data
-        print std_attrs
-        print dyn_attrs
         return std_attrs, dyn_attrs
 
     def read_DynamicAttribute(self, attr):


### PR DESCRIPTION
If a controller is deployed with sardanadsconfig the default values of attributes are not written to the database. Normally this is dine by the defctrl or defelem macros. Depending on the implementation of an affected controller this may or may not be a problem, but it can lead to strange and annoying errors. This PR adds a check when the Pool starts to write any missing default value after each device is started.   