### PR TITLE
Improve Taurus extensions API documentation

### DIFF
--- a/doc/source/devel/api/sardana/taurus.rst
+++ b/doc/source/devel/api/sardana/taurus.rst
@@ -11,3 +11,4 @@
     :maxdepth: 1
     
     core <taurus/core>
+    qt <taurus/qt>

--- a/doc/source/devel/api/sardana/taurus/core/tango/sardana.rst
+++ b/doc/source/devel/api/sardana/taurus/core/tango/sardana.rst
@@ -7,10 +7,21 @@
 
 .. automodule:: sardana.taurus.core.tango.sardana
 
+.. rubric:: Functions
+
+.. hlist::
+    :columns: 3
+
+    * :func:`registerExtensions`
+    * :func:`unregisterExtensions`
+
 .. rubric:: Modules
 
 .. toctree::
     :maxdepth: 1
     
     pool <sardana/pool>
+    macroserver <sardana/macroserver>
 
+.. autofunction:: registerExtensions
+.. autofunction:: unregisterExtensions

--- a/doc/source/devel/api/sardana/taurus/core/tango/sardana/macroserver.rst
+++ b/doc/source/devel/api/sardana/taurus/core/tango/sardana/macroserver.rst
@@ -1,0 +1,46 @@
+.. currentmodule:: sardana.taurus.core.tango.sardana.macroserver
+
+=================
+Taurus Extensions
+=================
+
+.. rubric:: Functions
+
+.. hlist::
+    :columns: 3
+
+    * :func:`registerExtensions`
+    * :func:`unregisterExtensions`
+
+.. rubric:: Classes
+
+.. hlist::
+    :columns: 4
+
+    * :class:`BaseDoor`
+    * :class:`BaseMacroServer`
+
+.. autofunction:: registerExtensions
+.. autofunction:: unregisterExtensions
+
+BaseDoor
+--------
+
+.. inheritance-diagram:: BaseDoor
+    :parts: 1
+
+.. autoclass:: BaseDoor
+    :show-inheritance:
+    :members:
+    :undoc-members:
+
+BaseMacroServer
+---------------
+
+.. inheritance-diagram:: BaseMacroServer
+    :parts: 1
+
+.. autoclass:: BaseMacroServer
+    :show-inheritance:
+    :members:
+    :undoc-members:

--- a/doc/source/devel/api/sardana/taurus/core/tango/sardana/pool.rst
+++ b/doc/source/devel/api/sardana/taurus/core/tango/sardana/pool.rst
@@ -4,6 +4,14 @@
 Taurus Extensions
 =================
 
+.. rubric:: Functions
+
+.. hlist::
+    :columns: 3
+
+    * :func:`registerExtensions`
+    * :func:`unregisterExtensions`
+
 .. rubric:: Classes
 
 .. hlist::
@@ -27,6 +35,9 @@ Taurus Extensions
     * :class:`TriggerGate`
     * :class:`TwoDExpChannel`
     * :class:`ZeroDExpChannel`
+
+.. autofunction:: registerExtensions
+.. autofunction:: unregisterExtensions
 
 BaseElement
 -----------

--- a/doc/source/devel/api/sardana/taurus/qt.rst
+++ b/doc/source/devel/api/sardana/taurus/qt.rst
@@ -1,0 +1,15 @@
+.. currentmodule:: sardana.taurus.qt
+
+:mod:`~sardana.taurus.qt`
+=========================
+
+.. automodule:: sardana.taurus.qt
+
+.. rubric:: Modules
+
+.. toctree::
+    :maxdepth: 1
+
+    qtcore <qt/qtcore>
+    qtgui <qt/qtgui>
+

--- a/doc/source/devel/api/sardana/taurus/qt/qtcore.rst
+++ b/doc/source/devel/api/sardana/taurus/qt/qtcore.rst
@@ -1,0 +1,14 @@
+.. currentmodule:: sardana.taurus.qt.qtcore
+
+:mod:`~sardana.taurus.qt.qtcore`
+============================
+
+.. automodule:: sardana.taurus.qt.qtcore
+
+.. rubric:: Modules
+
+.. toctree::
+    :maxdepth: 1
+
+    tango <qtcore/tango>
+

--- a/doc/source/devel/api/sardana/taurus/qt/qtcore.rst
+++ b/doc/source/devel/api/sardana/taurus/qt/qtcore.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: sardana.taurus.qt.qtcore
 
 :mod:`~sardana.taurus.qt.qtcore`
-============================
+================================
 
 .. automodule:: sardana.taurus.qt.qtcore
 

--- a/doc/source/devel/api/sardana/taurus/qt/qtcore/tango.rst
+++ b/doc/source/devel/api/sardana/taurus/qt/qtcore/tango.rst
@@ -1,0 +1,14 @@
+.. currentmodule:: sardana.taurus.qt.qtcore.tango
+
+:mod:`~sardana.taurus.qt.qtcore.tango`
+=================================
+
+.. automodule:: sardana.taurus.qt.qtcore.tango
+
+.. rubric:: Modules
+
+.. toctree::
+    :maxdepth: 1
+
+    sardana <tango/sardana>
+

--- a/doc/source/devel/api/sardana/taurus/qt/qtcore/tango.rst
+++ b/doc/source/devel/api/sardana/taurus/qt/qtcore/tango.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: sardana.taurus.qt.qtcore.tango
 
 :mod:`~sardana.taurus.qt.qtcore.tango`
-=================================
+======================================
 
 .. automodule:: sardana.taurus.qt.qtcore.tango
 

--- a/doc/source/devel/api/sardana/taurus/qt/qtcore/tango/sardana.rst
+++ b/doc/source/devel/api/sardana/taurus/qt/qtcore/tango/sardana.rst
@@ -1,0 +1,25 @@
+.. currentmodule:: sardana.taurus.qt.qtcore.tango.sardana
+
+.. _sardana-taurus-api:
+
+:mod:`~sardana.taurus.qt.qtcore.tango.sardana`
+==============================================
+
+.. automodule:: sardana.taurus.qt.qtcore.tango.sardana
+
+.. rubric:: Functions
+
+.. hlist::
+    :columns: 3
+
+    * :func:`registerExtensions`
+
+.. rubric:: Modules
+
+.. toctree::
+    :maxdepth: 1
+
+    pool <sardana/pool>
+    macroserver <sardana/macroserver>
+
+.. autofunction:: registerExtensions

--- a/doc/source/devel/api/sardana/taurus/qt/qtcore/tango/sardana.rst
+++ b/doc/source/devel/api/sardana/taurus/qt/qtcore/tango/sardana.rst
@@ -1,7 +1,5 @@
 .. currentmodule:: sardana.taurus.qt.qtcore.tango.sardana
 
-.. _sardana-taurus-api:
-
 :mod:`~sardana.taurus.qt.qtcore.tango.sardana`
 ==============================================
 

--- a/doc/source/devel/api/sardana/taurus/qt/qtcore/tango/sardana/macroserver.rst
+++ b/doc/source/devel/api/sardana/taurus/qt/qtcore/tango/sardana/macroserver.rst
@@ -1,0 +1,44 @@
+.. currentmodule:: sardana.taurus.qt.qtcore.tango.sardana.macroserver
+
+=================
+Taurus Extensions
+=================
+
+.. rubric:: Functions
+
+.. hlist::
+    :columns: 3
+
+    * :func:`registerExtensions`
+
+.. rubric:: Classes
+
+.. hlist::
+    :columns: 4
+
+    * :class:`QDoor`
+    * :class:`QMacroServer`
+
+.. autofunction:: registerExtensions
+
+QDoor
+-----
+
+.. inheritance-diagram:: QDoor
+    :parts: 1
+
+.. autoclass:: QDoor
+    :show-inheritance:
+    :members:
+    :undoc-members:
+
+QMacroServer
+------------
+
+.. inheritance-diagram:: QMacroServer
+    :parts: 1
+
+.. autoclass:: QMacroServer
+    :show-inheritance:
+    :members:
+    :undoc-members:

--- a/doc/source/devel/api/sardana/taurus/qt/qtcore/tango/sardana/pool.rst
+++ b/doc/source/devel/api/sardana/taurus/qt/qtcore/tango/sardana/pool.rst
@@ -1,0 +1,44 @@
+.. currentmodule:: sardana.taurus.qt.qtcore.tango.sardana.pool
+
+=================
+Taurus Extensions
+=================
+
+.. rubric:: Functions
+
+.. hlist::
+    :columns: 3
+
+    * :func:`registerExtensions`
+
+.. rubric:: Classes
+
+.. hlist::
+    :columns: 4
+
+    * :class:`QPool`
+    * :class:`QMeasurementGroup`
+
+.. autofunction:: registerExtensions
+
+QPool
+-----
+
+.. inheritance-diagram:: QPool
+    :parts: 1
+
+.. autoclass:: QPool
+    :show-inheritance:
+    :members:
+    :undoc-members:
+
+QMeasurementGroup
+-----------------
+
+.. inheritance-diagram:: QMeasurementGroup
+    :parts: 1
+
+.. autoclass:: QMeasurementGroup
+    :show-inheritance:
+    :members:
+    :undoc-members:

--- a/doc/source/devel/api/sardana/taurus/qt/qtgui.rst
+++ b/doc/source/devel/api/sardana/taurus/qt/qtgui.rst
@@ -1,0 +1,6 @@
+.. currentmodule:: sardana.taurus.qt.qtgui
+
+:mod:`~sardana.taurus.qt.qtgui`
+================================
+
+.. automodule:: sardana.taurus.qt.qtgui

--- a/doc/source/users/faq.rst
+++ b/doc/source/users/faq.rst
@@ -54,14 +54,13 @@ How to call procedures?
 The central idea of the Sardana SCADA_ system is to execute procedures centrally.
 The execution can be started from either:
 
-    * *spock* offers a command line interface with commands very similar to SPEC_.
-      It is documented :ref:`here <sardana-spock>`.
-    * Procedures can also be executed with from a :term:`GUI`. Taurus provides
-      `generic widgets for macro execution <http://www.tango-
-      controls.org/static/taurus/latest/doc/html/users/ui/macros/>`__.
+    * :ref:`sardana-spock` offers a command line interface with commands very similar to SPEC_.
+    * Procedures can also be executed with a :term:`GUI`. Taurus provides
+      :ref:`generic widgets for macro execution <sardana-taurus>`.
     * Procedures can also be executed in specific :term:`GUI` s and specific Taurus_
       widgets. The :term:`API` to execute macros from python code is documented
-      here **<LINK>**.
+      in :mod:`sardana.taurus.core.tango.sardana` and from PyQt code is documented
+      in :mod:`sardana.taurus.qt.qtcore.tango.sardana`.
 
 How to write procedures?
 ------------------------

--- a/src/sardana/taurus/core/tango/sardana/__init__.py
+++ b/src/sardana/taurus/core/tango/sardana/__init__.py
@@ -23,7 +23,30 @@
 ##
 ##############################################################################
 
-"""The sardana package. It contains specific part of sardana"""
+"""Taurus extensions for Sardana devices.
+
+Objects obtained with :func:`taurus.Device` expose standard interfaces
+e.g., allow to interact with their attributes, check their state, etc.
+This module defines classes for enriched interaction with Sardana devices
+(also for other elements not exported as devices), e.g. synchronous move
+of a sardana motor with :meth:`~sardana.taurus.core.tango.sardana.pool.Motor.move`
+method instead of writing motor's position attribute and then waiting for its
+state change.
+
+To obtain these enriched objects with :func:`taurus.Device` you need to first
+register the extension classes with
+the :obj:`~sardana.taurus.core.tango.sardana.registerExtensions` function.
+
+The registration needs to be done before the first access to the given
+:func:`taurus.Device`.
+
+When you would like to get back to the default :func:`taurus.Device` behavior
+you need to unregister the extension classes with the
+:obj:`~sardana.taurus.core.tango.sardana.unregisterExtensions` function.
+
+Note that the unregistration will not remove the already created devices from
+the :func:`taurus.Factory` cache.
+"""
 
 __docformat__ = 'restructuredtext'
 

--- a/src/sardana/taurus/core/tango/sardana/__init__.py
+++ b/src/sardana/taurus/core/tango/sardana/__init__.py
@@ -29,7 +29,8 @@ Objects obtained with :func:`taurus.Device` expose standard interfaces
 e.g., allow to interact with their attributes, check their state, etc.
 This module defines classes for enriched interaction with Sardana devices
 (also for other elements not exported as devices), e.g. synchronous move
-of a sardana motor with :meth:`~sardana.taurus.core.tango.sardana.pool.Motor.move`
+of a sardana motor with
+:meth:`~sardana.taurus.core.tango.sardana.pool.Motor.move`
 method instead of writing motor's position attribute and then waiting for its
 state change.
 

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -1139,9 +1139,9 @@ class BaseMacroServer(MacroServerDevice):
         in XML file.
 
         :param macroNode: (MacroNode) macro node obj populated from XML
-        information
+          information
 
-        See Also: getMacroNodeObj
+        See also: getMacroNodeObj
         """
         macroName = macroNode.name()
         macroInfoObj = self.getMacroInfoObj(macroName)

--- a/src/sardana/taurus/qt/qtcore/tango/sardana/__init__.py
+++ b/src/sardana/taurus/qt/qtcore/tango/sardana/__init__.py
@@ -43,7 +43,8 @@ the :obj:`~sardana.taurus.qt.qtcore.tango.sardana.registerExtensions` function.
 The registration needs to be done before the first access to the given
 :func:`taurus.Device`.
 
-.. note:: If you are using :class:`~taurus.qt.qtgui.application.TaurusApplication`
+.. note:: If you are using
+  :class:`~taurus.qt.qtgui.application.TaurusApplication`
   then the registration is done behind the scene at the moment of
   :class:`~taurus.qt.qtgui.application.TaurusApplication` construction.
 """

--- a/src/sardana/taurus/qt/qtcore/tango/sardana/__init__.py
+++ b/src/sardana/taurus/qt/qtcore/tango/sardana/__init__.py
@@ -42,6 +42,10 @@ the :obj:`~sardana.taurus.qt.qtcore.tango.sardana.registerExtensions` function.
 
 The registration needs to be done before the first access to the given
 :func:`taurus.Device`.
+
+.. note:: If you are using :class:`~taurus.qt.qtgui.application.TaurusApplication`
+  then the registration is done behind the scene at the moment of
+  :class:`~taurus.qt.qtgui.application.TaurusApplication` construction.
 """
 
 __docformat__ = 'restructuredtext'

--- a/src/sardana/taurus/qt/qtcore/tango/sardana/__init__.py
+++ b/src/sardana/taurus/qt/qtcore/tango/sardana/__init__.py
@@ -29,11 +29,12 @@ Objects obtained with :func:`taurus.Device` expose standard interfaces
 e.g., allow to interact with their attributes, check their state, etc.
 This module defines classes for enriched interaction with Sardana devices
 (also for other elements not exported as devices), e.g. synchronous move
-of a sardana motor with :meth:`~sardana.taurus.core.tango.sardana.pool.Motor.move`
+of a sardana motor with
+:meth:`~sardana.taurus.core.tango.sardana.pool.Motor.move`
 method instead of writing motor's position attribute and then waiting for its
-state change. The difference between these classes with respect to the ones from
-the :mod:`sardana.taurus.core.tango.sardana` module is the Qt friendly interface
-e.g. the Sardana events are translated to Qt signals.
+state change. The difference between these classes with respect to the ones
+from the :mod:`sardana.taurus.core.tango.sardana` module is the Qt friendly
+interface e.g. the Sardana events are translated to Qt signals.
 
 To obtain these enriched objects with :func:`taurus.Device` you need to first
 register the extension classes with

--- a/src/sardana/taurus/qt/qtcore/tango/sardana/__init__.py
+++ b/src/sardana/taurus/qt/qtcore/tango/sardana/__init__.py
@@ -23,8 +23,24 @@
 ##
 ##############################################################################
 
-"""
-Sardana extension for taurus Qt
+"""Taurus Qt extensions for Sardana devices.
+
+Objects obtained with :func:`taurus.Device` expose standard interfaces
+e.g., allow to interact with their attributes, check their state, etc.
+This module defines classes for enriched interaction with Sardana devices
+(also for other elements not exported as devices), e.g. synchronous move
+of a sardana motor with :meth:`~sardana.taurus.core.tango.sardana.pool.Motor.move`
+method instead of writing motor's position attribute and then waiting for its
+state change. The difference between these classes with respect to the ones from
+the :mod:`sardana.taurus.core.tango.sardana` module is the Qt friendly interface
+e.g. the Sardana events are translated to Qt signals.
+
+To obtain these enriched objects with :func:`taurus.Device` you need to first
+register the extension classes with
+the :obj:`~sardana.taurus.qt.qtcore.tango.sardana.registerExtensions` function.
+
+The registration needs to be done before the first access to the given
+:func:`taurus.Device`.
 """
 
 __docformat__ = 'restructuredtext'


### PR DESCRIPTION
This PR partially solves one of the tasks from the Documentation Camp board:

> We should document API of the taurus extensions methods like: count, move, etc. so it contains explicitly the timeout argument.

Maybe it does not document the methods itself but give a short introduction to the Taurus extensions modules: `sardana.taurus.core.tango.sardana` and `sardana.taurus.qt.qtcore.tango.sardana`.

It also adds to the API documentation the whole part about the Taurus Qt extensions.

Finally it also fixes broken links from FAQ "How to call procedures?", so it fixes #1228.

@sardana-org/integrators could you please take a look on this and eventually integrate? Thanks!