### PR TITLE
Dump info on channels if MG acq fails in step scan, ct and uct 

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -659,7 +659,16 @@ def _value_to_repr(data):
         return data
 
 
-class ct(Macro, Hookable):
+class _ct:
+
+    def dump_information(self, elements):
+        msg = ["Elements ended acquisition with:"]
+        for element in elements:
+            msg.append(element.information())
+        self.info("\n".join(msg))
+
+
+class ct(Macro, Hookable, _ct):
     """Count for the specified time on the measurement group
        or experimental channel given as second argument
        (if not given the active measurement group is used)"""
@@ -701,7 +710,20 @@ class ct(Macro, Hookable):
         for preAcqHook in self.getHooks('pre-acq'):
             preAcqHook()
 
-        state, data = self.countable_elem.count(integ_time)
+        try:
+            state, data = self.countable_elem.count(integ_time)
+        except Exception:
+            if self.countable_elem.type == Type.MeasurementGroup:
+                names = self.countable_elem.ElementList
+                elements = [self.getObj(name) for name in names]
+                self.dump_information(elements)
+            raise
+        if state != DevState.ON:
+            if self.countable_elem.type == Type.MeasurementGroup:
+                names = self.countable_elem.ElementList
+                elements = [self.getObj(name) for name in names]
+                self.dump_information(elements)
+                raise ValueError("Acquisition ended with {}".format(state))
 
         for postAcqHook in self.getHooks('post-acq'):
             postAcqHook()
@@ -726,7 +748,7 @@ class ct(Macro, Hookable):
             self.output(line)
 
 
-class uct(Macro):
+class uct(Macro, _ct):
     """Count on the active measurement group and update"""
 
     param_def = [
@@ -785,14 +807,26 @@ class uct(Macro):
 
         self.print_value = True
         try:
-            _, data = self.countable_elem.count(integ_time)
-            self.setData(Record(data))
+            state, data = self.countable_elem.count(integ_time)
+        except Exception:
+            if self.countable_elem.type == Type.MeasurementGroup:
+                names = self.countable_elem.ElementList
+                elements = [self.getObj(name) for name in names]
+                self.dump_information(elements)
+            raise
         finally:
             self.finish()
+        if state != DevState.ON:
+            if self.countable_elem.type == Type.MeasurementGroup:
+                names = self.countable_elem.ElementList
+                elements = [self.getObj(name) for name in names]
+                self.dump_information(elements)
+                raise ValueError("Acquisition ended with {}".format(state))
+        self.setData(Record(data))
+        self.printAllValues()
 
     def finish(self):
         self._clean()
-        self.printAllValues()
 
     def _clean(self):
         for channel in self.channels:

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1118,7 +1118,7 @@ class SScan(GScan):
         except InterruptException:
             raise
         except Exception:
-            self.dump_information(n, step)
+            self.dump_information(n, step, self.motion.moveable_list)
             raise
         self.debug("[ END ] motion")
 
@@ -1213,11 +1213,10 @@ class SScan(GScan):
             except Exception:
                 pass
 
-    def dump_information(self, n, step):
-        moveables = self.motion.moveable_list
+    def dump_information(self, n, step, elements):
         msg = ["Report: Stopped at step #" + str(n) + " with:"]
-        for moveable in moveables:
-            msg.append(moveable.information())
+        for element in elements:
+            msg.append(element.information())
         self.macro.info("\n".join(msg))
 
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1157,10 +1157,17 @@ class SScan(GScan):
         integ_time = step['integ_time']
         # Acquire data
         self.debug("[START] acquisition")
-        if self._deterministic_scan:
-            state, data_line = mg.count_raw()
-        else:
-            state, data_line = mg.count(integ_time)
+        try:
+            if self._deterministic_scan:
+                state, data_line = mg.count_raw()
+            else:
+                state, data_line = mg.count(integ_time)
+        except InterruptException:
+            raise
+        except Exception:
+            channels = [self.macro.getExpChannel(ch) for ch in mg.ElementList]
+            self.dump_information(n, step, channels)
+            raise
         for ec in self._extra_columns:
             data_line[ec.getName()] = ec.read()
         self.debug("[ END ] acquisition")

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1139,7 +1139,7 @@ class SScan(GScan):
         self.macro.checkPoint()
 
         if state != Ready:
-            self.dump_information(n, step)
+            self.dump_information(n, step, self.motion.moveable_list)
             m = "Scan aborted after problematic motion: " \
                 "Motion ended with %s\n" % str(state)
             raise ScanException({'msg': m})
@@ -2651,7 +2651,7 @@ class HScan(SScan):
         except InterruptException:
             raise
         except Exception:
-            self.dump_information(n, step)
+            self.dump_information(n, step, motion.moveable_list)
             raise
 
         try:
@@ -2660,7 +2660,7 @@ class HScan(SScan):
         except InterruptException:
             raise
         except Exception:
-            self.dump_information(n, step)
+            self.dump_information(n, step, motion.moveable_list)
             raise
         self._sum_acq_time += integ_time
 
@@ -2670,7 +2670,7 @@ class HScan(SScan):
         m_state, m_positions = motion.readState(), motion.readPosition()
 
         if m_state != Ready:
-            self.dump_information(n, step)
+            self.dump_information(n, step, motion.moveable_list)
             m = "Scan aborted after problematic motion: " \
                 "Motion ended with %s\n" % str(m_state)
             raise ScanException({'msg': m})
@@ -2699,11 +2699,10 @@ class HScan(SScan):
             except Exception:
                 pass
 
-    def dump_information(self, n, step):
-        moveables = self.motion.moveable_list
+    def dump_information(self, n, step, elements):
         msg = ["Report: Stopped at step #" + str(n) + " with:"]
-        for moveable in moveables:
-            msg.append(moveable.information())
+        for element in elements:
+            msg.append(element.information())
         self.macro.info("\n".join(msg))
 
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1165,8 +1165,9 @@ class SScan(GScan):
         except InterruptException:
             raise
         except Exception:
-            channels = [self.macro.getExpChannel(ch) for ch in mg.ElementList]
-            self.dump_information(n, step, channels)
+            names = mg.ElementList
+            elements = [self.macro.getObj(name) for name in names]
+            self.dump_information(n, step, elements)
             raise
         for ec in self._extra_columns:
             data_line[ec.getName()] = ec.read()

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -47,6 +47,7 @@ import sys
 import time
 import traceback
 import weakref
+from datetime import datetime
 import numpy
 
 import PyTango
@@ -554,37 +555,43 @@ class PoolElement(BaseElement, TangoDevice):
         indent = "\n" + tab + 10 * ' '
         msg = [self.getName() + ":"]
         try:
-            state_value = self.stateObj.read().rvalue
+            t = time.time()
+            state_time = datetime.fromtimestamp(t).strftime("%H:%M:%S.%f")
+            # TODO: use expiration_period=float("inf") to always use event
+            #  value (taurus-org/taurus#1105)
+            state = self.stateObj.read()
+            state_time = state.time.strftime("%H:%M:%S.%f")
             # state_value is DevState enumeration (IntEnum)
-            state = state_value.name.capitalize()
+            state = state.rvalue.name.capitalize()
         except DevFailed as df:
             if len(df.args):
                 state = df.args[0].desc
             else:
                 e_info = sys.exc_info()[:2]
-                state = traceback.format_exception_only(*e_info)
+                state = traceback.format_exception_only(*e_info)[0].rstrip()
         except:
             e_info = sys.exc_info()[:2]
-            state = traceback.format_exception_only(*e_info)
-        try:
-            msg.append(tab + "   State: " + state)
-        except TypeError:
-            msg.append(tab + "   State: " + state[0])
+            state = traceback.format_exception_only(*e_info)[0].rstrip()
+        msg.append(tab + "   State: " + state + " ({})".format(state_time))
 
         try:
-            e_info = sys.exc_info()[:2]
-            status = self.status()
-            status = status.replace('\n', indent)
+            t = time.time()
+            status_time = datetime.fromtimestamp(t).strftime("%H:%M:%S.%f")
+            # TODO: ideally status should come from the event and no extra
+            #  readout should be made
+            status = self.read_attribute("status")
+            status_time = status.time.strftime("%H:%M:%S.%f")
+            status = status.value.replace('\n', indent)
         except DevFailed as df:
             if len(df.args):
                 status = df.args[0].desc
             else:
                 e_info = sys.exc_info()[:2]
-                status = traceback.format_exception_only(*e_info)
+                status = traceback.format_exception_only(*e_info)[0].rstrip()
         except:
             e_info = sys.exc_info()[:2]
-            status = traceback.format_exception_only(*e_info)
-        msg.append(tab + "  Status: " + status)
+            status = traceback.format_exception_only(*e_info)[0].rstrip()
+        msg.append(tab + "  Status: " + status + " ({})".format(status_time))
 
         return msg
 

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -569,7 +569,7 @@ class PoolElement(BaseElement, TangoDevice):
             else:
                 e_info = sys.exc_info()[:2]
                 state = traceback.format_exception_only(*e_info)[0].rstrip()
-        except:
+        except Exception:
             e_info = sys.exc_info()[:2]
             state = traceback.format_exception_only(*e_info)[0].rstrip()
         msg.append(tab + "   State: " + state + " ({})".format(state_time))
@@ -588,7 +588,7 @@ class PoolElement(BaseElement, TangoDevice):
             else:
                 e_info = sys.exc_info()[:2]
                 status = traceback.format_exception_only(*e_info)[0].rstrip()
-        except:
+        except Exception:
             e_info = sys.exc_info()[:2]
             status = traceback.format_exception_only(*e_info)[0].rstrip()
         msg.append(tab + "  Status: " + status + " ({})".format(status_time))


### PR DESCRIPTION
MeasurementGroup may get into the FAULT state mainly due to these three reasons:
* software synchronized acquisition startup (load or start sequence) fails  
* one of its channels reports FAULT state
* the last readout of State or Value/ValueRef fails.

This is only reported to the user with the exception message: `Exception: Measurement group ended acquisition with Fault state`.

Similarly to dumping information about moveables when motion fails also dump it for channels in the case the measurement group acquisition fails. 

This is something what we discussed on the last follow-up meeting based on a poor experience when debugging a problem at DESY. I think this PR adds more verbosity about the measurement group problems. For example, now we would get:

```
Door_zreszela_1 [17]: ascan mot01 0 1 1 0.001
Operation will be saved in /tmp/test.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #175 started at Fri Mar 13 23:00:05 2020. It will take at least 0:00:02.830427
 #Pt No    mot01      ct01     twod01      dt
Report: Stopped at step #0 with:
ct01:
       State: Fault
      Status: ct01 is Fault
              Exception: ERROR STATE
twod01:
       State: Moving
      Status: twod01 is On
              Stopped
Operation saved in /tmp/test.h5 (HDF5::NXscan)
Scan #175 ended at Fri Mar 13 23:00:06 2020, taking 0:00:00.262264. Dead time 100.0% (motion dead time 10.0%)
An error occurred while running ascan:
Exception: Measurement group ended acquisition with Fault state
Hint: in Spock execute `www`to get more details

```
Note that there are still things to improve. For example, the channel's Status could correspond to the last readout done by the acquisition action. Now it is not the case. The Status information is read via Tango when composing the information, so an extra `StateOne` call is performed.

@teresanunez it would be great if you could review and test it. Thanks!