### PR TITLE
Make sure pyplot examples correctly refresh plot on the client

### DIFF
--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -983,9 +983,9 @@ example::
         self.pyplot.title(r'Verify $J_0(x)=\frac{1}{\pi}\int_0^{\pi}\cos(x \sin\phi)\,d\phi$')
         self.pyplot.xlabel('$x$')
         self.pyplot.legend()
-	self.pyplot.draw()
+        self.pyplot.draw()
 
-The last call to `pyplot.draw()` is important to ensure the client updates
+The last call to ``pyplot.draw()`` is important to ensure the client updates
 the figure properly.
 
 Running this macro from spock will result in something like:
@@ -1053,8 +1053,8 @@ points!
 
 Clients like spock receive the requests to plot in a separate thread.
 Matplotlib has a long history of issues concerning plot updates using different
-threads. To mitigate these effects please be sure to call `self.pyplot.draw()`
-on your macro every time you needto be sure the matplotlib figure is up to date.
+threads. To mitigate these effects please be sure to call ``self.pyplot.draw()``
+on your macro every time you need to be sure the matplotlib figure is up to date.
 
 .. _sardana-macro-input:
 

--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -983,6 +983,10 @@ example::
         self.pyplot.title(r'Verify $J_0(x)=\frac{1}{\pi}\int_0^{\pi}\cos(x \sin\phi)\,d\phi$')
         self.pyplot.xlabel('$x$')
         self.pyplot.legend()
+	self.pyplot.draw()
+
+The last call to `pyplot.draw()` is important to ensure the client updates
+the figure properly.
 
 Running this macro from spock will result in something like:
 
@@ -1014,6 +1018,7 @@ Just for fun, the following macro computes a fractal and plots it as an image::
             mask = (fractal == 255) & (abs(z) > 10)
             fractal[mask] = 254 * n / finteractions
         self.pyplot.imshow(fractal)
+        self.pyplot.draw()
 
 And the resulting image (interactions=20, density=512):
 
@@ -1045,6 +1050,11 @@ This means that the following code which works in a normal IPython_ console will
 Also consider that each time you plot the complete data to be plotted is sent
 from the server to the client... so please avoid plotting arrays of 10,000,000
 points!
+
+Clients like spock receive the requests to plot in a separate thread.
+Matplotlib has a long history of issues concerning plot updates using different
+threads. To mitigate these effects please be sure to call `self.pyplot.draw()`
+on your macro every time you needto be sure the matplotlib figure is up to date.
 
 .. _sardana-macro-input:
 

--- a/src/sardana/macroserver/macros/examples/plotting.py
+++ b/src/sardana/macroserver/macros/examples/plotting.py
@@ -26,6 +26,7 @@ def J0_plot(self):
         r'Verify $J_0(x)=\frac{1}{\pi}\int_0^{\pi}\cos(x \sin\phi)\,d\phi$')
     self.pyplot.xlabel('$x$')
     self.pyplot.legend()
+    self.pyplot.draw()
 
 
 from numpy import random
@@ -36,6 +37,7 @@ def random_image(self):
     """Shows a random image 32x32"""
     img = random.random((32, 32))
     self.pyplot.matshow(img)
+    self.pyplot.draw()
 
 import numpy
 
@@ -61,3 +63,4 @@ def mandelbrot(self, interactions, density):
         mask = (fractal == 255) & (abs(z) > 10)
         fractal[mask] = 254 * n / interactions
     self.pyplot.imshow(fractal)
+    self.pyplot.draw()

--- a/src/sardana/macroserver/macros/examples/scans.py
+++ b/src/sardana/macroserver/macros/examples/scans.py
@@ -656,6 +656,7 @@ class ascan_with_addcustomdata(ascan_demo):
         # as a bonus, plot the fit
         self.pyplot.plot(x, y, 'ro')
         self.pyplot.plot(x, fitted_y, 'b-')
+        self.pyplot.draw()
 
 
 class ascanct_midtrigger(Macro):


### PR DESCRIPTION
Newer versions of ipython / matplotlib seem to miss plot call refresh when calls to plot are executed in different threads.

This PR tries to make the pyplot macro examples work correctly and gives advice in the documentation