### PR TITLE
Protect against exceptions in MeasurementGroup.count_continuous

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -2149,8 +2149,10 @@ class MeasurementGroup(PoolElement):
         cfg.prepare()
         self.setSynchronization(synchronization)
         self.subscribeValueBuffer(value_buffer_cb)
-        self.count_raw(start_time)
-        self.unsubscribeValueBuffer(value_buffer_cb)
+        try:
+            self.count_raw(start_time)
+        finally:
+            self.unsubscribeValueBuffer(value_buffer_cb)
         state = self.getStateEG().readValue()
         if state == Fault:
             msg = "Measurement group ended acquisition with Fault state"


### PR DESCRIPTION
The count_continuous method is not protected against possible
exceptions in the count_raw call (e.g. TimeOuts). Due to this the
subscription of all value buffers are kept.
This cause that the online recorder still reports the output even
the door is in alarm.