### PR TITLE
Adapt to new taurus behavior of cmd_line_parser

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/common.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/common.py
@@ -357,8 +357,10 @@ def test_macrocombobox(ms_name):
 
 if __name__ == "__main__":
     import sys
+    from taurus.core.util.argparse import get_taurus_parser
     from taurus.qt.qtgui.application import TaurusApplication
-    app = TaurusApplication()
+    parser = get_taurus_parser()
+    app = TaurusApplication(cmd_line_parser=parser)
     args = app.get_command_line_args()
     ms_name = args[0]
     test_macrocombobox(ms_name)

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/dooroutput.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/dooroutput.py
@@ -246,9 +246,11 @@ class DoorAttrListener(Qt.QObject):
 if __name__ == "__main__":
     import sys
     import taurus
+    from taurus.core.util.argparse import get_taurus_parser
     from taurus.qt.qtgui.application import TaurusApplication
 
-    app = TaurusApplication(sys.argv)
+    parser = get_taurus_parser()
+    app = TaurusApplication(sys.argv, cmd_line_parser=parser)
     args = app.get_command_line_args()
 
     doorOutput = DoorOutput()

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/favouriteseditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/favouriteseditor.py
@@ -220,9 +220,11 @@ def test():
     import sys
     import taurus
     import time
+    from taurus.core.util.argparse import get_taurus_parser
     from taurus.qt.qtgui.application import TaurusApplication
 
-    app = TaurusApplication(sys.argv)
+    parser = get_taurus_parser()
+    app = TaurusApplication(sys.argv, cmd_line_parser=parser)
 
     favouritesEditor = FavouritesMacrosEditor()
 

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/historyviewer.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/historyviewer.py
@@ -169,9 +169,11 @@ def test():
     import sys
     import taurus
     import time
+    from taurus.core.util.argparse import get_taurus_parser
     from taurus.qt.qtgui.application import TaurusApplication
 
-    app = TaurusApplication(sys.argv)
+    parser = get_taurus_parser()
+    app = TaurusApplication(sys.argv, cmd_line_parser=parser)
 
     historyViewer = HistoryMacrosViewer()
 

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macrobutton.py
@@ -381,7 +381,8 @@ if __name__ == '__main__':
     parser.set_description("Macro button for macro execution")
 
     app = TaurusApplication(app_name="macrobutton",
-                            app_version=taurus.Release.version)
+                            app_version=taurus.Release.version,
+                            cmd_line_parser=parser)
 
     args = app.get_command_line_args()
 

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroexecutor.py
@@ -1075,10 +1075,18 @@ def createMacroExecutor(args):
 
 
 def main():
+    from taurus.core.util import argparse
     from taurus.qt.qtgui.application import TaurusApplication
-    import taurus
 
-    app = TaurusApplication(sys.argv, app_version=sardana.Release.version)
+    parser = argparse.get_taurus_parser()
+    parser.set_usage("%prog [options]")
+    parser.set_description("Sardana macro executor.\n"
+                           "It allows execution of macros, keeping history "
+                           "of previous executions and favourites.")
+    app = TaurusApplication(sys.argv,
+                            cmd_line_parser=parser,
+                            app_name="macroexecutor",
+                            app_version=sardana.Release.version)
     args = app.get_command_line_args()
 
     app.setOrganizationName("Taurus")

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroparameterseditor/customeditors/senv.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/macroparameterseditor/customeditors/senv.py
@@ -383,9 +383,11 @@ CUSTOM_EDITOR = SenvEditor
 if __name__ == "__main__":
     import sys
     import taurus
+    from taurus.core.util.argparse import get_taurus_parser
     from taurus.qt.qtgui.application import TaurusApplication
 
-    app = TaurusApplication(sys.argv)
+    parser = get_taurus_parser()
+    app = TaurusApplication(sys.argv, cmd_line_parser=parser)
     args = app.get_command_line_args()
     editor = SenvEditor()
     macroServer = taurus.Device(args[0])

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/showscanonline.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/showscanonline.py
@@ -102,7 +102,7 @@ def main(group, taurus_log_level, door):
     from taurus.qt.qtgui.application import TaurusApplication
 
     app = TaurusApplication(app_name='Showscan Online', org_domain="Sardana",
-                            org_name="Tango communinity")
+                            org_name="Tango communinity", cmd_line_parser=None)
 
     assertPlotAvailability()
 

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/showscanonline.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/showscanonline.py
@@ -102,7 +102,7 @@ def main(group, taurus_log_level, door):
     from taurus.qt.qtgui.application import TaurusApplication
 
     app = TaurusApplication(app_name='Showscan Online', org_domain="Sardana",
-                            org_name="Tango communinity", cmd_line_parser=None)
+                            org_name="Tango communinity")
 
     assertPlotAvailability()
 


### PR DESCRIPTION
https://github.com/taurus-org/taurus/pull/1089 changes default behavior of cmd_line_parser kwarg of TaurusApplication. If not passed Taurus won't provide any parser. Use get_taurus_pareser (OptParse) and pass it to the TaurusApplication.