### PR TITLE
Add missing default attribute values on Pool start

### DIFF
--- a/src/sardana/pool/poolmetacontroller.py
+++ b/src/sardana/pool/poolmetacontroller.py
@@ -227,9 +227,9 @@ class DataInfo(object):
         return kwargs
 
     def __repr__(self):
-        return "{0}(name={1}, type={2}, format={3}, access={4})".format(
+        return "{0}(name={1}, type={2}, format={3}, access={4}, default_value={5})".format(
             self.__class__.__name__, self.name, DataType[self.dtype],
-            DataFormat[self.dformat], DataAccess[self.access])
+            DataFormat[self.dformat], DataAccess[self.access], self.default_value)
 
 # class PropertyInfo(DataInfo):
 

--- a/src/sardana/pool/poolmetacontroller.py
+++ b/src/sardana/pool/poolmetacontroller.py
@@ -227,9 +227,15 @@ class DataInfo(object):
         return kwargs
 
     def __repr__(self):
-        return "{0}(name={1}, type={2}, format={3}, access={4}, default_value={5})".format(
-            self.__class__.__name__, self.name, DataType[self.dtype],
-            DataFormat[self.dformat], DataAccess[self.access], self.default_value)
+        return "{0}(name={1}, type={2}, format={3},"\
+            "access={4}, default_value={5})".format(
+                self.__class__.__name__,
+                self.name,
+                DataType[self.dtype],
+                DataFormat[self.dformat],
+                DataAccess[self.access],
+                self.default_value
+            )
 
 # class PropertyInfo(DataInfo):
 

--- a/src/sardana/tango/core/SardanaDevice.py
+++ b/src/sardana/tango/core/SardanaDevice.py
@@ -545,11 +545,10 @@ class SardanaDeviceClass(DeviceClass):
             try:
                 if hasattr(dev, "write_default_values"):
                     dev.write_default_values()
-            except:
+            except Exception:
                 dev.warning("Failed to write missing default value")
                 dev.debug("Details:", exc_info=1)
 
-       
     def device_name_factory(self, dev_name_list):
         """Builds list of device names to use when no Database is being used
 

--- a/src/sardana/tango/macroserver/test/base.py
+++ b/src/sardana/tango/macroserver/test/base.py
@@ -86,6 +86,7 @@ class BaseMacroServerTestCase(object):
             self._msstarter.startDs()
             self.door = PyTango.DeviceProxy(self.door_name)
             for _ in range(5):
+                time.sleep(1)
                 try:
                     state = self.door.read_attribute('state').value
                 except Exception:
@@ -94,7 +95,6 @@ class BaseMacroServerTestCase(object):
                              PyTango.DevState.ON,
                              PyTango.DevState.STANDBY):
                     break
-                time.sleep(1)
         except Exception as e:
             # force tearDown in order to eliminate the MacroServer
             print(e)

--- a/src/sardana/tango/macroserver/test/base.py
+++ b/src/sardana/tango/macroserver/test/base.py
@@ -84,17 +84,20 @@ class BaseMacroServerTestCase(object):
                                            {key: values})
             # start MS server
             self._msstarter.startDs()
-            self.door = PyTango.DeviceProxy(self.door_name)
-            for _ in range(5):
+            for _ in range(10):
                 time.sleep(1)
                 try:
+                    self.door = PyTango.DeviceProxy(self.door_name)
                     state = self.door.read_attribute('state').value
                 except Exception:
+                    self.door = None
                     state = None
                 if state in (PyTango.DevState.RUNNING,
                              PyTango.DevState.ON,
                              PyTango.DevState.STANDBY):
                     break
+            if self.door is None:
+                raise Exception("Could not connect to door")
         except Exception as e:
             # force tearDown in order to eliminate the MacroServer
             print(e)

--- a/src/sardana/tango/macroserver/test/base.py
+++ b/src/sardana/tango/macroserver/test/base.py
@@ -28,6 +28,7 @@
 __all__ = ['BaseMacroServerTestCase']
 
 import os
+import time
 
 import PyTango
 from taurus.core.util import whichexecutable
@@ -84,6 +85,16 @@ class BaseMacroServerTestCase(object):
             # start MS server
             self._msstarter.startDs()
             self.door = PyTango.DeviceProxy(self.door_name)
+            for _ in range(5):
+                try:
+                    state = self.door.read_attribute('state').value
+                except Exception:
+                    state = None
+                if state in (PyTango.DevState.RUNNING,
+                             PyTango.DevState.ON,
+                             PyTango.DevState.STANDBY):
+                    break
+                time.sleep(1)
         except Exception as e:
             # force tearDown in order to eliminate the MacroServer
             print(e)

--- a/src/sardana/tango/pool/Controller.py
+++ b/src/sardana/tango/pool/Controller.py
@@ -234,15 +234,11 @@ class Controller(PoolDevice):
                 "Controller %s doesn't have any information", self.ctrl)
             return PoolDevice.get_dynamic_attributes(self)
         # print stuff
-        print self.ctrl
-        print info
         self._dynamic_attributes_cache = dyn_attrs = CaselessDict()
         self._standard_attributes_cache = std_attrs = CaselessDict()
         for attr_name, attr_data in list(info.ctrl_attributes.items()):
             name, tg_info = to_tango_attr_info(attr_name, attr_data)
             dyn_attrs[attr_name] = attr_name, tg_info, attr_data
-        print std_attrs
-        print dyn_attrs
         return std_attrs, dyn_attrs
 
     def read_DynamicAttribute(self, attr):

--- a/src/sardana/tango/pool/Controller.py
+++ b/src/sardana/tango/pool/Controller.py
@@ -233,11 +233,16 @@ class Controller(PoolDevice):
             self.warning(
                 "Controller %s doesn't have any information", self.ctrl)
             return PoolDevice.get_dynamic_attributes(self)
+        # print stuff
+        print self.ctrl
+        print info
         self._dynamic_attributes_cache = dyn_attrs = CaselessDict()
         self._standard_attributes_cache = std_attrs = CaselessDict()
         for attr_name, attr_data in list(info.ctrl_attributes.items()):
             name, tg_info = to_tango_attr_info(attr_name, attr_data)
             dyn_attrs[attr_name] = attr_name, tg_info, attr_data
+        print std_attrs
+        print dyn_attrs
         return std_attrs, dyn_attrs
 
     def read_DynamicAttribute(self, attr):

--- a/src/sardana/tango/pool/Controller.py
+++ b/src/sardana/tango/pool/Controller.py
@@ -233,7 +233,6 @@ class Controller(PoolDevice):
             self.warning(
                 "Controller %s doesn't have any information", self.ctrl)
             return PoolDevice.get_dynamic_attributes(self)
-        # print stuff
         self._dynamic_attributes_cache = dyn_attrs = CaselessDict()
         self._standard_attributes_cache = std_attrs = CaselessDict()
         for attr_name, attr_data in list(info.ctrl_attributes.items()):

--- a/src/sardana/tango/pool/PoolDevice.py
+++ b/src/sardana/tango/pool/PoolDevice.py
@@ -196,7 +196,7 @@ class PoolDevice(SardanaDevice):
 
     def write_default_values(self):
         dev_name = self.get_name()
-        for attr_name, value in self._missing_default_values.iteritems():
+        for attr_name, value in self._missing_default_values.items():
             self.warning("Write default value, Device: %s Attribute: %s, value: %s", dev_name, attr_name, value)
             attr_proxy = AttributeProxy(dev_name + '/' + attr_name)
             attr_proxy.write(value)
@@ -224,7 +224,6 @@ class PoolDevice(SardanaDevice):
                                                    write, is_allowed)
                 attrs[attr.get_name()] = None
 
-
         if dyn_attrs is not None:
             read = self.__class__._read_DynamicAttribute
             write = self.__class__._write_DynamicAttribute
@@ -236,7 +235,6 @@ class PoolDevice(SardanaDevice):
                                                   attr_info, read,
                                                   write, is_allowed)
                 attrs[attr.get_name()] = None
-                
         return attrs
 
     def remove_unwanted_dynamic_attributes(self, new_std_attrs, new_dyn_attrs):

--- a/src/sardana/tango/pool/PoolDevice.py
+++ b/src/sardana/tango/pool/PoolDevice.py
@@ -182,26 +182,28 @@ class PoolDevice(SardanaDevice):
         """
         return CaselessDict(), CaselessDict()
 
-
     def check_default_value(self, attr_name, attr_info):
         default_value = attr_info.default_value
         db = self.get_database()
         dev_name = self.get_name()
-        attr_props = CaselessDict(db.get_device_attribute_property(dev_name, attr_name))
+        attr_props = CaselessDict(
+            db.get_device_attribute_property(dev_name, attr_name))
         stored_value = attr_props[attr_name.lower()].get("__value", None)
         if stored_value is None and default_value is not None:
-            self.warning("Missing default value, Device: %s Attribute: %s", dev_name, attr_name)
+            self.warning("Missing default value, Device: %s Attribute: %s",
+                         dev_name, attr_name)
             self._missing_default_values[attr_name] = default_value
-
 
     def write_default_values(self):
         dev_name = self.get_name()
         for attr_name, value in self._missing_default_values.items():
-            self.warning("Write default value, Device: %s Attribute: %s, value: %s", dev_name, attr_name, value)
+            self.warning("Write default value, "
+                         "Device: %s Attribute: %s, value: %s",
+                         dev_name,
+                         attr_name,
+                         value)
             attr_proxy = AttributeProxy(dev_name + '/' + attr_name)
             attr_proxy.write(value)
-
-
 
     def initialize_dynamic_attributes(self):
         """Initializes this device dynamic attributes"""

--- a/src/sardana/tango/pool/PoolDevice.py
+++ b/src/sardana/tango/pool/PoolDevice.py
@@ -37,7 +37,7 @@ import time
 from PyTango import Util, DevVoid, DevLong64, DevBoolean, DevString,\
     DevDouble, DevEncoded, DevVarStringArray, DispLevel, DevState, SCALAR, \
     SPECTRUM, IMAGE, READ_WRITE, READ, AttrData, CmdArgType, DevFailed,\
-    seqStr_2_obj, Except, ErrSeverity
+    seqStr_2_obj, Except, ErrSeverity, AttributeProxy
 
 from taurus.core.util.containers import CaselessDict
 from taurus.core.util.codecs import CodecFactory
@@ -75,6 +75,7 @@ class PoolDevice(SardanaDevice):
         util = Util.instance()
         self._pool_device = util.get_device_list_by_class("Pool")[0]
         self._element = None
+        self._missing_default_values = {}
 
     @property
     def pool_device(self):
@@ -181,6 +182,27 @@ class PoolDevice(SardanaDevice):
         """
         return CaselessDict(), CaselessDict()
 
+
+    def check_default_value(self, attr_name, attr_info):
+        default_value = attr_info.default_value
+        db = self.get_database()
+        dev_name = self.get_name()
+        attr_props = CaselessDict(db.get_device_attribute_property(dev_name, attr_name))
+        stored_value = attr_props[attr_name.lower()].get("__value", None)
+        if stored_value is None and default_value is not None:
+            self.warning("Missing default value, Device: %s Attribute: %s", dev_name, attr_name)
+            self._missing_default_values[attr_name] = default_value
+
+
+    def write_default_values(self):
+        dev_name = self.get_name()
+        for attr_name, value in self._missing_default_values.iteritems():
+            self.warning("Write default value, Device: %s Attribute: %s, value: %s", dev_name, attr_name, value)
+            attr_proxy = AttributeProxy(dev_name + '/' + attr_name)
+            attr_proxy.write(value)
+
+
+
     def initialize_dynamic_attributes(self):
         """Initializes this device dynamic attributes"""
         self._attributes = attrs = CaselessDict()
@@ -196,10 +218,12 @@ class PoolDevice(SardanaDevice):
             is_allowed = self.__class__._is_DynamicAttribute_allowed
             for attr_name, data_info in list(std_attrs.items()):
                 attr_name, data_info, attr_info = data_info
+                self.check_default_value(attr_name, attr_info)
                 attr = self.add_standard_attribute(attr_name, data_info,
                                                    attr_info, read,
                                                    write, is_allowed)
                 attrs[attr.get_name()] = None
+
 
         if dyn_attrs is not None:
             read = self.__class__._read_DynamicAttribute
@@ -207,10 +231,12 @@ class PoolDevice(SardanaDevice):
             is_allowed = self.__class__._is_DynamicAttribute_allowed
             for attr_name, data_info in list(dyn_attrs.items()):
                 attr_name, data_info, attr_info = data_info
+                self.check_default_value(attr_name, attr_info)
                 attr = self.add_dynamic_attribute(attr_name, data_info,
                                                   attr_info, read,
                                                   write, is_allowed)
                 attrs[attr.get_name()] = None
+                
         return attrs
 
     def remove_unwanted_dynamic_attributes(self, new_std_attrs, new_dyn_attrs):

--- a/src/sardana/tango/pool/test/base.py
+++ b/src/sardana/tango/pool/test/base.py
@@ -35,7 +35,7 @@ from sardana import sardanacustomsettings
 from sardana.tango.core.util import (get_free_server, get_free_device,
                                      get_free_alias)
 from taurus.core.util import whichexecutable
-
+import time
 
 class BasePoolTestCase(object):
     """Abstract class for pool DS testing.
@@ -69,6 +69,16 @@ class BasePoolTestCase(object):
         self._starter.startDs()
         # register extensions so the test methods can use them
         self.pool = PyTango.DeviceProxy(self.pool_name)
+        for _ in range(5):
+            time.sleep(1)
+            try:
+                state = self.pool.read_attribute('state').value
+            except Exception:
+                state = None
+            if state in (PyTango.DevState.RUNNING,
+                         PyTango.DevState.ON,
+                         PyTango.DevState.STANDBY):
+                break
 
     def tearDown(self):
         """Remove the Pool instance.

--- a/src/sardana/tango/pool/test/base.py
+++ b/src/sardana/tango/pool/test/base.py
@@ -68,17 +68,20 @@ class BasePoolTestCase(object):
         # start Pool server
         self._starter.startDs()
         # register extensions so the test methods can use them
-        self.pool = PyTango.DeviceProxy(self.pool_name)
-        for _ in range(5):
+        for _ in range(10):
             time.sleep(1)
             try:
+                self.pool = PyTango.DeviceProxy(self.pool_name)
                 state = self.pool.read_attribute('state').value
             except Exception:
+                self.pool = None
                 state = None
             if state in (PyTango.DevState.RUNNING,
                          PyTango.DevState.ON,
                          PyTango.DevState.STANDBY):
                 break
+        if self.pool is None:
+            raise Exception("Could not connect to pool")
 
     def tearDown(self):
         """Remove the Pool instance.

--- a/src/sardana/tango/pool/test/test_measurementgroup.py
+++ b/src/sardana/tango/pool/test/test_measurementgroup.py
@@ -145,7 +145,20 @@ class MeasSarTestTestCase(SarTestTestCase):
             config[ctrl_full_name] = ctrl_config
 
         try:
-            self.meas = PyTango.DeviceProxy(self.mg_name)
+            for _ in range(10):
+                time.sleep(1)
+                try:
+                    self.meas = PyTango.DeviceProxy(self.mg_name)
+                    state = self.meas.read_attribute('state').value
+                except Exception:
+                    self.meas = None
+                    state = None
+                if state in (PyTango.DevState.RUNNING,
+                             PyTango.DevState.ON,
+                             PyTango.DevState.STANDBY):
+                    break
+            if self.meas is None:
+                raise Exception("Could not connect to measurement group")
         except:
             raise Exception('Could not create the MeasurementGroup: %s' %
                             (self.mg_name))


### PR DESCRIPTION
If a controller is deployed with for example [json2tango](https://github.com/MaxIV-KitsControls/lib-maxiv-dsconfig) the default values of attributes are not written to the database. Normally this is done by the defctrl or defelem macros. Depending on the implementation of an affected controller this may or may not be a problem, but it can lead to strange and annoying errors. This PR adds a check when the Pool starts to write any missing default value after each device is started.