### PR TITLE
New style and text information for limit icons

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -1068,12 +1068,12 @@ class PoolMotorTVReadWidget(TaurusWidget):
         btn.setMaximumSize(25, 25)
         btn.setText('')
 
-    def prepare_limit(self, btn):
-        btn_policy = Qt.QSizePolicy(Qt.QSizePolicy.Fixed, Qt.QSizePolicy.Fixed)
-        btn_policy.setHorizontalStretch(0)
-        btn_policy.setVerticalStretch(0)
-        btn.setSizePolicy(btn_policy)
-        btn.setText('')
+    def prepare_limit(self, lbl):
+        lbl_policy = Qt.QSizePolicy(Qt.QSizePolicy.Fixed, Qt.QSizePolicy.Fixed)
+        lbl_policy.setHorizontalStretch(0)
+        lbl_policy.setVerticalStretch(0)
+        lbl.setSizePolicy(lbl_policy)
+        lbl.setText('')
 
     def config_limit(self, limit, polarity, state):
         """

--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -984,10 +984,12 @@ class PoolMotorTVReadWidget(TaurusWidget):
         limits_layout.setSpacing(0)
 
         self.lim_neg = Qt.QLabel()
+        self.prepare_limit(self.lim_neg)
         limits_layout.addWidget(self.lim_neg)
         self.config_limit(self.lim_neg, "negative", "Disabled")
 
         self.lim_pos = Qt.QLabel()
+        self.prepare_limit(self.lim_pos)
         limits_layout.addWidget(self.lim_pos)
         self.config_limit(self.lim_pos, "positive", "Disabled")
 
@@ -1081,8 +1083,6 @@ class PoolMotorTVReadWidget(TaurusWidget):
         :param polarity: {negative, positive}
         :param state: {Disabled, Enabled, SwActive, HwActive}
         """
-        self.prepare_limit(limit)
-
         if polarity == "negative":
             tooltip = 'Negative Limit'
             icon = Qt.QIcon("designer:minus.png")

--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -1050,21 +1050,14 @@ class PoolMotorTVReadWidget(TaurusWidget):
             motor_dev.abort()
 
     def setExpertView(self, expertView):
-        if self.taurusValueBuddy().motor_dev is not None:
-            if self.taurusValueBuddy().hasHwLimits():
-                self.config_limit(self.lim_neg, "negative", "Enabled")
-                self.config_limit(self.lim_pos, "positive", "Enabled")
-            else:
-                self.config_limit(self.lim_neg, "negative", "Disabled")
-                self.config_limit(self.lim_pos, "positive", "Disabled")
-
-        if self.lbl_enc_read is not None:
-            self.lbl_enc.setVisible(False)
-            self.lbl_enc_read.setVisible(False)
-            if expertView and self.taurusValueBuddy().motor_dev is not None:
-                encoder = self.taurusValueBuddy().hasEncoder()
-                self.lbl_enc.setVisible(encoder)
-                self.lbl_enc_read.setVisible(encoder)
+        if self.lbl_enc_read is None:
+            return
+        self.lbl_enc.setVisible(False)
+        self.lbl_enc_read.setVisible(False)
+        if expertView and self.taurusValueBuddy().motor_dev is not None:
+            encoder = self.taurusValueBuddy().hasEncoder()
+            self.lbl_enc.setVisible(encoder)
+            self.lbl_enc_read.setVisible(encoder)
 
     def prepare_button(self, btn):
         btn_policy = Qt.QSizePolicy(Qt.QSizePolicy.Fixed, Qt.QSizePolicy.Fixed)


### PR DESCRIPTION
Icons now are labels instead of buttons. They have a more intuitive icon and reflect correctly all the limit states. Indicating with the text information if the active limit is software or hardware.
Here's an example on how all the states look:
![new_sardana_limits](https://user-images.githubusercontent.com/37841875/74669892-5c1d4880-51a8-11ea-8501-ca707ce78424.png)
The states are in this order:

> Disabled, Enabled, Software Active, Hardware Active.

To see if the which type of active is, put the cursor on the icon to display text information.

This changes also Fixes #210 

Limits on PMTV:
![sardana_limits_PMTV](https://user-images.githubusercontent.com/37841875/74724514-a4864600-523c-11ea-81b5-f395133b97e6.png)
