### PR TITLE
Pmtv relies on encoder

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -1090,7 +1090,8 @@ class PoolMotorTVReadWidget(TaurusWidget):
 
             # Align everything on top
             self.layout().addItem(Qt.QSpacerItem(
-                1, 1, Qt.QSizePolicy.Minimum, Qt.QSizePolicy.Expanding), 2, 0, 1, 2)
+                1, 1, Qt.QSizePolicy.Minimum,
+                Qt.QSizePolicy.Expanding), 2, 0, 1, 2)
 
             self.lbl_enc.setVisible(False)
             self.lbl_enc_read.setVisible(False)

--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -1363,7 +1363,9 @@ class PoolMotorTVWriteWidget(TaurusWidget):
             return
         TaurusWidget.setModel(self, model + '/Position')
         self.le_write_absolute.setModel(model + '/Position#wvalue.magnitude')
-
+        if self.taurusValueBuddy().motor_dev is not None and \
+                self.taurusValueBuddy().hasEncoder():
+            self.lbl_enc_read.setModel(model + '/Encoder')
         # Handle User/Expert View
         self.setExpertView(self.taurusValueBuddy()._expertView)
         self.taurusValueBuddy().expertViewChanged.connect(

--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -1022,14 +1022,8 @@ class PoolMotorTVReadWidget(TaurusWidget):
         # self.cb_expertRead.addItems(['Enc'])
         #self.layout().addWidget(self.cb_expertRead, 1, 0)
 
-        self.lbl_enc = Qt.QLabel('Encoder')
-        self.layout().addWidget(self.lbl_enc, 1, 0)
-
-        self.lbl_enc_read = TaurusLabel()
-        self.lbl_enc_read.setBgRole('none')
-        self.lbl_enc_read.setSizePolicy(Qt.QSizePolicy(
-            Qt.QSizePolicy.Expanding, Qt.QSizePolicy.Fixed))
-        self.layout().addWidget(self.lbl_enc_read, 1, 1)
+        self.lbl_enc = None
+        self.lbl_enc_read = None
 
         # Align everything on top
         self.layout().addItem(Qt.QSpacerItem(
@@ -1040,8 +1034,6 @@ class PoolMotorTVReadWidget(TaurusWidget):
         # SO WE ASSUME 'expertview is FALSE' AND WE HAVE TO AVOID self.setExpertView :-(
         # WOULD BE NICE THAT THE taurusValueBuddy COULD EMIT THE PROPER
         # SIGNAL...
-        self.lbl_enc.setVisible(False)
-        self.lbl_enc_read.setVisible(False)
 
     def eventFilter(self, obj, event):
         if event.type() == Qt.QEvent.MouseButtonDblClick:
@@ -1064,17 +1056,17 @@ class PoolMotorTVReadWidget(TaurusWidget):
             motor_dev.abort()
 
     def setExpertView(self, expertView):
-        self.lbl_enc.setVisible(False)
-        self.lbl_enc_read.setVisible(False)
         if self.taurusValueBuddy().motor_dev is not None:
             hw_limits = self.taurusValueBuddy().hasHwLimits()
             self.btn_lim_neg.setEnabled(hw_limits)
             self.btn_lim_pos.setEnabled(hw_limits)
-
-        if expertView and self.taurusValueBuddy().motor_dev is not None:
-            encoder = self.taurusValueBuddy().hasEncoder()
-            self.lbl_enc.setVisible(encoder)
-            self.lbl_enc_read.setVisible(encoder)
+        if self.lbl_enc_read and self.lbl_enc is not None:
+            self.lbl_enc.setVisible(False)
+            self.lbl_enc_read.setVisible(False)
+            if expertView and self.taurusValueBuddy().motor_dev is not None:
+                encoder = self.taurusValueBuddy().hasEncoder()
+                self.lbl_enc.setVisible(encoder)
+                self.lbl_enc_read.setVisible(encoder)
 
     def prepare_button(self, btn):
         btn_policy = Qt.QSizePolicy(Qt.QSizePolicy.Fixed, Qt.QSizePolicy.Fixed)
@@ -1085,8 +1077,27 @@ class PoolMotorTVReadWidget(TaurusWidget):
         btn.setMaximumSize(25, 25)
         btn.setText('')
 
+    def create_encoder(self):
+        if self.taurusValueBuddy().hasEncoder() and self.lbl_enc_read is None:
+            self.lbl_enc = Qt.QLabel('Encoder')
+            self.layout().addWidget(self.lbl_enc, 1, 0)
+
+            self.lbl_enc_read = TaurusLabel()
+            self.lbl_enc_read.setBgRole('none')
+            self.lbl_enc_read.setSizePolicy(Qt.QSizePolicy(
+                Qt.QSizePolicy.Expanding, Qt.QSizePolicy.Fixed))
+            self.layout().addWidget(self.lbl_enc_read, 1, 1)
+
+            # Align everything on top
+            self.layout().addItem(Qt.QSpacerItem(
+                1, 1, Qt.QSizePolicy.Minimum, Qt.QSizePolicy.Expanding), 2, 0, 1, 2)
+
+            self.lbl_enc.setVisible(False)
+            self.lbl_enc_read.setVisible(False)
+
     def setModel(self, model):
         if hasattr(self, 'taurusValueBuddy'):
+            self.create_encoder()
             try:
                 self.taurusValueBuddy().expertViewChanged.disconnect(
                     self.setExpertView)
@@ -1095,12 +1106,12 @@ class PoolMotorTVReadWidget(TaurusWidget):
         if model in (None, ''):
             TaurusWidget.setModel(self, model)
             self.lbl_read.setModel(model)
-            self.lbl_enc_read.setModel(model)
+            if self.lbl_enc_read is not None:
+                self.lbl_enc_read.setModel(model)
             return
         TaurusWidget.setModel(self, model + '/Position')
         self.lbl_read.setModel(model + '/Position')
-        if self.taurusValueBuddy().motor_dev is not None and \
-                self.taurusValueBuddy().hasEncoder():
+        if self.lbl_enc_read and self.taurusValueBuddy().motor_dev is not None:
             self.lbl_enc_read.setModel(model + '/Encoder')
         # Handle User/Expert view
         self.setExpertView(self.taurusValueBuddy()._expertView)

--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -1099,7 +1099,9 @@ class PoolMotorTVReadWidget(TaurusWidget):
             return
         TaurusWidget.setModel(self, model + '/Position')
         self.lbl_read.setModel(model + '/Position')
-        self.lbl_enc_read.setModel(model + '/Encoder')
+        if self.taurusValueBuddy().motor_dev is not None and \
+                self.taurusValueBuddy().hasEncoder():
+            self.lbl_enc_read.setModel(model + '/Encoder')
         # Handle User/Expert view
         self.setExpertView(self.taurusValueBuddy()._expertView)
         self.taurusValueBuddy().expertViewChanged.connect(
@@ -1363,9 +1365,7 @@ class PoolMotorTVWriteWidget(TaurusWidget):
             return
         TaurusWidget.setModel(self, model + '/Position')
         self.le_write_absolute.setModel(model + '/Position#wvalue.magnitude')
-        if self.taurusValueBuddy().motor_dev is not None and \
-                self.taurusValueBuddy().hasEncoder():
-            self.lbl_enc_read.setModel(model + '/Encoder')
+
         # Handle User/Expert View
         self.setExpertView(self.taurusValueBuddy()._expertView)
         self.taurusValueBuddy().expertViewChanged.connect(

--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -1060,7 +1060,7 @@ class PoolMotorTVReadWidget(TaurusWidget):
             hw_limits = self.taurusValueBuddy().hasHwLimits()
             self.btn_lim_neg.setEnabled(hw_limits)
             self.btn_lim_pos.setEnabled(hw_limits)
-        if self.lbl_enc_read and self.lbl_enc is not None:
+        if self.lbl_enc_read is not None:
             self.lbl_enc.setVisible(False)
             self.lbl_enc_read.setVisible(False)
             if expertView and self.taurusValueBuddy().motor_dev is not None:
@@ -1077,7 +1077,7 @@ class PoolMotorTVReadWidget(TaurusWidget):
         btn.setMaximumSize(25, 25)
         btn.setText('')
 
-    def create_encoder(self):
+    def _create_encoder(self):
         if self.taurusValueBuddy().hasEncoder() and self.lbl_enc_read is None:
             self.lbl_enc = Qt.QLabel('Encoder')
             self.layout().addWidget(self.lbl_enc, 1, 0)
@@ -1097,13 +1097,10 @@ class PoolMotorTVReadWidget(TaurusWidget):
             self.lbl_enc_read.setVisible(False)
 
     def setModel(self, model):
-        if hasattr(self, 'taurusValueBuddy'):
-            self.create_encoder()
-            try:
-                self.taurusValueBuddy().expertViewChanged.disconnect(
-                    self.setExpertView)
-            except TypeError:
-                pass
+        if self.taurusValueBuddy().hasEncoder() and self.lbl_enc_read is None:
+            self._create_encoder()
+            self.taurusValueBuddy().expertViewChanged.disconnect(
+                self.setExpertView)
         if model in (None, ''):
             TaurusWidget.setModel(self, model)
             self.lbl_read.setModel(model)
@@ -1112,7 +1109,8 @@ class PoolMotorTVReadWidget(TaurusWidget):
             return
         TaurusWidget.setModel(self, model + '/Position')
         self.lbl_read.setModel(model + '/Position')
-        if self.lbl_enc_read and self.taurusValueBuddy().motor_dev is not None:
+        if (self.lbl_enc_read is not None
+                and self.taurusValueBuddy().motor_dev is not None):
             self.lbl_enc_read.setModel(model + '/Encoder')
         # Handle User/Expert view
         self.setExpertView(self.taurusValueBuddy()._expertView)


### PR DESCRIPTION
PMTV was setting an encoder model on readWidget setModel. Added code that checks if the motor has an encoder before creating the model.
Fixes #209 