### PR TITLE
Console size py3

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -66,17 +66,6 @@ from itertools import zip_longest
 CHANGE_EVT_TYPES = TaurusEventType.Change, TaurusEventType.Periodic
 
 
-
-
-
-def _get_console_width():
-    try:
-        width = int(os.popen('stty size', 'r').read().split()[1])
-    except Exception:
-        width = float('inf')
-    return width
-
-
 def _get_nb_lines(nb_chrs, max_chrs):
     return int(math.ceil(float(nb_chrs)/max_chrs))
 
@@ -691,7 +680,7 @@ class BaseDoor(MacroServerDevice):
         return data
 
     def logReceived(self, log_name, output):
-        max_chrs = _get_console_width()
+        max_chrs = os.get_terminal_size().columns
         if not output or self._silent or self._ignore_logs:
             return
 


### PR DESCRIPTION
Use `os.get_terminal_size()` to determine console size instead of doing an expensive popen call.

Bonus: it works on windows ;-)

I did not use `shutil.get_terminal_size()` on purpose: it is about 500x slower and doesn't add anything useful 