### PR TITLE
Remove INTERFACES and INTERFACES_EXPANDED from sardanadefs documentation

### DIFF
--- a/doc/source/devel/api/sardana/sardanadefs.rst
+++ b/doc/source/devel/api/sardana/sardanadefs.rst
@@ -47,10 +47,6 @@
 
 .. autodata:: sardana.sardanadefs.InterfacesExpanded
 
-.. autodata:: sardana.sardanadefs.INTERFACES
-
-.. autodata:: sardana.sardanadefs.INTERFACES_EXPANDED
-
 .. rubric:: Functions
 
 .. autofunction:: sardana.sardanadefs.from_dtype_str


### PR DESCRIPTION
This part of the  documentation gives problems when constructing Debian package of sardana documentaion.

These data structures are auto documented with autodata. Since these are very big and complicated strcutures, the documentation is not attractive and readable at all. Remove them from the API documentation and just leave the docstings in the code.

An example of how it looks now:

![image](https://user-images.githubusercontent.com/6735649/68757435-39f5b680-060c-11ea-83f3-8ffb404297c6.png)
