### PR TITLE
Macro saved files

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -806,25 +806,35 @@ class TaurusMacroExecutorWidget(TaurusWidget):
         macroName = str(macroName)
         if macroName == "":
             macroName, macroNode = None, None
-#            macroNode = macro.MacroNode(name="")
+#           macroNode = macro.MacroNode(name="")
             self.playMacroAction.setEnabled(False)
             self.addToFavouritesAction.setEnabled(False)
         else:
-            if self._isHistoryMacro:
-                macroNode = self.historyBuffer()
-                self.setHistoryBuffer(None)
-                self.favouritesMacrosEditor.list.clearSelection()
-            else:
-                macroNode = self.favouritesBuffer()
-                self.setFavouritesBuffer(None)
-                self.historyMacrosViewer.list.clearSelection()
-            self._isHistoryMacro = False
+            try:
+                self.checkDoorState()
 
-            if macroNode is None:
-                macroNode = self.getModelObj().getMacroNodeObj(macroName)
+                if self._isHistoryMacro:
+                    macroNode = self.historyBuffer()
+                    self.setHistoryBuffer(None)
+                    self.favouritesMacrosEditor.list.clearSelection()
+                else:
+                    macroNode = self.favouritesBuffer()
+                    self.setFavouritesBuffer(None)
+                    self.historyMacrosViewer.list.clearSelection()
+                self._isHistoryMacro = False
 
-            self.playMacroAction.setEnabled(True)
-            self.addToFavouritesAction.setEnabled(True)
+                if macroNode is None:
+                    macroNode = self.getModelObj().getMacroNodeObj(macroName)
+
+                self.playMacroAction.setEnabled(True)
+                self.addToFavouritesAction.setEnabled(True)
+
+            except:
+                macroName, macroNode = None, None
+                #           macroNode = macro.MacroNode(name="")
+                self.playMacroAction.setEnabled(False)
+                self.addToFavouritesAction.setEnabled(False)
+                self.warning("Door isn't on")
 
         self.paramEditorModel().setRoot(macroNode)
         self.spockCommand.setModel(self.paramEditorModel())

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -834,7 +834,7 @@ class TaurusMacroExecutorWidget(TaurusWidget):
                 #           macroNode = macro.MacroNode(name="")
                 self.playMacroAction.setEnabled(False)
                 self.addToFavouritesAction.setEnabled(False)
-                self.warning("Door isn't on")
+                self.warning("Door isn't active")
 
         self.paramEditorModel().setRoot(macroNode)
         self.spockCommand.setModel(self.paramEditorModel())


### PR DESCRIPTION
- Solved cascade of warnings while selecting favourite macro or history macro on #18 context.

Other issues have been detected, probably related to this issue:
- History is eliminated if GUI is initialized without Sardana.
- Perspective only saves favourites, not sequences.
- Loading perspective while disconected from Sardana doesn't produce warning and only loads        favourites.
- Favourites stack up loading perspective instead of eliminating the previous and loading the new ones.
- Running Sardana after initializing GUI freezes GUI and it must be terminated by SO.
- Can't reproduce issue #18 when loading the door on "Macro execution configuration..." due to previous new issue.

Taurus version used for this issues --> 4.6.1

- Also python 3.5.3 on Sardana causes periodic warning about the door not being connected when GUI starts and Sardana doesn't. This issue doesn't happen on python 3.6
- Taurus 4.5.4-alpha pip install GUI is not working on my environment (python 3.5.3).