### PR TITLE
Build docs with Sphinx 3

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -299,3 +299,13 @@ intersphinx_mapping = {
     'https://matplotlib.org/': None,
     'https://pythonhosted.org/guiqwt/': None,
 }
+
+
+def _skip_read_attr_hardware(app, what, name, obj, skip, options):
+    if what == "class" and name == "read_attr_hardware":
+        return True
+
+
+def setup(app):
+    # due to tango-controls/pytango#352 we need to exclude read_attr_hardware
+    app.connect('autodoc-skip-member', _skip_read_attr_hardware)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -289,7 +289,7 @@ graphviz_output_format = 'png'  # 'svg'
 # -- Options for reference to other documentation ------------------------
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.5', None),
+    'python': ('https://docs.python.org/3', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
     'ipython': ('http://ipython.org/ipython-doc/stable/', None),

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -135,7 +135,7 @@ release = sardana.Release.version
 exclude_trees = []
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-# default_role = None
+default_role = "obj"
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -289,15 +289,15 @@ graphviz_output_format = 'png'  # 'svg'
 # -- Options for reference to other documentation ------------------------
 
 intersphinx_mapping = {
-    'https://docs.python.org/dev': None,
-    'https://docs.scipy.org/doc/scipy/reference': None,
-    'https://docs.scipy.org/doc/numpy': None,
-    'http://ipython.org/ipython-doc/stable/': None,
-    'http://pytango.readthedocs.io/en/stable/': None,
-    'http://taurus-scada.org': None,
-    'http://pyqt.sourceforge.net/Docs/PyQt4/': None,
-    'https://matplotlib.org/': None,
-    'https://pythonhosted.org/guiqwt/': None,
+    'python': ('https://docs.python.org/3.5', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'ipython': ('http://ipython.org/ipython-doc/stable/', None),
+    'pytango': ('https://pytango.readthedocs.io/en/stable/', None),
+    'taurus': ('http://taurus-scada.org', None),
+    'pyqt': ('https://www.riverbankcomputing.com/static/Docs/PyQt5/', None),
+    'matplotlib': ('https://matplotlib.org/', None),
+    'guiqwt': ('https://pythonhosted.org/guiqwt/', None),
 }
 
 

--- a/doc/source/devel/api/api_test.rst
+++ b/doc/source/devel/api/api_test.rst
@@ -24,9 +24,7 @@ Macro test API
 Decorator
 ---------
 
-.. decorator:: macroTest
-
-    .. autofunction:: macroTest
+.. autodecorator:: macroTest
 
 
 

--- a/doc/source/users/spock.rst
+++ b/doc/source/users/spock.rst
@@ -645,17 +645,17 @@ spock console:
 Using spock as a Tango_ console
 -------------------------------
 
-As metioned in the beggining of this chapter, the sardana spock automatically
-activates the PyTango_ 's ipython console extension. Therefore all Tango_
+As mentioned in the beginning of this chapter, the sardana spock automatically
+activates the PyTango_ 's ipython console extension [#]_. Therefore all Tango_
 features are automatically available on the sardana spock console. For example,
-creating a :class:`~PyTango.DeviceProxy` will work inside the sardana spock
+creating a :class:`tango.DeviceProxy` will work inside the sardana spock
 console:
 
 .. sourcecode:: spock
 
-    LAB-01-D01 [1]: tgtest = PyTango.DeviceProxy("sys/tg_test/1")
+    LAB-01-D01 [1]: tgtest = Device("sys/tg_test/1")
     
-    LAB-01-D01 [2]: print( tgtest.state() )
+    LAB-01-D01 [2]: print(tgtest.state())
     RUNNING
 
 .. rubric:: Footnotes

--- a/src/sardana/macroserver/macros/test/base.py
+++ b/src/sardana/macroserver/macros/test/base.py
@@ -44,7 +44,7 @@ _NOT_PASSED = __NotPassedType()
 
 def macroTest(klass=None, helper_name=None, test_method_name=None,
               test_method_doc=None, **helper_kwargs):
-    """This decorator is an specialization of :function::`taurus.test.insertTest`
+    """This decorator is an specialization of `taurus.test.insertTest`
     for macro testing. It inserts test methods from a helper method that may
     accept arguments.
 
@@ -110,7 +110,7 @@ def macroTest(klass=None, helper_name=None, test_method_name=None,
         class FooTest(RunMacroTestCase, unittest.TestCase):
             macro_name = 'twice'
 
-    .. seealso:: :function::`taurus.test.insertTest`
+    .. seealso:: `taurus.test.insertTest`
 
     """
     # recipe to allow decorating with and without arguments

--- a/src/sardana/pool/controller.py
+++ b/src/sardana/pool/controller.py
@@ -109,13 +109,14 @@ class Controller(object):
     :keyword kwargs:
     """
 
+    #:
     #: .. deprecated:: 1.0
     #:     use :attr:`~Controller.ctrl_properties` instead
     class_prop = {}
 
     #: A sequence of :obj:`str` representing the controller features
     ctrl_features = []
-
+    #:
     #: .. deprecated:: 1.0
     #:     use :attr:`~Controller.axis_attributes` instead
     ctrl_extra_attributes = {}
@@ -1522,7 +1523,7 @@ class IORegisterController(Controller, Readable):
     """Base class for a IORegister controller. Inherit from this class to
     implement your own IORegister controller for the device pool.
     """
-
+    #:
     #: .. deprecated:: 1.0
     #:     use :attr:`~Controller.axis_attributes` instead
     predefined_values = ()


### PR DESCRIPTION
The documentation builds started to fail due to PyTango intersphinx mapping problems.
These appeared to be solved with the latests Sphinx. I made some effort to fix warnings after the Sphinx upgrade.

I take a profit of this PR to set default role in docs to obj. This way one could create cross-references (even intersphinx) with just back-quotes e.g.\`taurus.Device\` instead of :obj:\`taurus.Device\`

This is a house-keeping PR, so I won't bother you with the reviews and whenever it gets green in Travis I will auto-merge.

Initially it will fail - still waiting for a new version of docker image with the Sphinx v3. But I will retrigger later..