### PR TITLE
Fix #1237: Macro functions with result don't return any result

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -2235,15 +2235,14 @@ class Macro(Logger):
         """**Unofficial Macro API**."""
         return self._pause_event.isPaused()
 
-    @classmethod
-    def hasResult(cls):
+    def hasResult(self):
         """**Unofficial Macro API**. Returns True if the macro should return
         a result or False otherwise
 
         :return: True if the macro should return a result or False otherwise
         :rtype: bool
         """
-        return len(cls.result_def) > 0
+        return len(self.result_def) > 0
 
     def getResult(self):
         """**Unofficial Macro API**. Returns the macro result object (if any)


### PR DESCRIPTION
Macro functions are just instances of the same MacroFunction class.
For every macro function call, the macroserver creates an instance
of MacroFunction.
The constructor of MacroFunction is already overwriting the values
of param_def and result_def so promoting hasResult() from
classmethod to method, should be sufficient to allow each macro
function to have distinct results.