### PR TITLE
Fix dummy C/T and 2D ctrls in the case of unfinished start

### DIFF
--- a/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
@@ -139,7 +139,7 @@ class DummyCounterTimerController(CounterTimerController):
         if self._armed:
             sta = State.Moving
             status = "Armed"
-        elif axis in self.counting_channels:
+        elif axis in self.counting_channels and self.start_time is not None:
             channel = self.channels[idx]
             now = time.time()
             elapsed_time = now - self.start_time
@@ -182,7 +182,7 @@ class DummyCounterTimerController(CounterTimerController):
         if self._armed:
             return  # still armed - no trigger/gate arrived yet
         # if in acquisition then calculate the values to return
-        if self.counting_channels:
+        if self.counting_channels and self.start_time is not None:
             now = time.time()
             elapsed_time = now - self.start_time
             for axis, channel in list(self.read_channels.items()):
@@ -263,12 +263,16 @@ class DummyCounterTimerController(CounterTimerController):
                                      AcqSynch.HardwareGate):
             self._disconnect_hardware_synchronization()
             self._armed = False
+        self.start_time = None
 
     def AbortOne(self, axis):
         if axis not in self.counting_channels:
             return
         now = time.time()
-        elapsed_time = now - self.start_time
+        if self.start_time is not None:
+            elapsed_time = now - self.start_time
+        else:
+            elapsed_time = 0
         self._finish(elapsed_time, axis)
 
     def GetCtrlPar(self, par):

--- a/src/sardana/pool/poolcontrollers/DummyTwoDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyTwoDController.py
@@ -264,7 +264,7 @@ class BasicDummyTwoDController(TwoDController):
         if self._armed:
             sta = State.Moving
             status = "Armed"
-        elif axis in self.counting_channels:
+        elif axis in self.counting_channels and self.start_time is not None:
             channel = self.channels[idx]
             now = time.time()
             elapsed_time = now - self.start_time
@@ -342,12 +342,16 @@ class BasicDummyTwoDController(TwoDController):
                                      AcqSynch.HardwareGate):
             self._disconnect_hardware_synchronization()
             self._armed = False
+        self.start_time = None
 
     def AbortOne(self, axis):
         if axis not in self.counting_channels:
             return
         now = time.time()
-        elapsed_time = now - self.start_time
+        if self.start_time is not None:
+            elapsed_time = now - self.start_time
+        else:
+            elapsed_time = 0
         self._finish(elapsed_time, axis)
 
     def getAmplitude(self, axis):


### PR DESCRIPTION
When StartAll method is not called StateOne and ReadOne raises
exception - start_time is not set. Avoid this problem by detecting and
dealing especially with this situation.

Note that this most probably fixes #1188 - in the said test the measurement group is stopped after 200 ms. It may be that if the stop interrupts the start then the subsequent StateOne will fail. I will rebuild it several times. If I don't see this test to fail I will merge it myself.