### PR TITLE
Fix RunMacro execution with string parameters without extra quotes

### DIFF
--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1137,8 +1137,8 @@ class MacroExecutor(Logger):
             macro_params = par_str_list[1:]
 
             def quote_string(string):
-                # if string contains double quotes, use single quotes, otherwise
-                # use double quotes
+                # if string contains double quotes, use single quotes,
+                # otherwise use double quotes
                 if re.search('"', string):
                     return "'{}'".format(string)
                 else:

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1148,9 +1148,9 @@ class MacroExecutor(Logger):
             # quote string parameter values containing whitespaces
             macro_params_quoted = []
             for param in macro_params:
-                if (not re.match(".*\s+.*", param)  # no white spaces
-                        or re.match("^'.*\s+.*'$", param)  # already quoted
-                        or re.match('^".*\s+.*"$', param)):  # already quoted
+                if (not re.match(r".*\s+.*", param)  # no white spaces
+                        or re.match(r"^'.*\s+.*'$", param)  # already quoted
+                        or re.match(r'^".*\s+.*"$', param)):  # already quoted
                     macro_params_quoted.append(param)
                 else:
                     macro_params_quoted.append(quote_string(param))

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -719,28 +719,7 @@ class MacroManager(MacroServerManager):
     def _createMacroNode(self, macro_name, macro_params_raw):
         macro = self.getMacro(macro_name)
         params_def = macro.get_parameter()
-
-        def quote_string(string):
-            # if string contains double quotes, use single quotes, otherwise
-            # use double quotes
-            if re.search('"', string):
-                return "'{}'".format(string)
-            else:
-                return '"{}"'.format(string)
-
-        # param parser relies on whitespace separation of parameter values
-        # quote string parameter values when necessary
-        macro_params_quoted = []
-        for param_def, param_raw in zip(params_def, macro_params_raw):
-            if (not param_def["type"] == "String"  # not string parameter
-                    or not re.match(".*\s+.*", param_raw)  # no white spaces
-                    or re.match("^'.*\s+.*'$", param_raw)  # already quoted
-                    or re.match('^".*\s+.*"$', param_raw)):  # already quoted
-                macro_params_quoted.append(param_raw)
-            else:
-                macro_params_quoted.append(quote_string(param_raw))
-        # merge params to a single, space separated, string (spock like)
-        macro_params_str = " ".join(macro_params_quoted)
+        macro_params_str = " ".join(macro_params_raw)
         param_parser = ParamParser(params_def)
         # parse string with macro params to the correct list representation
         macro_params = param_parser.parse(macro_params_str)
@@ -1156,7 +1135,26 @@ class MacroExecutor(Logger):
             xml_root = xml_seq = etree.Element('sequence')
             macro_name = par_str_list[0]
             macro_params = par_str_list[1:]
-            macro_node = self._createMacroNode(macro_name, macro_params)
+
+            def quote_string(string):
+                # if string contains double quotes, use single quotes, otherwise
+                # use double quotes
+                if re.search('"', string):
+                    return "'{}'".format(string)
+                else:
+                    return '"{}"'.format(string)
+
+            # param parser relies on whitespace separation of parameter values
+            # quote string parameter values containing whitespaces
+            macro_params_quoted = []
+            for param in macro_params:
+                if (not re.match(".*\s+.*", param)  # no white spaces
+                        or re.match("^'.*\s+.*'$", param)  # already quoted
+                        or re.match('^".*\s+.*"$', param)):  # already quoted
+                    macro_params_quoted.append(param)
+                else:
+                    macro_params_quoted.append(quote_string(param))
+            macro_node = self._createMacroNode(macro_name, macro_params_quoted)
             xml_macro = macro_node.toXml()
             xml_seq.append(xml_macro)
         else:


### PR DESCRIPTION
In spock syntax when you use string parameters with white spaces you need
to use quotes. However when you use RunMacro Door's command, you already
pass string parameters as DevVarStringArray separate items. Then it
should not be mandatory to use quotes for string parameters with white spaces.
Fix it by quoting this parameter values when necessary.

One can test it with this kind of macro:

```python
class str_par(Macro):

    param_def = [["value", Type.String, None, "string parameter"]]

    def run(self, value):
        self.print(value)
```

Before, executing RunMacro command with ["str_par", "Hola, que tal?"] was giving error. With this PR it works. 

@sardana-org/integrators could you take a look on it? Many thanks!