### PR TITLE
Fix regscans points repeat

### DIFF
--- a/src/sardana/macroserver/macros/examples/scans.py
+++ b/src/sardana/macroserver/macros/examples/scans.py
@@ -347,7 +347,7 @@ class regscan(Macro):
                 r][0], self.regions[r][1]
             positions = numpy.linspace(
                 region_start, region_stop, region_nr_intervals + 1)
-            if region_start != self.start_pos:
+            if point_id != 0:
                 # positions must be calculated from the start to the end of the region
                 # but after the first region, the 'start' point must not be
                 # repeated
@@ -408,7 +408,7 @@ class reg2scan(Macro):
                 r][0], self.regions[r][1]
             positions = numpy.linspace(
                 region_start, region_stop, region_nr_intervals + 1)
-            if region_start != self.start_pos:
+            if point_id != 0:
                 # positions must be calculated from the start to the end of the region
                 # but after the first region, the 'start' point must not be
                 # repeated
@@ -473,7 +473,7 @@ class reg3scan(Macro):
                 r][0], self.regions[r][1]
             positions = numpy.linspace(
                 region_start, region_stop, region_nr_intervals + 1)
-            if region_start != self.start_pos:
+            if point_id != 0:
                 # positions must be calculated from the start to the end of the region
                 # but after the first region, the 'start' point must not be
                 # repeated


### PR DESCRIPTION
Hi,
we've discovered a bug in regscans. When starting point of a region is the same as the starting position, scan point is repeated twice (basically one of them is not ommited).  

Example of this bug below (see points 7-8 and 18-19):

```
Door_test_1 [34]: rscan mot01 0.5 0 0.5 2 0 5 -0.5 5 0 5 0.5 5 0 2
Scan #18 started at Mon Apr 27 16:10:16 2020. It will take at least 0:00:15.981031
 #Pt No    mot01      ct01      ct05     epoch       dt   
   0         0        0.5       0.5     1.588e+09  0.174259
   1        0.25      0.5       0.5     1.588e+09  0.891304
   2        0.5       0.5       0.5     1.588e+09  1.60174 
   3        0.4       0.5       0.5     1.588e+09  2.26886 
   4        0.3       0.5       0.5     1.588e+09  2.93647 
   5        0.2       0.5       0.5     1.588e+09  3.61776 
   6        0.1       0.5       0.5     1.588e+09   4.2919 
   7         0        0.5       0.5     1.588e+09  4.96892 
   8         0        0.5       0.5     1.588e+09  5.54238 
   9        -0.1      0.5       0.5     1.588e+09  6.19282 
   10       -0.2      0.5       0.5     1.588e+09   6.8597 
   11       -0.3      0.5       0.5     1.588e+09  7.51575 
   12       -0.4      0.5       0.5     1.588e+09  8.18407 
   13       -0.5      0.5       0.5     1.588e+09  8.84132 
   14       -0.4      0.5       0.5     1.588e+09  9.49642 
   15       -0.3      0.5       0.5     1.588e+09  10.1601 
   16       -0.2      0.5       0.5     1.588e+09  10.8231 
   17       -0.1      0.5       0.5     1.588e+09  11.4903 
   18        0        0.5       0.5     1.588e+09  12.1458 
   19        0        0.5       0.5     1.588e+09  12.7085 
   20       0.1       0.5       0.5     1.588e+09  13.3906 
   21       0.2       0.5       0.5     1.588e+09   14.076 
   22       0.3       0.5       0.5     1.588e+09  14.7484 
   23       0.4       0.5       0.5     1.588e+09  15.4043 
   24       0.5       0.5       0.5     1.588e+09  16.0802 
   25       0.25      0.5       0.5     1.588e+09  16.8118 
   26        0        0.5       0.5     1.588e+09   17.541 
Scan #18 ended at Mon Apr 27 16:10:34 2020, taking 0:00:18.091749. Dead time 25.4% (motion dead time 17.9%)
```

Simple solution comes with this PR.