### PR TITLE
Fix clear operation (motion & acq) and reset of acq ctrls dicts

### DIFF
--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -45,7 +45,8 @@ from taurus.core.util.enumeration import Enumeration
 from sardana import SardanaValue, State, ElementType, TYPE_TIMERABLE_ELEMENTS
 from sardana.sardanathreadpool import get_thread_pool
 from sardana.pool import AcqSynch, AcqMode
-from sardana.pool.poolaction import ActionContext, PoolAction
+from sardana.pool.poolaction import ActionContext, PoolAction, \
+    OperationContext
 from sardana.pool.poolsynchronization import PoolSynchronization
 
 #: enumeration representing possible motion states
@@ -264,6 +265,14 @@ class AcqController(AcqConfigurationItem):
             return list(self._channels_enabled)
         else:
             return list(self._channels_disabled)
+
+
+class AcquisitionBaseContext(OperationContext):
+
+    def exit(self):
+        pool_action = self._pool_action
+        pool_action._reset_ctrl_dicts()
+        return OperationContext.exit(self)
 
 
 class PoolAcquisition(PoolAction):
@@ -650,6 +659,8 @@ class PoolAcquisitionBase(PoolAction):
         deemed necessary by the core developers.
     """
 
+    OperationContextClass = AcquisitionBaseContext
+
     def __init__(self, main_element, name):
         PoolAction.__init__(self, main_element, name)
         self._channels = []
@@ -808,117 +819,114 @@ class PoolAcquisitionBase(PoolAction):
         self._set_pool_ctrl_dict_loop(ctrls)
         # split controllers to read value and value reference
         self._split_ctrl(ctrls)
-        try:
-            # channels that are acquired (only enabled)
-            self._channels = []
+        # channels that are acquired (only enabled)
+        self._channels = []
 
-            def load(channel, value, repetitions, latency=0):
-                axis = channel.axis
-                pool_ctrl = channel.controller
-                ctrl = pool_ctrl.ctrl
-                ctrl.PreLoadAll()
+        def load(channel, value, repetitions, latency=0):
+            axis = channel.axis
+            pool_ctrl = channel.controller
+            ctrl = pool_ctrl.ctrl
+            ctrl.PreLoadAll()
+            try:
+                res = ctrl.PreLoadOne(axis, value, repetitions,
+                                      latency)
+            except TypeError:
                 try:
-                    res = ctrl.PreLoadOne(axis, value, repetitions,
-                                          latency)
+                    res = ctrl.PreLoadOne(axis, value, repetitions)
+                    msg = ("PreLoadOne(axis, value, repetitions) is "
+                           "deprecated since version 2.7.0."
+                           "Use PreLoadOne(axis, value, repetitions, "
+                           "latency_time) instead.")
+                    self.warning(msg)
                 except TypeError:
-                    try:
-                        res = ctrl.PreLoadOne(axis, value, repetitions)
-                        msg = ("PreLoadOne(axis, value, repetitions) is "
-                               "deprecated since version 2.7.0."
-                               "Use PreLoadOne(axis, value, repetitions, "
-                               "latency_time) instead.")
-                        self.warning(msg)
-                    except TypeError:
-                        res = ctrl.PreLoadOne(axis, value)
-                        msg = ("PreLoadOne(axis, value) is deprecated since "
-                               "version 2.3.0. Use PreLoadOne(axis, value, "
-                               "repetitions, latency_time) instead.")
-                        self.warning(msg)
-                if not res:
-                    msg = ("%s.PreLoadOne(%d) returned False" %
-                           (pool_ctrl.name, axis))
-                    raise Exception(msg)
+                    res = ctrl.PreLoadOne(axis, value)
+                    msg = ("PreLoadOne(axis, value) is deprecated since "
+                           "version 2.3.0. Use PreLoadOne(axis, value, "
+                           "repetitions, latency_time) instead.")
+                    self.warning(msg)
+            if not res:
+                msg = ("%s.PreLoadOne(%d) returned False" %
+                       (pool_ctrl.name, axis))
+                raise Exception(msg)
+            try:
+                ctrl.LoadOne(axis, value, repetitions, latency)
+            except TypeError:
                 try:
-                    ctrl.LoadOne(axis, value, repetitions, latency)
+                    ctrl.LoadOne(axis, value, repetitions)
+                    msg = ("LoadOne(axis, value, repetitions) is"
+                           "deprecated since version Jan18."
+                           "Use LoadOne(axis, value, repetitions, "
+                           "latency_time) instead.")
+                    self.warning(msg)
                 except TypeError:
-                    try:
-                        ctrl.LoadOne(axis, value, repetitions)
-                        msg = ("LoadOne(axis, value, repetitions) is"
-                               "deprecated since version Jan18."
-                               "Use LoadOne(axis, value, repetitions, "
-                               "latency_time) instead.")
-                        self.warning(msg)
-                    except TypeError:
-                        ctrl.LoadOne(axis, value)
-                        msg = ("LoadOne(axis, value) is deprecated since "
-                               "version 2.3.0. Use LoadOne(axis, value, "
-                               "repetitions) instead.")
-                        self.warning(msg)
-                ctrl.LoadAll()
+                    ctrl.LoadOne(axis, value)
+                    msg = ("LoadOne(axis, value) is deprecated since "
+                           "version 2.3.0. Use LoadOne(axis, value, "
+                           "repetitions) instead.")
+                    self.warning(msg)
+            ctrl.LoadAll()
 
-            with ActionContext(self):
-                # PreLoadAll, PreLoadOne, LoadOne and LoadAll
-                for ctrl in ctrls:
-                    # TODO find solution for master now sardana only use timer
-                    load(ctrl.timer, value, repetitions, latency)
+        with ActionContext(self):
+            # PreLoadAll, PreLoadOne, LoadOne and LoadAll
+            for ctrl in ctrls:
+                # TODO find solution for master now sardana only use timer
+                load(ctrl.timer, value, repetitions, latency)
 
-                # TODO: remove when the action allows to use tango attributes
-                try:
-                    ctrls.pop('__tango__')
-                except Exception:
-                    pass
+            # TODO: remove when the action allows to use tango attributes
+            try:
+                ctrls.pop('__tango__')
+            except Exception:
+                pass
 
-                # PreStartAll on all enabled controllers
-                for ctrl in ctrls:
+            # PreStartAll on all enabled controllers
+            for ctrl in ctrls:
+                pool_ctrl = ctrl.element
+                pool_ctrl.ctrl.PreStartAll()
+
+            # PreStartOne & StartOne on all enabled elements
+            for ctrl in ctrls:
+                channels = ctrl.get_channels(enabled=True)
+
+                # make sure that the master timer/monitor is started as
+                # the last one
+                channels.remove(ctrl.master)
+                channels.append(ctrl.master)
+                for channel in channels:
+                    axis = channel.axis
                     pool_ctrl = ctrl.element
-                    pool_ctrl.ctrl.PreStartAll()
-
-                # PreStartOne & StartOne on all enabled elements
-                for ctrl in ctrls:
-                    channels = ctrl.get_channels(enabled=True)
-
-                    # make sure that the master timer/monitor is started as
-                    # the last one
-                    channels.remove(ctrl.master)
-                    channels.append(ctrl.master)
-                    for channel in channels:
-                        axis = channel.axis
-                        pool_ctrl = ctrl.element
-                        ret = pool_ctrl.ctrl.PreStartOne(axis, value)
-                        if not ret:
-                            msg = ("%s.PreStartOne(%d) returns False" %
-                                   (ctrl.name, axis))
-                            raise Exception(msg)
-                        try:
-                            pool_ctrl = ctrl.element
-                            pool_ctrl.ctrl.StartOne(axis, value)
-                        except Exception as e:
-                            self.debug(e, exc_info=True)
-                            channel.set_state(State.Fault, propagate=2)
-                            msg = ("%s.StartOne(%d) failed" %
-                                   (ctrl.name, axis))
-                            raise Exception(msg)
-
-                        self._channels.append(channel)
-
-                # set the state of all elements to  and inform their listeners
-                for channel in self._channels:
-                    channel.set_state(State.Moving, propagate=2)
-
-                # StartAll on all enabled controllers
-                for ctrl in ctrls:
+                    ret = pool_ctrl.ctrl.PreStartOne(axis, value)
+                    if not ret:
+                        msg = ("%s.PreStartOne(%d) returns False" %
+                               (ctrl.name, axis))
+                        raise Exception(msg)
                     try:
                         pool_ctrl = ctrl.element
-                        pool_ctrl.ctrl.StartAll()
+                        pool_ctrl.ctrl.StartOne(axis, value)
                     except Exception as e:
-                        channels = ctrl.get_channels(enabled=True)
                         self.debug(e, exc_info=True)
-                        for channel in channels:
-                            channel.set_state(State.Fault, propagate=2)
-                        msg = ("%s.StartAll() failed" % ctrl.name)
+                        channel.set_state(State.Fault, propagate=2)
+                        msg = ("%s.StartOne(%d) failed" %
+                               (ctrl.name, axis))
                         raise Exception(msg)
-        finally:
-            self._reset_ctrl_dicts()
+
+                    self._channels.append(channel)
+
+            # set the state of all elements to  and inform their listeners
+            for channel in self._channels:
+                channel.set_state(State.Moving, propagate=2)
+
+            # StartAll on all enabled controllers
+            for ctrl in ctrls:
+                try:
+                    pool_ctrl = ctrl.element
+                    pool_ctrl.ctrl.StartAll()
+                except Exception as e:
+                    channels = ctrl.get_channels(enabled=True)
+                    self.debug(e, exc_info=True)
+                    for channel in channels:
+                        channel.set_state(State.Fault, propagate=2)
+                    msg = ("%s.StartAll() failed" % ctrl.name)
+                    raise Exception(msg)
 
     def _set_pool_ctrl_dict_loop(self, ctrls):
         ctrl_channels = {}
@@ -1001,76 +1009,73 @@ class PoolAcquisitionHardware(PoolAcquisitionBase):
 
     @DebugIt()
     def action_loop(self):
-        try:
-            i = 0
+        i = 0
 
-            states, values, value_refs = {}, {}, {}
-            for channel in self._channels:
-                element = channel.element
-                states[element] = None
+        states, values, value_refs = {}, {}, {}
+        for channel in self._channels:
+            element = channel.element
+            states[element] = None
 
-            nap = self._acq_sleep_time
-            nb_states_per_value = self._nb_states_per_value
+        nap = self._acq_sleep_time
+        nb_states_per_value = self._nb_states_per_value
 
-            while True:
-                self.read_state_info(ret=states)
-                if not self.in_acquisition(states):
-                    break
+        while True:
+            self.read_state_info(ret=states)
+            if not self.in_acquisition(states):
+                break
 
-                # read value every n times
-                if not i % nb_states_per_value:
-                    self.read_value(ret=values)
-                    for acquirable, value in list(values.items()):
-                        if is_value_error(value):
-                            self.error("Loop read value error for %s" %
-                                       acquirable.name)
-                            msg = "Details: " + "".join(
-                                traceback.format_exception(*value.exc_info))
-                            self.debug(msg)
-                            acquirable.put_value(value)
-                        else:
-                            acquirable.extend_value_buffer(value)
-
-                time.sleep(nap)
-                i += 1
-
-            with ActionContext(self):
-                self.raw_read_state_info(ret=states)
-                self.raw_read_value(ret=values)
-                self.raw_read_value_ref(ret=value_refs)
-
-            for acquirable, state_info in list(states.items()):
-                # first update the element state so that value calculation
-                # that is done after takes the updated state into account
-                acquirable.set_state_info(state_info, propagate=0)
-                if acquirable in values:
-                    value = values[acquirable]
+            # read value every n times
+            if not i % nb_states_per_value:
+                self.read_value(ret=values)
+                for acquirable, value in list(values.items()):
                     if is_value_error(value):
-                        self.error("Loop final read value error for: %s" %
+                        self.error("Loop read value error for %s" %
                                    acquirable.name)
                         msg = "Details: " + "".join(
                             traceback.format_exception(*value.exc_info))
                         self.debug(msg)
                         acquirable.put_value(value)
                     else:
-                        acquirable.extend_value_buffer(value, propagate=2)
-                if acquirable in value_refs:
-                    value_ref = value_refs[acquirable]
-                    if is_value_error(value_ref):
-                        self.error("Loop final read value ref error for: %s" %
-                                   acquirable.name)
-                        msg = "Details: " + "".join(
-                            traceback.format_exception(*value_ref.exc_info))
-                        self.debug(msg)
-                    acquirable.extend_value_ref_buffer(value_ref, propagate=2)
-                state_info = acquirable._from_ctrl_state_info(state_info)
-                set_state_info = functools.partial(acquirable.set_state_info,
-                                                   state_info,
-                                                   propagate=2,
-                                                   safe=True)
-                self.add_finish_hook(set_state_info, False)
-        finally:
-            self._reset_ctrl_dicts()
+                        acquirable.extend_value_buffer(value)
+
+            time.sleep(nap)
+            i += 1
+
+        with ActionContext(self):
+            self.raw_read_state_info(ret=states)
+            self.raw_read_value(ret=values)
+            self.raw_read_value_ref(ret=value_refs)
+
+        for acquirable, state_info in list(states.items()):
+            # first update the element state so that value calculation
+            # that is done after takes the updated state into account
+            acquirable.set_state_info(state_info, propagate=0)
+            if acquirable in values:
+                value = values[acquirable]
+                if is_value_error(value):
+                    self.error("Loop final read value error for: %s" %
+                               acquirable.name)
+                    msg = "Details: " + "".join(
+                        traceback.format_exception(*value.exc_info))
+                    self.debug(msg)
+                    acquirable.put_value(value)
+                else:
+                    acquirable.extend_value_buffer(value, propagate=2)
+            if acquirable in value_refs:
+                value_ref = value_refs[acquirable]
+                if is_value_error(value_ref):
+                    self.error("Loop final read value ref error for: %s" %
+                               acquirable.name)
+                    msg = "Details: " + "".join(
+                        traceback.format_exception(*value_ref.exc_info))
+                    self.debug(msg)
+                acquirable.extend_value_ref_buffer(value_ref, propagate=2)
+            state_info = acquirable._from_ctrl_state_info(state_info)
+            set_state_info = functools.partial(acquirable.set_state_info,
+                                               state_info,
+                                               propagate=2,
+                                               safe=True)
+            self.add_finish_hook(set_state_info, False)
 
 
 class PoolAcquisitionSoftware(PoolAcquisitionBase):
@@ -1117,73 +1122,70 @@ class PoolAcquisitionSoftware(PoolAcquisitionBase):
 
     @DebugIt()
     def action_loop(self):
-        try:
-            states, values, value_refs = {}, {}, {}
-            for channel in self._channels:
-                element = channel.element
-                states[element] = None
+        states, values, value_refs = {}, {}, {}
+        for channel in self._channels:
+            element = channel.element
+            states[element] = None
 
-            nap = self._acq_sleep_time
-            nb_states_per_value = self._nb_states_per_value
+        nap = self._acq_sleep_time
+        nb_states_per_value = self._nb_states_per_value
 
-            i = 0
-            while True:
-                self.read_state_info(ret=states)
-                if not self.in_acquisition(states):
-                    break
+        i = 0
+        while True:
+            self.read_state_info(ret=states)
+            if not self.in_acquisition(states):
+                break
 
-                # read value every n times
-                if not i % nb_states_per_value:
-                    self.read_value_loop(ret=values)
-                    for acquirable, value in list(values.items()):
-                        acquirable.put_value(value)
+            # read value every n times
+            if not i % nb_states_per_value:
+                self.read_value_loop(ret=values)
+                for acquirable, value in list(values.items()):
+                    acquirable.put_value(value)
 
-                time.sleep(nap)
-                i += 1
+            time.sleep(nap)
+            i += 1
 
-            for slave in self._slaves:
-                try:
-                    slave.stop_action()
-                except Exception:
-                    self.warning("Unable to stop slave acquisition %s",
-                                 slave.getLogName())
-                    self.debug("Details", exc_info=1)
+        for slave in self._slaves:
+            try:
+                slave.stop_action()
+            except Exception:
+                self.warning("Unable to stop slave acquisition %s",
+                             slave.getLogName())
+                self.debug("Details", exc_info=1)
 
-            with ActionContext(self):
-                self.raw_read_state_info(ret=states)
-                self.raw_read_value(ret=values)
-                self.raw_read_value_ref(ret=value_refs)
+        with ActionContext(self):
+            self.raw_read_state_info(ret=states)
+            self.raw_read_value(ret=values)
+            self.raw_read_value_ref(ret=value_refs)
 
-            for acquirable, state_info in list(states.items()):
-                # first update the element state so that value calculation
-                # that is done after takes the updated state into account
-                acquirable.set_state_info(state_info, propagate=0)
-                if acquirable in values:
-                    value = values[acquirable]
-                    if is_value_error(value):
-                        self.error("Loop final read value error for: %s" %
-                                   acquirable.name)
-                        msg = "Details: " + "".join(
-                            traceback.format_exception(*value.exc_info))
-                        self.debug(msg)
-                    acquirable.append_value_buffer(value, self._index)
-                if acquirable in value_refs:
-                    value_ref = value_refs[acquirable]
-                    if is_value_error(value_ref):
-                        self.error("Loop final read value ref error for: %s" %
-                                   acquirable.name)
-                        msg = "Details: " + "".join(
-                            traceback.format_exception(*value_ref.exc_info))
-                        self.debug(msg)
-                    acquirable.append_value_ref_buffer(value_ref, self._index)
-                state_info = acquirable._from_ctrl_state_info(state_info)
-                set_state_info = functools.partial(acquirable.set_state_info,
-                                                   state_info,
-                                                   propagate=2,
-                                                   safe=True)
-                self.add_finish_hook(set_state_info, False)
-        finally:
-            self._reset_ctrl_dicts()
+        for acquirable, state_info in list(states.items()):
+            # first update the element state so that value calculation
+            # that is done after takes the updated state into account
+            acquirable.set_state_info(state_info, propagate=0)
+            if acquirable in values:
+                value = values[acquirable]
+                if is_value_error(value):
+                    self.error("Loop final read value error for: %s" %
+                               acquirable.name)
+                    msg = "Details: " + "".join(
+                        traceback.format_exception(*value.exc_info))
+                    self.debug(msg)
+                acquirable.append_value_buffer(value, self._index)
+            if acquirable in value_refs:
+                value_ref = value_refs[acquirable]
+                if is_value_error(value_ref):
+                    self.error("Loop final read value ref error for: %s" %
+                               acquirable.name)
+                    msg = "Details: " + "".join(
+                        traceback.format_exception(*value_ref.exc_info))
+                    self.debug(msg)
+                acquirable.append_value_ref_buffer(value_ref, self._index)
+            state_info = acquirable._from_ctrl_state_info(state_info)
+            set_state_info = functools.partial(acquirable.set_state_info,
+                                               state_info,
+                                               propagate=2,
+                                               safe=True)
+            self.add_finish_hook(set_state_info, False)
 
 
 class PoolAcquisitionSoftwareStart(PoolAcquisitionBase):
@@ -1217,88 +1219,85 @@ class PoolAcquisitionSoftwareStart(PoolAcquisitionBase):
 
     @DebugIt()
     def action_loop(self):
-        try:
-            i = 0
+        i = 0
 
-            states, values, value_refs = {}, {}, {}
-            for channel in self._channels:
-                element = channel.element
-                states[element] = None
+        states, values, value_refs = {}, {}, {}
+        for channel in self._channels:
+            element = channel.element
+            states[element] = None
 
-            nap = self._acq_sleep_time
-            nb_states_per_value = self._nb_states_per_value
+        nap = self._acq_sleep_time
+        nb_states_per_value = self._nb_states_per_value
 
-            while True:
-                self.read_state_info(ret=states)
-                if not self.in_acquisition(states):
-                    break
+        while True:
+            self.read_state_info(ret=states)
+            if not self.in_acquisition(states):
+                break
 
-                # read value every n times
-                if not i % nb_states_per_value:
-                    self.read_value(ret=values)
-                    for acquirable, value in list(values.items()):
-                        if is_value_error(value):
-                            self.error("Loop read value error for %s" %
-                                       acquirable.name)
-                            msg = "Details: " + "".join(
-                                traceback.format_exception(*value.exc_info))
-                            self.debug(msg)
-                            acquirable.put_value(value)
-                        else:
-                            acquirable.extend_value_buffer(value)
-                    self.read_value_ref(ret=value_refs)
-                    for acquirable, value_ref in list(value_refs.items()):
-                        if is_value_error(value_ref):
-                            self.error("Loop read value ref error for %s" %
-                                       acquirable.name)
-                            msg = "Details: " + "".join(
-                                traceback.format_exception(*value.exc_info))
-                            self.debug(msg)
-                            acquirable.put_value_ref(value)
-                        else:
-                            acquirable.extend_value_ref_buffer(value_ref)
-                time.sleep(nap)
-                i += 1
-
-            with ActionContext(self):
-                self.raw_read_state_info(ret=states)
-                self.raw_read_value(ret=values)
-                self.raw_read_value_ref(ret=value_refs)
-
-            for acquirable, state_info in list(states.items()):
-                # first update the element state so that value calculation
-                # that is done after takes the updated state into account
-                acquirable.set_state_info(state_info, propagate=0)
-                if acquirable in values:
-                    value = values[acquirable]
+            # read value every n times
+            if not i % nb_states_per_value:
+                self.read_value(ret=values)
+                for acquirable, value in list(values.items()):
                     if is_value_error(value):
-                        self.error("Loop final read value error for: %s" %
+                        self.error("Loop read value error for %s" %
                                    acquirable.name)
                         msg = "Details: " + "".join(
                             traceback.format_exception(*value.exc_info))
                         self.debug(msg)
                         acquirable.put_value(value)
                     else:
-                        acquirable.extend_value_buffer(value, propagate=2)
-                if acquirable in value_refs:
-                    value_ref = value_refs[acquirable]
+                        acquirable.extend_value_buffer(value)
+                self.read_value_ref(ret=value_refs)
+                for acquirable, value_ref in list(value_refs.items()):
                     if is_value_error(value_ref):
-                        self.error("Loop final read value ref error for: %s" %
+                        self.error("Loop read value ref error for %s" %
                                    acquirable.name)
                         msg = "Details: " + "".join(
-                            traceback.format_exception(*value_ref.exc_info))
+                            traceback.format_exception(*value.exc_info))
                         self.debug(msg)
-                        acquirable.put_value_ref(value_ref)
+                        acquirable.put_value_ref(value)
                     else:
-                        acquirable.extend_value_ref_buffer(value_ref, propagate=2)
-                state_info = acquirable._from_ctrl_state_info(state_info)
-                set_state_info = functools.partial(acquirable.set_state_info,
-                                                   state_info,
-                                                   propagate=2,
-                                                   safe=True)
-                self.add_finish_hook(set_state_info, False)
-        finally:
-            self._reset_ctrl_dicts()
+                        acquirable.extend_value_ref_buffer(value_ref)
+            time.sleep(nap)
+            i += 1
+
+        with ActionContext(self):
+            self.raw_read_state_info(ret=states)
+            self.raw_read_value(ret=values)
+            self.raw_read_value_ref(ret=value_refs)
+
+        for acquirable, state_info in list(states.items()):
+            # first update the element state so that value calculation
+            # that is done after takes the updated state into account
+            acquirable.set_state_info(state_info, propagate=0)
+            if acquirable in values:
+                value = values[acquirable]
+                if is_value_error(value):
+                    self.error("Loop final read value error for: %s" %
+                               acquirable.name)
+                    msg = "Details: " + "".join(
+                        traceback.format_exception(*value.exc_info))
+                    self.debug(msg)
+                    acquirable.put_value(value)
+                else:
+                    acquirable.extend_value_buffer(value, propagate=2)
+            if acquirable in value_refs:
+                value_ref = value_refs[acquirable]
+                if is_value_error(value_ref):
+                    self.error("Loop final read value ref error for: %s" %
+                               acquirable.name)
+                    msg = "Details: " + "".join(
+                        traceback.format_exception(*value_ref.exc_info))
+                    self.debug(msg)
+                    acquirable.put_value_ref(value_ref)
+                else:
+                    acquirable.extend_value_ref_buffer(value_ref, propagate=2)
+            state_info = acquirable._from_ctrl_state_info(state_info)
+            set_state_info = functools.partial(acquirable.set_state_info,
+                                               state_info,
+                                               propagate=2,
+                                               safe=True)
+            self.add_finish_hook(set_state_info, False)
 
 
 class PoolCTAcquisition(PoolAcquisitionBase):
@@ -1333,64 +1332,62 @@ class PoolCTAcquisition(PoolAcquisitionBase):
 
     @DebugIt()
     def action_loop(self):
-        try:
-            i = 0
+        i = 0
 
-            states, values = {}, {}
-            for element in self._channels:
-                states[element] = None
-                # values[element] = None
+        states, values = {}, {}
+        for element in self._channels:
+            states[element] = None
+            # values[element] = None
 
-            nap = self._acq_sleep_time
-            nb_states_per_value = self._nb_states_per_value
+        nap = self._acq_sleep_time
+        nb_states_per_value = self._nb_states_per_value
 
-            # read values to send a first event when starting to acquire
-            with ActionContext(self):
-                self.raw_read_value_loop(ret=values)
+        # read values to send a first event when starting to acquire
+        with ActionContext(self):
+            self.raw_read_value_loop(ret=values)
+            for acquirable, value in list(values.items()):
+                acquirable.put_value(value, propagate=2)
+
+        while True:
+            self.read_state_info(ret=states)
+            if not self.in_acquisition(states):
+                break
+
+            # read value every n times
+            if not i % nb_states_per_value:
+                self.read_value_loop(ret=values)
                 for acquirable, value in list(values.items()):
-                    acquirable.put_value(value, propagate=2)
+                    acquirable.put_value(value)
 
-            while True:
-                self.read_state_info(ret=states)
-                if not self.in_acquisition(states):
-                    break
+            time.sleep(nap)
+            i += 1
 
-                # read value every n times
-                if not i % nb_states_per_value:
-                    self.read_value_loop(ret=values)
-                    for acquirable, value in list(values.items()):
-                        acquirable.put_value(value)
+        for slave in self._slaves:
+            try:
+                slave.stop_action()
+            except Exception:
+                self.warning("Unable to stop slave acquisition %s",
+                             slave.getLogName())
+                self.debug("Details", exc_info=1)
 
-                time.sleep(nap)
-                i += 1
+        with ActionContext(self):
+            self.raw_read_state_info(ret=states)
+            self.raw_read_value_loop(ret=values)
 
-            for slave in self._slaves:
-                try:
-                    slave.stop_action()
-                except Exception:
-                    self.warning("Unable to stop slave acquisition %s",
-                                 slave.getLogName())
-                    self.debug("Details", exc_info=1)
+        for acquirable, state_info in list(states.items()):
+            # first update the element state so that value calculation
+            # that is done after takes the updated state into account
+            acquirable.set_state_info(state_info, propagate=0)
+            if acquirable in values:
+                value = values[acquirable]
+                acquirable.put_value(value, propagate=2)
+            state_info = acquirable._from_ctrl_state_info(state_info)
+            set_state_info = functools.partial(acquirable.set_state_info,
+                                               state_info,
+                                               propagate=2,
+                                               safe=True)
+            self.add_finish_hook(set_state_info, False)
 
-            with ActionContext(self):
-                self.raw_read_state_info(ret=states)
-                self.raw_read_value_loop(ret=values)
-
-            for acquirable, state_info in list(states.items()):
-                # first update the element state so that value calculation
-                # that is done after takes the updated state into account
-                acquirable.set_state_info(state_info, propagate=0)
-                if acquirable in values:
-                    value = values[acquirable]
-                    acquirable.put_value(value, propagate=2)
-                state_info = acquirable._from_ctrl_state_info(state_info)
-                set_state_info = functools.partial(acquirable.set_state_info,
-                                                   state_info,
-                                                   propagate=2,
-                                                   safe=True)
-                self.add_finish_hook(set_state_info, False)
-        finally:
-            self._reset_ctrl_dicts()
 
 class Pool0DAcquisition(PoolAction):
 

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -1063,10 +1063,12 @@ class PoolAcquisitionHardware(PoolAcquisitionBase):
                             traceback.format_exception(*value_ref.exc_info))
                         self.debug(msg)
                     acquirable.extend_value_ref_buffer(value_ref, propagate=2)
-                with acquirable:
-                    acquirable.clear_operation()
-                    state_info = acquirable._from_ctrl_state_info(state_info)
-                    acquirable.set_state_info(state_info, propagate=2)
+                state_info = acquirable._from_ctrl_state_info(state_info)
+                set_state_info = functools.partial(acquirable.set_state_info,
+                                                   state_info,
+                                                   propagate=2,
+                                                   safe=True)
+                self.add_finish_hook(set_state_info, False)
         finally:
             self._reset_ctrl_dicts()
 
@@ -1174,10 +1176,12 @@ class PoolAcquisitionSoftware(PoolAcquisitionBase):
                             traceback.format_exception(*value_ref.exc_info))
                         self.debug(msg)
                     acquirable.append_value_ref_buffer(value_ref, self._index)
-                with acquirable:
-                    acquirable.clear_operation()
-                    state_info = acquirable._from_ctrl_state_info(state_info)
-                    acquirable.set_state_info(state_info, propagate=2)
+                state_info = acquirable._from_ctrl_state_info(state_info)
+                set_state_info = functools.partial(acquirable.set_state_info,
+                                                   state_info,
+                                                   propagate=2,
+                                                   safe=True)
+                self.add_finish_hook(set_state_info, False)
         finally:
             self._reset_ctrl_dicts()
 
@@ -1287,10 +1291,12 @@ class PoolAcquisitionSoftwareStart(PoolAcquisitionBase):
                         acquirable.put_value_ref(value_ref)
                     else:
                         acquirable.extend_value_ref_buffer(value_ref, propagate=2)
-                with acquirable:
-                    acquirable.clear_operation()
-                    state_info = acquirable._from_ctrl_state_info(state_info)
-                    acquirable.set_state_info(state_info, propagate=2)
+                state_info = acquirable._from_ctrl_state_info(state_info)
+                set_state_info = functools.partial(acquirable.set_state_info,
+                                                   state_info,
+                                                   propagate=2,
+                                                   safe=True)
+                self.add_finish_hook(set_state_info, False)
         finally:
             self._reset_ctrl_dicts()
 
@@ -1377,10 +1383,12 @@ class PoolCTAcquisition(PoolAcquisitionBase):
                 if acquirable in values:
                     value = values[acquirable]
                     acquirable.put_value(value, propagate=2)
-                with acquirable:
-                    acquirable.clear_operation()
-                    state_info = acquirable._from_ctrl_state_info(state_info)
-                    acquirable.set_state_info(state_info, propagate=2)
+                state_info = acquirable._from_ctrl_state_info(state_info)
+                set_state_info = functools.partial(acquirable.set_state_info,
+                                                   state_info,
+                                                   propagate=2,
+                                                   safe=True)
+                self.add_finish_hook(set_state_info, False)
         finally:
             self._reset_ctrl_dicts()
 

--- a/src/sardana/pool/poolaction.py
+++ b/src/sardana/pool/poolaction.py
@@ -195,6 +195,8 @@ class PoolAction(Logger):
     """A generic class to handle any type of operation (like motion or
     acquisition)"""
 
+    OperationContextClass = OperationContext
+
     def __init__(self, main_element, name="GlobalAction"):
         Logger.__init__(self, name)
         self._action_run_lock = threading.Lock()
@@ -336,7 +338,7 @@ class PoolAction(Logger):
 
         if synch:
             try:
-                with OperationContext(self) as context:
+                with self.OperationContextClass(self) as context:
                     self.start_action(*args, **kwargs)
                     self._started = False
                     self.action_loop()
@@ -344,7 +346,7 @@ class PoolAction(Logger):
                 self._started = False
                 self._running = False
         else:
-            context = OperationContext(self)
+            context = self.OperationContextClass(self)
             context.enter()
             try:
                 self.start_action(*args, **kwargs)

--- a/src/sardana/pool/poolbaseelement.py
+++ b/src/sardana/pool/poolbaseelement.py
@@ -262,8 +262,12 @@ class PoolBaseElement(PoolObject):
                                              ctrl_status=status)
         return status_info[0], new_status
 
-    def set_state_info(self, state_info, propagate=1):
-        self._set_state_info(state_info, propagate=propagate)
+    def set_state_info(self, state_info, propagate=1, safe=False):
+        if safe:
+            with self:
+                self._set_state_info(state_info, propagate=propagate)
+        else:
+            self._set_state_info(state_info, propagate=propagate)
 
     def _set_state_info(self, state_info, propagate=1):
         state_info = self.calculate_state_info(state_info)

--- a/src/sardana/pool/poolmotion.py
+++ b/src/sardana/pool/poolmotion.py
@@ -31,6 +31,7 @@ __all__ = ["MotionState", "MotionMap", "PoolMotion", "PoolMotionItem"]
 __docformat__ = 'restructuredtext'
 
 import time
+import functools
 
 from taurus.core.util.log import DebugIt
 from taurus.core.util.enumeration import Enumeration
@@ -390,9 +391,11 @@ class PoolMotion(PoolAction):
                     # ... but before protect the motor so that the monitor
                     # doesn't come in between the two instructions below and
                     # send a state event on it's own
-                    with moveable:
-                        moveable.clear_operation()
-                    moveable.set_state_info(real_state_info, propagate=2)
+                    set_state_info = functools.partial(moveable.set_state_info,
+                                                       state_info,
+                                                       propagate=2,
+                                                       safe=True)
+                    self.add_finish_hook(set_state_info, False)
 
                 # Then update the state
                 if not stopped_now:


### PR DESCRIPTION
This PR fixes two problems which affects very fast operations.

**Problem affecting acquisitions**

Since 6a80fdc ctrls were reset as _finish_hook_ to allow free readout of Value and ValueRef attributes after acquisition has finished (after SEP17 this won't be needed cause Sardana will always keep in memory the last acquisition results).
This is buggy in the case of very fast acquisitions - the elements were already released from the acquisition context and new acquisition could overlap with the finish_hook.

Avoid this problem by resetting the controllers in the custom `AcquisitionBaseContext`.

**Problem affecting motions and acquisitions**

`OperationConext` is wrongly cleared twice - within the `action_loop` and when the `OperationContext` exits. In the case of fast motions and acquisitions this may cause that when leaving the previous operation context we clear the operation context of the next one. Call `set_state_info` as _finish_hook_ so it will be called when the operation context is cleared already.
In the case of motion also protect it with lock (for unknown reasons it was not protected).

@tiagocoutinho it would be great if you could review and test it at the BL04. Many thanks!