### PR TITLE
Improve gscan to detect if a file or dir path is set but empty in the…

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -484,6 +484,9 @@ class GScan(Logger):
         macro = self.macro
         try:
             scan_dir = macro.getEnv('ScanDir')
+            if scan_dir == '' or None:
+                macro.warning('ScanDir value is empty')
+                raise Exception('ScanDir value is empty')
         except InterruptException:
             raise
         except Exception:
@@ -498,6 +501,9 @@ class GScan(Logger):
 
         try:
             file_names = macro.getEnv('ScanFile')
+            if file_names == [''] or None:
+                macro.warning('ScanFile value is empty')
+                raise Exception('ScanFile value is empty')
         except InterruptException:
             raise
         except Exception:


### PR DESCRIPTION
Improve gscan to detect if a file or dir path is set but empty in the environment. Sends a warning message indicating the fields are empty and rises an exception telling the field is not set and the results of the gscan will not be saved.
Fixes #1259 