### PR TITLE
Limit macroexecutor history

### DIFF
--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -91,3 +91,6 @@ VALUE_REF_BUFFER_CODEC = "pickle"
 #:   this documentation it is not available for conda.
 #: - "dumb" - worst performance but directly available with Python 3.
 MS_ENV_SHELVE_BACKEND = None
+
+#: macroexecutor maximum number of macros stored in the history
+MACROEXECUTOR_MAX_HISTORY = 100

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/historyviewer.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/historyviewer.py
@@ -28,6 +28,7 @@ historyviewer.py:
 """
 import copy
 
+from sardana import sardanacustomsettings
 from taurus.external.qt import Qt, compat
 from taurus.qt.qtgui.container import TaurusWidget
 from taurus.qt.qtcore.configuration import BaseConfigurableClass
@@ -49,6 +50,10 @@ class HistoryMacrosViewer(TaurusWidget):
 
         self.list = HistoryMacrosList(self)
         self._model = MacrosListModel()
+        max_history = getattr(sardanacustomsettings,
+                              "MACROEXECUTOR_MAX_HISTORY",
+                              None)
+        self._model.setMaxLen(max_history)
         self.list.setModel(self._model)
 
 # self.registerConfigDelegate(self.list)

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/model.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/model.py
@@ -39,7 +39,6 @@ class MacrosListModel(Qt.QAbstractListModel):
         Qt.QAbstractListModel.__init__(self, parent)
         self.list = []
         self._max_len = None
-        self._len = 0
 
     def setMaxLen(self, max_len):
         self._max_len = max_len
@@ -63,10 +62,8 @@ class MacrosListModel(Qt.QAbstractListModel):
     def insertRow(self, macroNode, row=0):
         self.beginInsertRows(Qt.QModelIndex(), row, row)
         self.list.insert(row, macroNode)
-        self._len += 1
-        if self._max_len is not None and self._len > self._max_len:
-            self.list.pop(self._len - 1)
-            self._len -= 1
+        if self._max_len is not None and len(self.list) > self._max_len:
+            self.list.pop()
         self.endInsertRows()
         return self.index(row)
 
@@ -109,10 +106,9 @@ class MacrosListModel(Qt.QAbstractListModel):
         self.beginResetModel()
         listElement = etree.fromstring(xmlString)
         for childElement in listElement.iterchildren("macro"):
-            if self._max_len is not None and self._len >= self._max_len:
+            if self._max_len is not None and len(self.list) >= self._max_len:
                 break
             macroNode = macro.MacroNode()
             macroNode.fromXml(childElement)
             self.list.append(macroNode)
-            self._len += 1
         self.endResetModel()

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/model.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/model.py
@@ -61,9 +61,9 @@ class MacrosListModel(Qt.QAbstractListModel):
 
     def insertRow(self, macroNode, row=0):
         self.beginInsertRows(Qt.QModelIndex(), row, row)
-        self.list.insert(row, macroNode)
-        if self._max_len is not None and len(self.list) > self._max_len:
+        if self._max_len is not None and len(self.list) == self._max_len:
             self.list.pop()
+        self.list.insert(row, macroNode)
         self.endInsertRows()
         return self.index(row)
 

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/model.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/favouriteseditor/model.py
@@ -72,7 +72,7 @@ class MacrosListModel(Qt.QAbstractListModel):
 
     def removeRow(self, row):
         self.beginRemoveRows(Qt.QModelIndex(), row, row)
-
+        self.list.pop(row)
         self.endRemoveRows()
         if row == self.rowCount():
             row = row - 1


### PR DESCRIPTION
This is a very old issue. It was reported again at the last follow-up meeting by MaxIV.

Macroexecutor history may grow infinitely. This slows down the GUI operation (startup and changing of the perspectives). Limit the macroexecution hitory to 100. Allow to change it using the sardanacustomsettings.

If one was using macroexecutor before and have stored already more than the _limit_ macros in the history, then at the next GUI startup it will only load the last _limit_ executed macros. The rest of them will be lost.

I propose 100 as the _limit_. This can be changed with the `sardanacustomsettings`.

@julianofjm, @aureocarneiro could you test and review it?