### PR TITLE
Protect worker threads with tango.EnsureOmnitThread

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -52,6 +52,7 @@ from taurus.core.util.enumeration import Enumeration
 from taurus.core.util.threadpool import ThreadPool
 from taurus.core.util.event import CallableRef
 
+from sardana.sardanathreadpool import OmniWorker
 from sardana.util.tree import BranchNode, LeafNode, Tree
 from sardana.util.motion import Motor as VMotor
 from sardana.util.motion import MotionPath
@@ -1962,7 +1963,7 @@ class CAcquisition(object):
 
     def __init__(self):
         self._thread_pool = ThreadPool(name="ValueBufferTH", Psize=1,
-                                       Qsize=100000)
+                                       Qsize=100000, worker_cls=OmniWorker)
         self._countdown_latch = CountLatch()
         self._index_offset = 0
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1962,8 +1962,17 @@ class CSScan(CScan):
 class CAcquisition(object):
 
     def __init__(self):
-        self._thread_pool = ThreadPool(name="ValueBufferTH", Psize=1,
-                                       Qsize=100000, worker_cls=OmniWorker)
+        # protect older versions of Taurus (without the worker_cls argument)
+        # remove it whenever we bump Taurus dependency
+        try:
+            self._thread_pool = ThreadPool(name="ValueBufferTH",
+                                           Psize=1,
+                                           Qsize=100000,
+                                           worker_cls=OmniWorker)
+        except TypeError:
+            self._thread_pool = ThreadPool(name="ValueBufferTH",
+                                           Psize=1,
+                                           Qsize=100000)
         self._countdown_latch = CountLatch()
         self._index_offset = 0
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1970,6 +1970,10 @@ class CAcquisition(object):
                                            Qsize=100000,
                                            worker_cls=OmniWorker)
         except TypeError:
+            import taurus
+            taurus.warning("Your Sardana system is affected by bug"
+                           "tango-controls/pytango#307. Please use "
+                           "Taurus with taurus-org/taurus#1081.")
             self._thread_pool = ThreadPool(name="ValueBufferTH",
                                            Psize=1,
                                            Qsize=100000)

--- a/src/sardana/sardanathreadpool.py
+++ b/src/sardana/sardanathreadpool.py
@@ -70,8 +70,8 @@ def get_thread_pool():
     global __thread_pool_lock
     with __thread_pool_lock:
         if __thread_pool is None:
-            # protect older versions of Taurus (without the worker_cls argument)
-            # remove it whenever we bump Taurus dependency
+            # protect older versions of Taurus (without the worker_cls
+            # argument) remove it whenever we bump Taurus dependency
             try:
                 __thread_pool = ThreadPool(name="SardanaTP", Psize=10,
                                            worker_cls=OmniWorker)

--- a/src/sardana/sardanathreadpool.py
+++ b/src/sardana/sardanathreadpool.py
@@ -57,6 +57,10 @@ class OmniWorker(Worker):
                 with tango.EnsureOmniThread():
                     Worker.run(self)
             else:
+                import taurus
+                taurus.warning("Your Sardana system is affected by bug "
+                               "tango-controls/pytango#307. Please use "
+                               "PyTango with tango-controls/pytango#327.")
                 Worker.run(self)
 
 
@@ -76,5 +80,10 @@ def get_thread_pool():
                 __thread_pool = ThreadPool(name="SardanaTP", Psize=10,
                                            worker_cls=OmniWorker)
             except TypeError:
+                import taurus
+                taurus.warning("Your Sardana system is affected by bug "
+                               "tango-controls/pytango#307. Please use "
+                               "Taurus with taurus-org/taurus#1081.")
                 __thread_pool = ThreadPool(name="SardanaTP", Psize=10)
+
         return __thread_pool

--- a/src/sardana/sardanathreadpool.py
+++ b/src/sardana/sardanathreadpool.py
@@ -34,10 +34,19 @@ __docformat__ = 'restructuredtext'
 
 import threading
 
-from taurus.core.util.threadpool import ThreadPool
+from taurus.core.util.threadpool import ThreadPool, Worker
+
 
 __thread_pool_lock = threading.Lock()
 __thread_pool = None
+
+
+class OmniWorker(Worker):
+
+    def run(self):
+        import tango
+        with tango.EnsureOmniThread():
+            Worker.run(self)
 
 
 def get_thread_pool():
@@ -50,5 +59,6 @@ def get_thread_pool():
     global __thread_pool_lock
     with __thread_pool_lock:
         if __thread_pool is None:
-            __thread_pool = ThreadPool(name="SardanaTP", Psize=10)
+            __thread_pool = ThreadPool(name="SardanaTP", Psize=10,
+                                       worker_cls=OmniWorker)
         return __thread_pool

--- a/src/sardana/sardanathreadpool.py
+++ b/src/sardana/sardanathreadpool.py
@@ -44,8 +44,14 @@ __thread_pool = None
 class OmniWorker(Worker):
 
     def run(self):
+        # There is no release of PyTango yet to bump the requirement
+        # so protect the older versions of PyTango.
         import tango
-        with tango.EnsureOmniThread():
+        try:
+            EnsureOmniThread = getattr(tango, "EnsureOmniThread")
+            with EnsureOmniThread():
+                Worker.run(self)
+        except AttributeError:
             Worker.run(self)
 
 

--- a/src/sardana/sardanathreadpool.py
+++ b/src/sardana/sardanathreadpool.py
@@ -70,6 +70,11 @@ def get_thread_pool():
     global __thread_pool_lock
     with __thread_pool_lock:
         if __thread_pool is None:
-            __thread_pool = ThreadPool(name="SardanaTP", Psize=10,
-                                       worker_cls=OmniWorker)
+            # protect older versions of Taurus (without the worker_cls argument)
+            # remove it whenever we bump Taurus dependency
+            try:
+                __thread_pool = ThreadPool(name="SardanaTP", Psize=10,
+                                           worker_cls=OmniWorker)
+            except TypeError:
+                __thread_pool = ThreadPool(name="SardanaTP", Psize=10)
         return __thread_pool

--- a/src/sardana/sardanathreadpool.py
+++ b/src/sardana/sardanathreadpool.py
@@ -53,10 +53,10 @@ class OmniWorker(Worker):
         # event subscriptions in PyTango#307. Use EnsureOmniThread introduced
         # in PyTango#327 whenever available.
         else:
-             if hasattr(tango, "EnsureOmniThread"):
-                 with tango.EnsureOmniThread():
-                     Worker.run(self)
-             else:
+            if hasattr(tango, "EnsureOmniThread"):
+                with tango.EnsureOmniThread():
+                    Worker.run(self)
+            else:
                 Worker.run(self)
 
 


### PR DESCRIPTION
Tango is not thread safe when using threading.Thread. One must use
omni threads instead. This was confirmed for parallel event subscriptions
in https://github.com/tango-controls/pytango/issues/307.

Customize taurus ThreadPool worker threads (https://github.com/taurus-org/taurus/pull/1081) to use
EnsureOmniThread (https://github.com/tango-controls/pytango/pull/327). Do it for:
* `sardanathreadpool.get_thread_pool` (global thread pool used in actions
  and dummy TG)
* `CAcquisition._thread_pool` (used to execute value_buffer callbacks -
  these employ recorders which could potentially subscribe to
  Tango events)

For the moment don't protect:
* `ThreadPool` used by `FuncGeneratorTestCase.thread_pool` (tests - so it is controlled usage)
* `threading.Thread` used by `PoolMonitor` (not really used)
* `threading.Thread` used by server execution task (not really used - so it is controlled usage)
* `threading.Thread` used by `PositionGenerator` (tests - so it is controlled usage)
* `threading.Thread` used by `DummyEventSource` (tests - so it is controlled usage)

It's very probable that this PR fixes #1291.
