### PR TITLE
Register a TaurusValue factory for pool widgets

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,13 +84,13 @@ gui_scripts = [
 ]
 
 form_factories = [
-    "sdn_pool = sardana.taurus.qt.qtgui.extra_pool.formitemfactory:pool_item_factory"  # noqa
+    "sardana.pool = sardana.taurus.qt.qtgui.extra_pool.formitemfactory:pool_item_factory"  # noqa
 ]
 
 entry_points = {
     'console_scripts': console_scripts,
     'gui_scripts': gui_scripts,
-    'taurus.qt.taurusform.item_factories': form_factories,
+    'taurus.form.item_factories': form_factories,
 }
 
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,15 @@ gui_scripts = [
     "showscan = sardana.taurus.qt.qtgui.extra_sardana.showscanonline:main"
 ]
 
-entry_points = {'console_scripts': console_scripts,
-                'gui_scripts': gui_scripts,
-                }
+form_factories = [
+    "sdn_pool = sardana.taurus.qt.qtgui.extra_pool.formitemfactory:pool_item_factory"
+]
+
+entry_points = {
+    'console_scripts': console_scripts,
+    'gui_scripts': gui_scripts,
+    'taurus.qt.taurusform.item_factories': form_factories,
+}
 
 classifiers = [
     'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ gui_scripts = [
 ]
 
 form_factories = [
-    "sdn_pool = sardana.taurus.qt.qtgui.extra_pool.formitemfactory:pool_item_factory"
+    "sdn_pool = sardana.taurus.qt.qtgui.extra_pool.formitemfactory:pool_item_factory"  # noqa
 ]
 
 entry_points = {

--- a/src/sardana/taurus/qt/qtgui/extra_pool/formitemfactory.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/formitemfactory.py
@@ -54,7 +54,7 @@ def pool_item_factory(model):
     # TODO: use sardana element types instead of tango classes
     try:
         key = model.getDeviceProxy().info().dev_class
-        klass = T_FORM_POOL_WIDGET_MAP.get[key]
+        klass = T_FORM_POOL_WIDGET_MAP.get(key)
     except:
         return None
     return klass()

--- a/src/sardana/taurus/qt/qtgui/extra_pool/formitemfactory.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/formitemfactory.py
@@ -55,6 +55,6 @@ def pool_item_factory(model):
     try:
         key = model.getDeviceProxy().info().dev_class
         klass = T_FORM_POOL_WIDGET_MAP.get(key)
-    except:
+    except Exception:
         return None
     return klass()

--- a/src/sardana/taurus/qt/qtgui/extra_pool/formitemfactory.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/formitemfactory.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+"""
+This module provides TaurusValue item factories to be registered as providers
+of custom TaurusForm item widgets.
+"""
+
+from . import PoolMotorTV, PoolChannelTV, PoolIORegisterTV
+
+T_FORM_POOL_WIDGET_MAP = {
+    "SimuMotor": PoolMotorTV,
+    "Motor": PoolMotorTV,
+    "PseudoMotor": PoolMotorTV,
+    "PseudoCounter": PoolChannelTV,
+    "CTExpChannel": PoolChannelTV,
+    "ZeroDExpChannel": PoolChannelTV,
+    "OneDExpChannel": PoolChannelTV,
+    "TwoDExpChannel": PoolChannelTV,
+    "IORegister": PoolIORegisterTV,
+}
+
+
+def pool_item_factory(model):
+    """
+    Taurus Value Factory to be registered as a TaurusForm item factory plugin
+
+    :param model: taurus model object
+
+    :return: custom TaurusValue class
+    """
+    # TODO: use sardana element types instead of tango classes
+    try:
+        key = model.getDeviceProxy().info().dev_class
+        klass = T_FORM_POOL_WIDGET_MAP.get[key]
+    except:
+        return None
+    return klass()

--- a/src/sardana/taurus/qt/qtgui/extra_pool/formitemfactory.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/formitemfactory.py
@@ -54,7 +54,7 @@ def pool_item_factory(model):
     # TODO: use sardana element types instead of tango classes
     try:
         key = model.getDeviceProxy().info().dev_class
-        klass = T_FORM_POOL_WIDGET_MAP.get(key)
+        klass = T_FORM_POOL_WIDGET_MAP[key]
     except Exception:
         return None
     return klass()


### PR DESCRIPTION
A recent PR in taurus (https://github.com/taurus-org/taurus/pull/1108) provides a new entrypoint for registering "TaurusValue item factories" (the entry point group name is "taurus.qt.taurusform.item_factories" )

Register one such factory to achieve the same result as with the old T_FORM_CUSTOM_WIDGET_MAP (i.e., using PoolMotorTV, etc. for sardana elements in a
TaurusForm)

If this PR is integrated, it can then easily be adapted to provide the same that was attempted with https://github.com/taurus-org/taurus/pull/1101, which is related to #1203