### PR TITLE
merge of doorDebug and doorOutput

### DIFF
--- a/src/sardana/taurus/qt/qtgui/macrolistener/macrolistener.py
+++ b/src/sardana/taurus/qt/qtgui/macrolistener/macrolistener.py
@@ -552,14 +552,9 @@ class MacroBroker(DynamicPlotManager):
                           self.__doorOutput.onDoorWarningChanged)
         SDM.connectReader("doorErrorChanged",
                           self.__doorOutput.onDoorErrorChanged)
-        mainwindow.createPanel(self.__doorOutput, 'DoorOutput',
-                               registerconfig=False, permanent=True)
-
-        # puts doorDebug
-        self.__doorDebug = DoorDebug()
         SDM.connectReader("doorDebugChanged",
-                          self.__doorDebug.onDoorDebugChanged)
-        mainwindow.createPanel(self.__doorDebug, 'DoorDebug',
+                          self.__doorOutput.onDoorDebugChanged)
+        mainwindow.createPanel(self.__doorOutput, 'DoorOutput',
                                registerconfig=False, permanent=True)
 
         # puts doorResult


### PR DESCRIPTION
New feature on the context menu of outputDoor, that allows the user to see debug information that was seen on doorDebug. doorDebug is now deprecated.
Fixes #965 