### PR TITLE
Call controller's DeleteDevice when Tango calls delete_device

### DIFF
--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -576,6 +576,8 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
         self.remove_element(elem)
 
         self.fire_event(EventType("ElementDeleted"), elem)
+        if hasattr(elem, "get_controller"):
+            elem.set_deleted(True)
 
     def create_instrument(self, full_name, klass_name, id=None):
         is_root = full_name.count('/') == 1

--- a/src/sardana/pool/poolelement.py
+++ b/src/sardana/pool/poolelement.py
@@ -46,6 +46,7 @@ class PoolElement(PoolBaseElement):
         self._ctrl = weakref.ref(ctrl)
         self._axis = kwargs.pop('axis')
         self._ctrl_id = ctrl.get_id()
+        self._deleted = False
         try:
             instrument = kwargs.pop('instrument')
             self.set_instrument(instrument)
@@ -73,6 +74,12 @@ class PoolElement(PoolBaseElement):
 
     def get_axis(self):
         return self._axis
+
+    def is_deleted(self):
+        return self._deleted
+
+    def set_deleted(self, deleted):
+        self._deleted = deleted
 
     def set_action_cache(self, action_cache):
         self._action_cache = action_cache
@@ -143,3 +150,5 @@ class PoolElement(PoolBaseElement):
     controller_id = property(get_controller_id, doc="element controller id")
     instrument = property(get_instrument, set_instrument,
                           doc="element instrument")
+    deleted = property(is_deleted, set_deleted,
+                       doc="element is deleted from pool (experimental API)")

--- a/src/sardana/tango/pool/PoolDevice.py
+++ b/src/sardana/tango/pool/PoolDevice.py
@@ -593,6 +593,21 @@ class PoolElementDevice(PoolDevice):
         except ValueError:
             pass
 
+    def delete_device(self):
+        element = self.element
+        if not element.deleted:
+            pool_ctrl = self.ctrl
+            ctrl = pool_ctrl.ctrl
+            if ctrl is not None:
+                axis = element.axis
+                try:
+                    ctrl.DeleteDevice(axis)
+                except Exception:
+                    name = element.name
+                    self.error("Unable to delete %s(%s)", name, axis,
+                               exc_info=1)
+        PoolDevice.delete_device(self)
+
     def read_Instrument(self, attr):
         """Read the value of the ``Instrument`` tango attribute.
         Returns the instrument full name or empty string if this element doesn't


### PR DESCRIPTION
AddDevice is called on init_device. Call DeleteDevice on delete_device.
This is done for all elements proceeding from a controller e.g. motor, counter/timer, pseudomotor, pseudocounter, etc.

We have discovered this when working with @tiagocoutinho on [sardana-ni660x](https://github.com/ALBA-Synchrotron/sardana-ni660x/blob/master/sardana_ni660x/ctrl/Ni660XCTCtrl.py) at BL04 at ALBA. There we have realized that the DeleteDevice is not called on the server shutdown. It is only called when one call DeleteElement command on the pool. @sardana-org/integrators you are welcome to review this. @tiagocoutinho could you also test it at the beamline, please. Many thanks!