### PR TITLE
Avoid using AttributeProxy when checking limits

### DIFF
--- a/src/sardana/pool/poolpseudomotor.py
+++ b/src/sardana/pool/poolpseudomotor.py
@@ -45,7 +45,6 @@ from sardana.pool.poolbasegroup import PoolBaseGroup
 from sardana.pool.poolmotion import PoolMotion
 from sardana.pool.poolexception import PoolException
 
-from PyTango import AttributeProxy
 
 class Position(SardanaAttribute):
 
@@ -552,31 +551,23 @@ class PoolPseudoMotor(PoolBaseGroup, PoolElement):
 
         if items is None:
             items = {}
-        for new_position, element in zip(physical_positions.value, user_elements):
+        for new_position, element in zip(physical_positions.value,
+                                         user_elements):
             if new_position is None:
                 raise PoolException("Cannot calculate motion: %s reports "
                                     "position to be None" % element.name)
-            # TODO: get the configuration for an specific sardana class and
-            # get rid of AttributeProxy - see sardana-org/sardana#663
-            config = AttributeProxy(element.name + '/position').get_config()
+            # TODO: use Sardana attribute configuration and
+            #  get rid of accessing tango - see sardana-org/sardana#663
+            from sardana.tango.core.util import _check_attr_range
             try:
-                high = float(config.max_value)
-            except ValueError:
-                high = None
-            try:
-                low = float(config.min_value)
-            except ValueError:
-                low = None
-            if high is not None:
-                if float(new_position) > high:
-                    msg = "requested movement of %s is above its upper limit"\
-                        % element.name
-                    raise RuntimeError(msg)
-            if low is not None:
-                if float(new_position) < low:
-                    msg = "requested movement of %s is below its lower limit"\
-                        % element.name
-                    raise RuntimeError(msg)
+                _check_attr_range(element.name, "position", new_position)
+            except ValueError as e:
+                # TODO: don't concatenate exception message whenever
+                #  tango-controls/pytango#340 is fixed
+                msg = "requested move of {} is outside of limits ({})".format(
+                    element.name, str(e)
+                )
+                raise ValueError(msg) from e
 
             element.calculate_motion(new_position, items=items,
                                      calculated=calculated)

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -286,6 +286,33 @@ def __get_last_write_value(attribute):
     return lrv
 
 
+def _check_attr_range(dev_name, attr_name, attr_value):
+    util = PyTango.Util.instance()
+    dev = util.get_device_by_name(dev_name)
+    multi_attr = dev.get_device_attr()
+    attr = multi_attr.get_w_attr_by_name(attr_name)
+    try:
+        min_value = attr.get_min_value()
+    # not specified min value raises DevFailed
+    except PyTango.DevFailed:
+        pass
+    else:
+        if attr_value < min_value:
+            msg = "w_value {} of {}/{} is lower than min_value {}".format(
+                  attr_value, dev_name, attr_name, min_value)
+            raise ValueError(msg)
+    try:
+        max_value = attr.get_max_value()
+    # not specified max value raises DevFailed
+    except PyTango.DevFailed:
+        pass
+    else:
+        if attr_value > max_value:
+            msg = "w_value {} of {}/{} is greater than max_value {}".format(
+                  attr_value, dev_name, attr_name, max_value)
+            raise ValueError(msg)
+
+
 def memorize_write_attribute(write_attr_func):
     """The main purpose is to use this as a decorator for write_<attr_name>
        device methods.


### PR DESCRIPTION
As it was already identified in https://github.com/sardana-org/sardana/pull/663#issuecomment-357734482 `AttributeProxy` creation could be avoided and device `WAttribute` object could be used directly. Do it for pseudo motors and motor groups to avoid problems due to https://github.com/tango-controls/pytango/issues/315.

@tiagocoutinho it would be great if you could review it - it affects BL04 at ALBA. Thanks a lot!