### PR TITLE
Fix dummy 1D: cast to int number of new frames

### DIFF
--- a/src/sardana/pool/poolcontrollers/DummyOneDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyOneDController.py
@@ -174,7 +174,7 @@ class DummyOneDController(OneDController):
         elif self._synchronization in (AcqSynch.HardwareTrigger,
                                        AcqSynch.HardwareGate):
             if self.integ_time is not None:
-                n = t // self.integ_time
+                n = int(t // self.integ_time)
                 cp = 0
                 if n > self._repetitions:
                     cp = n - self._repetitions


### PR DESCRIPTION
Commit 223cdf7 wrongly removed the cast assuming that in Python 3 //
operation always returns integer number. This however depends on the operands
types. When one of the operands is float, the result is float. Here we are
dividing times which are floats. Re-introduce the cast.

The rest of the said commit is ok cause it was actually removing float casts
for / operations which in Python 3 always return float.

Note to @sardana-org/integrators: this is a revert of wrongly introduced change (done by me:) I will auto-mege it if no negative voices in the next days. 