### PR TITLE
Rename Synchronization to SynchDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,13 @@ This file follows the formats and conventions from [keepachangelog.com]
 
 ### Changed
 
+* Renamed _synchronization_ to _synch description_
+  * Tango MeasurementGroup `Synchronization` attribute to `SynchDescription`
+  * Core MeasurementGroup `synchronization` property to `synch_description`
+  * Sardana-Taurus Device MeasurementGroup `getSynchronizationObj()`,
+    `getSynchronization()` and `setSynchronization()` methods to
+    `getSynchDescriptionObj()`,`getSynchDescription()`
+    and `setSynchDescription()` (#1337)
 * Requirements are no longer checked when importing sardana (#1185)
 * Measurement group (Taurus extension) configuration API methods, known in 
   the old sense for setting a global measurement group timer/monitor:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ This file follows the formats and conventions from [keepachangelog.com]
     `getSynchronization()` and `setSynchronization()` methods to
     `getSynchDescriptionObj()`,`getSynchDescription()`
     and `setSynchDescription()` (#1337)
+  * `SynchronizationDescription` helper class to `SynchDescription`
 * Requirements are no longer checked when importing sardana (#1185)
 * Measurement group (Taurus extension) configuration API methods, known in 
   the old sense for setting a global measurement group timer/monitor:

--- a/doc/source/devel/api/api_measurementgroup.rst
+++ b/doc/source/devel/api/api_measurementgroup.rst
@@ -42,7 +42,7 @@ latency time
     Latency time between two consecutive acquisitions in the same acquisition
     operation.
 
-synchronization
+synch description
     Describes the acquisition operation synchronization. It is composed from
     the group(s) of equidistant acquisitions described by the following
     parameters:

--- a/doc/source/devel/api/sardana/pool/poolsynchronization.rst
+++ b/doc/source/devel/api/sardana/pool/poolsynchronization.rst
@@ -10,7 +10,7 @@
 .. hlist::
     :columns: 3
 
-    * :class:`SynchronizationDescription`
+    * :class:`SynchDescription`
     * :class:`PoolSynchronization`
 
 PoolSynchronization
@@ -24,13 +24,13 @@ PoolSynchronization
     :members:
     :undoc-members:
 
-SynchronizationDescription
---------------------------
+SynchDescription
+----------------
 
-.. inheritance-diagram:: SynchronizationDescription
+.. inheritance-diagram:: SynchDescription
     :parts: 1
 
-.. autoclass:: SynchronizationDescription
+.. autoclass:: SynchDescription
     :show-inheritance:
     :members:
     :undoc-members:

--- a/src/sardana/macroserver/macros/expconf.py
+++ b/src/sardana/macroserver/macros/expconf.py
@@ -34,6 +34,7 @@ import taurus
 from taurus.console import Alignment
 from taurus.console.list import List
 
+from sardana.pool import AcqSynchType
 from sardana.macroserver.msexception import UnknownEnv
 from sardana.taurus.core.tango.sardana import PlotType
 from sardana.macroserver.macro import macro, Macro, Type, Optional
@@ -51,6 +52,10 @@ def plot_axes_sanitizer(values):
     return ["n/a" if len(v) == 0 else v[0] for v in values]
 
 
+def synchrtonization_sanitizer(values):
+    return [AcqSynchType.whatis(v) for v in values]
+
+
 def plot_axes_validator(value):
     value = value.lower()
     if value in ("idx", "<idx>"):
@@ -61,15 +66,30 @@ def plot_axes_validator(value):
 
 
 def bool_validator(value):
+    in_value = value
     value = value.lower()
     if value in ['true', '1']:
         value = True
     elif value in ['false', '0']:
         value = False
     else:
-        raise ValueError('{0} is not a boolean'.format(value))
+        raise ValueError('{0} is not a boolean'.format(in_value))
     return value
 
+
+def synchronization_validator(value):
+    in_value = value
+    value = value.lower()
+    try:
+        try:
+            value = int(value)
+        except:
+            value = AcqSynchType.get(value.capitalize())
+        else:
+            value = AcqSynchType.get(value)
+    except KeyError:
+        raise ValueError("{0} is not a synchronization type".format(in_value))
+    return value
 
 # if sanitizers and validators evolve to sth too complicated refactor this
 # to use classes
@@ -81,6 +101,9 @@ parameter_map = OrderedDict([
     ("timer", ("Timer", sanitizer, None)),
     ("monitor", ("Monitor", sanitizer, None)),
     ("synchronizer", ("Synchronizer", sanitizer, None)),
+    ("synchronization",
+        ("Synchronization", synchrtonization_sanitizer,
+         synchronization_validator)),
     ("valuerefenabled", ("ValueRefEnabled", sanitizer, bool_validator)),
     ("valuerefpattern", ("ValueRefPattern", sanitizer, None))
 ])
@@ -164,6 +187,7 @@ def set_meas_conf(self, parameter, value, items, meas_grp):
     - **Timer**: <channel name> e.g. ct01
     - **Monitor**: <channel name> e.g. ct01
     - **Synchronizer**: software or <trigger/gate name> e.g. tg01
+    - **Synchronization**: 0/Trigger, 1/Gate or 2/Start
     - **ValueRefEnabled** - True/1 or False/0
     - **ValueRefPattern** - URI e.g. file:///tmp/img_{index}.tiff
 

--- a/src/sardana/macroserver/macros/expconf.py
+++ b/src/sardana/macroserver/macros/expconf.py
@@ -83,7 +83,7 @@ def synchronization_validator(value):
     try:
         try:
             value = int(value)
-        except:
+        except ValueError:
             value = AcqSynchType.get(value.capitalize())
         else:
             value = AcqSynchType.get(value)

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2725,8 +2725,7 @@ class TScan(GScan, CAcquisition):
         CAcquisition.__init__(self)
         self._synch_description = None
 
-    def _create_synch_description(self, active_time, repeats,
-                                            latency_time=0):
+    def _create_synch_description(self, active_time, repeats, latency_time=0):
         delay_time = 0
         mg_latency_time = self.measurement_group.getLatencyTime()
         if mg_latency_time > latency_time:
@@ -2757,7 +2756,7 @@ class TScan(GScan, CAcquisition):
             latency_time = getattr(self.macro, "latency_time", 0)
             synch_description = \
                 self._create_synch_description(active_time, repeats,
-                                                         latency_time)
+                                               latency_time)
         self._synch_description = synch_description
         return synch_description
 

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -365,7 +365,7 @@ class PoolAcquisition(PoolAction):
                 self.debug('Stopping ZeroD acquisition.')
                 self._0d_acq.stop_action()
 
-    def prepare(self, config, acq_mode, value, synchronization=None,
+    def prepare(self, config, acq_mode, value, synch_description=None,
                 moveable=None, sw_synch_initial_domain=None,
                 nb_starts=1, **kwargs):
         """Prepare measurement process.
@@ -382,8 +382,8 @@ class PoolAcquisition(PoolAction):
         ctrls_sw = []
         ctrls_sw_start = []
 
-        repetitions = synchronization.repetitions
-        latency = synchronization.passive_time
+        repetitions = synch_description.repetitions
+        latency = synch_description.passive_time
         # Prepare controllers synchronized by hardware
         acq_sync_hw = [AcqSynch.HardwareTrigger, AcqSynch.HardwareStart,
                        AcqSynch.HardwareGate]
@@ -442,7 +442,7 @@ class PoolAcquisition(PoolAction):
         # Prepare synchronizer controllers
         ctrls = config.get_synch_ctrls(enabled=True)
         ctrls_synch = get_acq_ctrls(ctrls)
-        synch_args = (ctrls_synch, synchronization)
+        synch_args = (ctrls_synch, synch_description)
         synch_kwargs = {'moveable': moveable,
                         'sw_synch_initial_domain': sw_synch_initial_domain}
         synch_kwargs.update(kwargs)

--- a/src/sardana/pool/poolcontrollers/test/test_DummyTriggerGateController.py
+++ b/src/sardana/pool/poolcontrollers/test/test_DummyTriggerGateController.py
@@ -8,19 +8,19 @@ from sardana.pool.test import FakePool, createPoolController, \
     createPoolTriggerGate, dummyPoolTGCtrlConf01, dummyTriggerGateConf01, \
     createControllerConfiguration
 
-synchronization1 = [{SynchParam.Delay: {SynchDomain.Time: 0},
-                     SynchParam.Active: {SynchDomain.Time: .03},
-                     SynchParam.Total: {SynchDomain.Time: .1},
-                     SynchParam.Repeats: 0}]
+synch_description1 = [{SynchParam.Delay: {SynchDomain.Time: 0},
+                       SynchParam.Active: {SynchDomain.Time: .03},
+                       SynchParam.Total: {SynchDomain.Time: .1},
+                       SynchParam.Repeats: 0}]
 
-synchronization2 = [{SynchParam.Delay: {SynchDomain.Time: 0},
-                     SynchParam.Active: {SynchDomain.Time: .01},
-                     SynchParam.Total: {SynchDomain.Time: .02},
-                     SynchParam.Repeats: 10}]
+synch_description2 = [{SynchParam.Delay: {SynchDomain.Time: 0},
+                       SynchParam.Active: {SynchDomain.Time: .01},
+                       SynchParam.Total: {SynchDomain.Time: .02},
+                       SynchParam.Repeats: 10}]
 
 
-@insertTest(helper_name='generation', synchronization=synchronization1)
-@insertTest(helper_name='generation', synchronization=synchronization2)
+@insertTest(helper_name='generation', synch_description=synch_description1)
+@insertTest(helper_name='generation', synch_description=synch_description2)
 class PoolDummyTriggerGateTestCase(unittest.TestCase):
     """Parameterizable integration test of the PoolSynchronization action and
     the DummTriggerGateController.
@@ -49,10 +49,10 @@ class PoolDummyTriggerGateTestCase(unittest.TestCase):
         self.tg_action = PoolSynchronization(self.dummy_tg)
         self.tg_action.add_element(self.dummy_tg)
 
-    def generation(self, synchronization):
+    def generation(self, synch_description):
         """Verify that the created PoolTGAction start_action starts correctly
         the involved controller."""
-        args = ([self.ctrl_conf], synchronization)
+        args = ([self.ctrl_conf], synch_description)
         self.tg_action.start_action(*args)
         self.tg_action.action_loop()
         # TODO: add asserts applicable to a dummy controller e.g. listen to

--- a/src/sardana/pool/pooldefs.py
+++ b/src/sardana/pool/pooldefs.py
@@ -89,7 +89,7 @@ class SynchDomain(SynchEnum):
 
 
 class SynchParam(SynchEnum):
-    """Enumeration of synchronization's group parameters.
+    """Enumeration of synchronization description group parameters.
 
     - Delay - initial delay (relative to the synchronization start)
     - Total - total interval

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -1201,9 +1201,8 @@ class PoolMeasurementGroup(PoolGroupElement):
                                   priority=propagate),
                         description)
 
-    synch_description = property(get_synch_description,
-                                           set_synch_description,
-                               doc="the current acquisition mode")
+    synch_description = property(get_synch_description, set_synch_description,
+                                 doc="the current acquisition mode")
 
     # -------------------------------------------------------------------------
     # moveable

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -610,6 +610,10 @@ class MeasurementConfiguration(object):
         The configuration parameters for given channels/controllers may differ
         depending on their types e.g. 0D channel does not support timer
         parameter while C/T does.
+
+        .. todo::
+            Raise exceptions when setting _Synchronization_ parameter for
+            external channels, 0D and PSeudoCounters.
         """
 
         pool = self._parent.pool

--- a/src/sardana/pool/poolsynchronization.py
+++ b/src/sardana/pool/poolsynchronization.py
@@ -27,7 +27,7 @@
 """This module is part of the Python Pool library. It defines the classes
 for the synchronization"""
 
-__all__ = ["PoolSynchronization", "SynchronizationDescription", "TGChannel"]
+__all__ = ["PoolSynchronization", "SynchDescription", "TGChannel"]
 
 import time
 from functools import partial
@@ -61,7 +61,7 @@ class TGChannel(PoolActionItem):
         return getattr(self.element, name)
 
 
-class SynchronizationDescription(list):
+class SynchDescription(list):
     """Synchronization description. It is composed from groups - repetitions
     of equidistant synchronization events. Each group is described by
     :class:`~sardana.pool.pooldefs.SynchParam` parameters which may have
@@ -90,8 +90,9 @@ class SynchronizationDescription(list):
     def _get_param(self, param, domain=SynchDomain.Time):
         """
         Extract parameter from synchronization description and its groups. If
-        there is only one group in the synchronization then returns float
-        with the value. Otherwise a list of floats with different values.
+        there is only one group in the synchronization description then
+        returns float with the value. Otherwise a list of floats with
+        different values.
 
         :param param: parameter type
         :type param: :class:`~sardana.pool.pooldefs.SynchParam`
@@ -133,15 +134,15 @@ class PoolSynchronization(PoolAction):
     def add_listener(self, listener):
         self._listener = listener
 
-    def start_action(self, ctrls, synchronization, moveable=None,
+    def start_action(self, ctrls, synch_description, moveable=None,
                      sw_synch_initial_domain=None, *args, **kwargs):
         """Start synchronization action.
 
         :param ctrls: list of enabled trigger/gate controllers
         :type ctrls: list
-        :param synchronization: synchronization description
-        :type synchronization:
-         :class:`~sardana.pool.poolsynchronization.SynchronizationDescription`
+        :param synch_description: synchronization description
+        :type synch_description:
+         :class:`~sardana.pool.poolsynchronization.SynchDescription`
         :param moveable: (optional) moveable object used as the
          synchronization source in the Position domain
         :type moveable: :class:`~sardna.pool.poolmotor.PoolMotor` or
@@ -159,12 +160,12 @@ class PoolSynchronization(PoolAction):
                 pool_ctrl.ctrl.PreSynchAll()
                 for channel in ctrl.get_channels(enabled=True):
                     axis = channel.axis
-                    ret = pool_ctrl.ctrl.PreSynchOne(axis, synchronization)
+                    ret = pool_ctrl.ctrl.PreSynchOne(axis, synch_description)
                     if not ret:
                         msg = ("%s.PreSynchOne(%d) returns False" %
                                (ctrl.name, axis))
                         raise Exception(msg)
-                    pool_ctrl.ctrl.SynchOne(axis, synchronization)
+                    pool_ctrl.ctrl.SynchOne(axis, synch_description)
                 pool_ctrl.ctrl.SynchAll()
 
             # attaching listener (usually acquisition action)
@@ -172,7 +173,7 @@ class PoolSynchronization(PoolAction):
             if self._listener is not None:
                 if sw_synch_initial_domain is not None:
                     self._synch_soft.initial_domain = sw_synch_initial_domain
-                self._synch_soft.set_configuration(synchronization)
+                self._synch_soft.set_configuration(synch_description)
                 self._synch_soft.add_listener(self._listener)
                 remove_acq_listener = partial(self._synch_soft.remove_listener,
                                               self._listener)

--- a/src/sardana/pool/test/test_acquisition.py
+++ b/src/sardana/pool/test/test_acquisition.py
@@ -229,11 +229,11 @@ class DummyAcquisitionTestCase(AcquisitionTestCase, TestCase):
             SynchParam.Total: {SynchDomain.Time: total_interval},
             SynchParam.Repeats: repetitions
         }
-        synchronization = [group]
+        synch_description = [group]
         # get the current number of jobs
         jobs_before = get_thread_pool().qsize
         self.hw_acq.run(hw_ctrls, integ_time, repetitions, 0)
-        self.synchronization.run(synch_ctrls, synchronization)
+        self.synchronization.run(synch_ctrls, synch_description)
         # waiting for acquisition and synchronization to finish
         while (self.hw_acq.is_running()
                or self.sw_acq.is_running()
@@ -311,10 +311,10 @@ class BaseAcquisitionSoftwareTestCase(AcquisitionTestCase):
             SynchParam.Total: {SynchDomain.Time: total_interval},
             SynchParam.Repeats: repetitions
         }
-        synchronization = [group]
+        synch_description = [group]
         # get the current number of jobs
         jobs_before = get_thread_pool().qsize
-        self.synchronization.run([], synchronization)
+        self.synchronization.run([], synch_description)
         self.wait_finish()
         self.do_asserts(repetitions, jobs_before, strict=False)
 
@@ -370,10 +370,10 @@ class BaseAcquisitionSoftwareStartTestCase(AcquisitionTestCase):
             SynchParam.Total: {SynchDomain.Time: total_interval},
             SynchParam.Repeats: repetitions
         }
-        synchronization = [group]
+        synch_description = [group]
         # get the current number of jobs
         jobs_before = get_thread_pool().qsize
-        self.synchronization.run([], synchronization)
+        self.synchronization.run([], synch_description)
         self.wait_finish()
         self.do_asserts(repetitions, jobs_before, strict=False)
 
@@ -415,11 +415,11 @@ class BaseAcquisitionHardwareTestCase(AcquisitionTestCase):
             SynchParam.Total: {SynchDomain.Time: total_interval},
             SynchParam.Repeats: repetitions
         }
-        synchronization = [group]
+        synch_description = [group]
         # get the current number of jobs
         jobs_before = get_thread_pool().qsize
         self.acquisition.run(ctrls, integ_time, repetitions, 0)
-        self.synchronization.run(synch_ctrls, synchronization)
+        self.synchronization.run(synch_ctrls, synch_description)
         self.wait_finish()
         self.do_asserts(repetitions, jobs_before)
 

--- a/src/sardana/pool/test/test_measurementgroup.py
+++ b/src/sardana/pool/test/test_measurementgroup.py
@@ -102,7 +102,8 @@ class BaseAcquisition(object):
                 (ch_name, ch_data_len, repetitions)
             self.assertEqual(ch_data_len, repetitions, msg)
 
-    def meas_double_acquisition(self, config, synch_description, moveable=None):
+    def meas_double_acquisition(self, config, synch_description,
+                                moveable=None):
         """ Run two acquisition with the same measurement group, first with
         multiple repetitions and then one repetition.
         """
@@ -224,7 +225,8 @@ class BaseAcquisition(object):
     def meas_contpos_acquisition(self, config, synch_description, moveable,
                                  second_config=None):
         # TODO: this code is ready only for one group configuration
-        initial = synch_description[0][SynchParam.Initial][SynchDomain.Position]
+        initial = \
+            synch_description[0][SynchParam.Initial][SynchDomain.Position]
         total = synch_description[0][SynchParam.Total][SynchDomain.Position]
         repeats = synch_description[0][SynchParam.Repeats]
         position = initial + total * repeats
@@ -255,30 +257,30 @@ class BaseAcquisition(object):
 
 
 synch_description1 = [{SynchParam.Delay: {SynchDomain.Time: 0},
-                     SynchParam.Active: {SynchDomain.Time: .01},
-                     SynchParam.Total: {SynchDomain.Time: .02},
-                     SynchParam.Repeats: 10}]
+                       SynchParam.Active: {SynchDomain.Time: .01},
+                       SynchParam.Total: {SynchDomain.Time: .02},
+                       SynchParam.Repeats: 10}]
 
 synch_description2 = [{SynchParam.Delay: {SynchDomain.Time: 0},
-                     SynchParam.Active: {SynchDomain.Time: .01},
-                     SynchParam.Total: {SynchDomain.Time: .02},
-                     SynchParam.Repeats: 100}]
+                       SynchParam.Active: {SynchDomain.Time: .01},
+                       SynchParam.Total: {SynchDomain.Time: .02},
+                       SynchParam.Repeats: 100}]
 
 synch_description3 = [{SynchParam.Delay: {SynchDomain.Time: .1},
-                     SynchParam.Initial: {SynchDomain.Position: 0},
-                     SynchParam.Active: {SynchDomain.Position: .1,
+                       SynchParam.Initial: {SynchDomain.Position: 0},
+                       SynchParam.Active: {SynchDomain.Position: .1,
                                          SynchDomain.Time: .01, },
-                     SynchParam.Total: {SynchDomain.Position: .2,
+                       SynchParam.Total: {SynchDomain.Position: .2,
                                         SynchDomain.Time: .1},
-                     SynchParam.Repeats: 10}]
+                       SynchParam.Repeats: 10}]
 
 synch_description4 = [{SynchParam.Delay: {SynchDomain.Time: 0.1},
-                     SynchParam.Initial: {SynchDomain.Position: 0},
-                     SynchParam.Active: {SynchDomain.Position: -.1,
-                                         SynchDomain.Time: .01, },
-                     SynchParam.Total: {SynchDomain.Position: -.2,
-                                        SynchDomain.Time: .1},
-                     SynchParam.Repeats: 10}]
+                       SynchParam.Initial: {SynchDomain.Position: 0},
+                       SynchParam.Active: {SynchDomain.Position: -.1,
+                                          SynchDomain.Time: .01, },
+                       SynchParam.Total: {SynchDomain.Position: -.2,
+                                          SynchDomain.Time: .1},
+                       SynchParam.Repeats: 10}]
 
 doc_1 = 'Synchronized acquisition with two channels from the same controller'\
         ' using the same trigger'

--- a/src/sardana/pool/test/test_measurementgroup.py
+++ b/src/sardana/pool/test/test_measurementgroup.py
@@ -102,38 +102,38 @@ class BaseAcquisition(object):
                 (ch_name, ch_data_len, repetitions)
             self.assertEqual(ch_data_len, repetitions, msg)
 
-    def meas_double_acquisition(self, config, synchronization, moveable=None):
+    def meas_double_acquisition(self, config, synch_description, moveable=None):
         """ Run two acquisition with the same measurement group, first with
         multiple repetitions and then one repetition.
         """
         channel_names = self.prepare_meas(config)
         # setting measurement parameters
-        self.pmg.set_synchronization(synchronization)
+        self.pmg.set_synch_description(synch_description)
         self.pmg.set_moveable(moveable, to_fqdn=False)
         repetitions = 0
-        for group in synchronization:
+        for group in synch_description:
             repetitions += group[SynchParam.Repeats]
         self.prepare_attribute_listener()
         self.acquire()
         self.acq_asserts(channel_names, repetitions)
         self.remove_attribute_listener()
-        synchronization = [{SynchParam.Delay: {SynchDomain.Time: 0},
-                            SynchParam.Active: {SynchDomain.Time: 0.1},
-                            SynchParam.Total: {SynchDomain.Time: 0.2},
-                            SynchParam.Repeats: 1}]
-        self.pmg.synchronization = synchronization
+        synch_description = [{SynchParam.Delay: {SynchDomain.Time: 0},
+                              SynchParam.Active: {SynchDomain.Time: 0.1},
+                              SynchParam.Total: {SynchDomain.Time: 0.2},
+                              SynchParam.Repeats: 1}]
+        self.pmg.synch_description = synch_description
         self.acquire()
         # TODO: implement asserts of Timer acquisition
 
-    def meas_double_acquisition_samemode(self, config, synchronization,
+    def meas_double_acquisition_samemode(self, config, synch_description,
                                          moveable=None):
         """ Run two acquisition with the same measurement group.
         """
         channel_names = self.prepare_meas(config)
-        self.pmg.set_synchronization(synchronization)
+        self.pmg.set_synch_description(synch_description)
         self.pmg.set_moveable(moveable, to_fqdn=False)
         repetitions = 0
-        for group in synchronization:
+        for group in synch_description:
             repetitions += group[SynchParam.Repeats]
         self.prepare_attribute_listener()
         self.acquire()
@@ -145,7 +145,7 @@ class BaseAcquisition(object):
         self.remove_attribute_listener()
         # TODO: implement asserts of Timer acquisition
 
-    def consecutive_acquisitions(self, pool, config, synchronization):
+    def consecutive_acquisitions(self, pool, config, synch_description):
         # creating mg user configuration and obtaining channel ids
         mg_conf, channel_ids, channel_names = createMGUserConfiguration(
             pool, config)
@@ -153,23 +153,23 @@ class BaseAcquisition(object):
         # setting mg configuration - this cleans the action cache!
         self.pmg.set_configuration_from_user(mg_conf, to_fqdn=False)
         repetitions = 0
-        for group in synchronization:
+        for group in synch_description:
             repetitions += group[SynchParam.Repeats]
         self.prepare_attribute_listener()
         self.acquire()
         self.acq_asserts(channel_names, repetitions)
 
-    def meas_cont_acquisition(self, config, synchronization, moveable=None,
+    def meas_cont_acquisition(self, config, synch_description, moveable=None,
                               second_config=None):
         """Executes measurement using the measurement group.
         Checks the lengths of the acquired data.
         """
         jobs_before = get_thread_pool().qsize
         channel_names = self.prepare_meas(config)
-        self.pmg.set_synchronization(synchronization)
+        self.pmg.set_synch_description(synch_description)
         self.pmg.set_moveable(moveable, to_fqdn=False)
         repetitions = 0
-        for group in synchronization:
+        for group in synch_description:
             repetitions += group[SynchParam.Repeats]
         self.prepare_attribute_listener()
         self.acquire()
@@ -177,7 +177,7 @@ class BaseAcquisition(object):
 
         if second_config is not None:
             self.consecutive_acquisitions(
-                self.pool, second_config, synchronization)
+                self.pool, second_config, synch_description)
 
         # checking if there are no pending jobs
         jobs_after = get_thread_pool().qsize
@@ -189,13 +189,13 @@ class BaseAcquisition(object):
         """Method used to abort a running acquisition"""
         self.pmg.stop()
 
-    def meas_cont_stop_acquisition(self, config, synchronization,
+    def meas_cont_stop_acquisition(self, config, synch_description,
                                    moveable=None):
         """Executes measurement using the measurement group and tests that the
         acquisition can be stopped.
         """
         self.prepare_meas(config)
-        self.pmg.synchronization = synchronization
+        self.pmg.synch_description = synch_description
         self.pmg.set_moveable(moveable, to_fqdn=False)
         self.prepare_attribute_listener()
 
@@ -221,22 +221,22 @@ class BaseAcquisition(object):
                 enumerate(zip(*list(self.attr_listener.data.values()))):
             print(i, record)
 
-    def meas_contpos_acquisition(self, config, synchronization, moveable,
+    def meas_contpos_acquisition(self, config, synch_description, moveable,
                                  second_config=None):
         # TODO: this code is ready only for one group configuration
-        initial = synchronization[0][SynchParam.Initial][SynchDomain.Position]
-        total = synchronization[0][SynchParam.Total][SynchDomain.Position]
-        repeats = synchronization[0][SynchParam.Repeats]
+        initial = synch_description[0][SynchParam.Initial][SynchDomain.Position]
+        total = synch_description[0][SynchParam.Total][SynchDomain.Position]
+        repeats = synch_description[0][SynchParam.Repeats]
         position = initial + total * repeats
         mot = self.mots[moveable]
         mot.set_base_rate(0)
         mot.set_acceleration(0.1)
         mot.set_velocity(0.5)
         channel_names = self.prepare_meas(config)
-        self.pmg.synchronization = synchronization
+        self.pmg.synch_description = synch_description
         self.pmg.set_moveable(moveable, to_fqdn=False)
         repetitions = 0
-        for group in synchronization:
+        for group in synch_description:
             repetitions += group[SynchParam.Repeats]
         self.prepare_attribute_listener()
         self.pmg.prepare()
@@ -254,17 +254,17 @@ class BaseAcquisition(object):
         self.pmg = None
 
 
-synchronization1 = [{SynchParam.Delay: {SynchDomain.Time: 0},
+synch_description1 = [{SynchParam.Delay: {SynchDomain.Time: 0},
                      SynchParam.Active: {SynchDomain.Time: .01},
                      SynchParam.Total: {SynchDomain.Time: .02},
                      SynchParam.Repeats: 10}]
 
-synchronization2 = [{SynchParam.Delay: {SynchDomain.Time: 0},
+synch_description2 = [{SynchParam.Delay: {SynchDomain.Time: 0},
                      SynchParam.Active: {SynchDomain.Time: .01},
                      SynchParam.Total: {SynchDomain.Time: .02},
                      SynchParam.Repeats: 100}]
 
-synchronization3 = [{SynchParam.Delay: {SynchDomain.Time: .1},
+synch_description3 = [{SynchParam.Delay: {SynchDomain.Time: .1},
                      SynchParam.Initial: {SynchDomain.Position: 0},
                      SynchParam.Active: {SynchDomain.Position: .1,
                                          SynchDomain.Time: .01, },
@@ -272,7 +272,7 @@ synchronization3 = [{SynchParam.Delay: {SynchDomain.Time: .1},
                                         SynchDomain.Time: .1},
                      SynchParam.Repeats: 10}]
 
-synchronization4 = [{SynchParam.Delay: {SynchDomain.Time: 0.1},
+synch_description4 = [{SynchParam.Delay: {SynchDomain.Time: 0.1},
                      SynchParam.Initial: {SynchDomain.Position: 0},
                      SynchParam.Active: {SynchDomain.Position: -.1,
                                          SynchDomain.Time: .01, },
@@ -355,25 +355,25 @@ config_15 = [[('_test_2d_1_1', 'software', AcqSynchType.Trigger)]]
 
 # TODO: listener is not ready to handle 2D
 # @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_15,
-#             config=config_15, synchronization=synchronization1)
+#             config=config_15, synch_description=synch_description1)
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_14,
-            config=config_14, synchronization=synchronization1)
+            config=config_14, synch_description=synch_description1)
 @insertTest(helper_name='meas_contpos_acquisition', test_method_doc=doc_12,
-            config=config_12, synchronization=synchronization4,
+            config=config_12, synch_description=synch_description4,
             moveable="_test_mot_1_1")
 @insertTest(helper_name='meas_contpos_acquisition', test_method_doc=doc_12,
-            config=config_12, synchronization=synchronization3,
+            config=config_12, synch_description=synch_description3,
             moveable="_test_mot_1_1")
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_1,
-            config=config_1, synchronization=synchronization1)
+            config=config_1, synch_description=synch_description1)
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_2,
-            config=config_2, synchronization=synchronization1)
+            config=config_2, synch_description=synch_description1)
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_3,
-            config=config_3, synchronization=synchronization1)
+            config=config_3, synch_description=synch_description1)
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_4,
-            config=config_4, synchronization=synchronization1)
+            config=config_4, synch_description=synch_description1)
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_5,
-            config=config_5, synchronization=synchronization1)
+            config=config_5, synch_description=synch_description1)
 # TODO: implement dedicated asserts/test for only software synchronized
 #       acquisition.
 #       Until this TODO gets implemented we comment the test since it may
@@ -383,24 +383,24 @@ config_15 = [[('_test_2d_1_1', 'software', AcqSynchType.Trigger)]]
 # @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_6,
 #             params=params_1, config=config_6)
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_7,
-            config=config_7, synchronization=synchronization1)
+            config=config_7, synch_description=synch_description1)
 @insertTest(helper_name='meas_cont_stop_acquisition', test_method_doc=doc_8,
-            config=config_7, synchronization=synchronization2)
+            config=config_7, synch_description=synch_description2)
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_9,
             config=config_1, second_config=config_7,
-            synchronization=synchronization1)
+            synch_description=synch_description1)
 @insertTest(helper_name='meas_double_acquisition', test_method_doc=doc_10,
-            config=config_7, synchronization=synchronization2)
+            config=config_7, synch_description=synch_description2)
 @insertTest(helper_name='meas_double_acquisition', test_method_doc=doc_10,
-            config=config_4, synchronization=synchronization1)
+            config=config_4, synch_description=synch_description1)
 @insertTest(helper_name='meas_double_acquisition_samemode', test_method_doc=doc_11,
-            config=config_11, synchronization=synchronization2)
+            config=config_11, synch_description=synch_description2)
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_9,
             config=config_1, second_config=config_7,
-            synchronization=synchronization1)
+            synch_description=synch_description1)
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_13,
             config=config_13,
-            synchronization=synchronization1)
+            synch_description=synch_description1)
 class AcquisitionTestCase(BasePoolTestCase, BaseAcquisition, unittest.TestCase):
     """Integration test of TGGeneration and Acquisition actions."""
 

--- a/src/sardana/pool/test/test_measurementgroup.py
+++ b/src/sardana/pool/test/test_measurementgroup.py
@@ -277,7 +277,7 @@ synch_description3 = [{SynchParam.Delay: {SynchDomain.Time: .1},
 synch_description4 = [{SynchParam.Delay: {SynchDomain.Time: 0.1},
                        SynchParam.Initial: {SynchDomain.Position: 0},
                        SynchParam.Active: {SynchDomain.Position: -.1,
-                                          SynchDomain.Time: .01, },
+                                           SynchDomain.Time: .01, },
                        SynchParam.Total: {SynchDomain.Position: -.2,
                                           SynchDomain.Time: .1},
                        SynchParam.Repeats: 10}]

--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -73,7 +73,7 @@ class MeasurementGroup(PoolGroupDevice):
     def init_device(self):
         PoolGroupDevice.init_device(self)
         # state and status are already set by the super class
-        detect_evts = "moveable", "synchronization", \
+        detect_evts = "moveable", "synchdescription", \
                       "softwaresynchronizerinitialdomain"
         # TODO: nbstarts could be moved to detect events with
         # abs_change criteria of 1, but be careful with
@@ -142,7 +142,7 @@ class MeasurementGroup(PoolGroupDevice):
             cfg = self.measurement_group.get_user_configuration()
             codec = CodecFactory().getCodec('json')
             _, event_value = codec.encode(('', cfg))
-        elif name == "synchronization":
+        elif name == "synchdescription":
             codec = CodecFactory().getCodec('json')
             _, event_value = codec.encode(('', event_value))
         elif name == "moveable" and event_value is None:
@@ -158,8 +158,8 @@ class MeasurementGroup(PoolGroupDevice):
                            quality=quality, priority=priority, error=error,
                            synch=False)
 
-    def _synchronization_str2enum(self, synchronization_str):
-        """Translates synchronization data structure so it uses
+    def _synch_description_str2enum(self, _synch_description_str):
+        """Translates synchronization description data structure so it uses
         SynchParam and SynchDomain enums as keys instead of strings.
 
         .. todo:: At some point remove the backwards compatibility
@@ -167,8 +167,8 @@ class MeasurementGroup(PoolGroupDevice):
           serialized to "<class>.<attr>" e.g. "SynchDomain.Time" and we were
           using a class method `fromStr` to interpret the enumeration objects.
         """
-        synchronization = []
-        for group_str in synchronization_str:
+        synch_description = []
+        for group_str in _synch_description_str:
             group = {}
             for param_str, conf_str in group_str.items():
                 try:
@@ -186,8 +186,8 @@ class MeasurementGroup(PoolGroupDevice):
                 else:
                     conf = conf_str
                 group[param] = conf
-            synchronization.append(group)
-        return synchronization
+            synch_description.append(group)
+        return synch_description
 
     def always_executed_hook(self):
         pass
@@ -265,18 +265,19 @@ class MeasurementGroup(PoolGroupDevice):
             moveable = None
         self.measurement_group.moveable = moveable
 
-    def read_Synchronization(self, attr):
-        synchronization = self.measurement_group.synchronization
+    def read_SynchDescription(self, attr):
+        synch_description = self.measurement_group.synch_description
         codec = CodecFactory().getCodec('json')
-        data = codec.encode(('', synchronization))
+        data = codec.encode(('', synch_description))
         attr.set_value(data[1])
 
-    def write_Synchronization(self, attr):
+    def write_SynchDescription(self, attr):
         data = attr.get_write_value()
-        synchronization = CodecFactory().decode(('json', data))
+        synch_description = CodecFactory().decode(('json', data))
         # translate dictionary keys
-        synchronization = self._synchronization_str2enum(synchronization)
-        self.measurement_group.synchronization = synchronization
+        synch_description = \
+            self._synch_description_str2enum(synch_description)
+        self.measurement_group.synch_description = synch_description
 
     def read_LatencyTime(self, attr):
         latency_time = self.measurement_group.latency_time
@@ -355,10 +356,10 @@ class MeasurementGroupClass(PoolGroupDeviceClass):
         'Moveable': [[DevString, SCALAR, READ_WRITE],
                      {'Memorized': "true",
                       'Display level': DispLevel.EXPERT}],
-        # TODO: Does it have sense to memorize Synchronization?
-        'Synchronization': [[DevString, SCALAR, READ_WRITE],
-                            {'Memorized': "true",
-                             'Display level': DispLevel.EXPERT}],
+        # TODO: Does it have sense to memorize SynchDescription?
+        'SynchDescription': [[DevString, SCALAR, READ_WRITE],
+                                       {'Memorized': "true",
+                                       'Display level': DispLevel.EXPERT}],
         'LatencyTime': [[DevDouble, SCALAR, READ],
                         {'Display level': DispLevel.EXPERT}],
         'SoftwareSynchronizerInitialDomain': [[DevString, SCALAR, READ_WRITE],

--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -358,8 +358,8 @@ class MeasurementGroupClass(PoolGroupDeviceClass):
                       'Display level': DispLevel.EXPERT}],
         # TODO: Does it have sense to memorize SynchDescription?
         'SynchDescription': [[DevString, SCALAR, READ_WRITE],
-                                       {'Memorized': "true",
-                                       'Display level': DispLevel.EXPERT}],
+                             {'Memorized': "true",
+                              'Display level': DispLevel.EXPERT}],
         'LatencyTime': [[DevDouble, SCALAR, READ],
                         {'Display level': DispLevel.EXPERT}],
         'SoftwareSynchronizerInitialDomain': [[DevString, SCALAR, READ_WRITE],

--- a/src/sardana/tango/pool/test/test_measurementgroup.py
+++ b/src/sardana/tango/pool/test/test_measurementgroup.py
@@ -171,10 +171,10 @@ class MeasSarTestTestCase(SarTestTestCase):
     def prepare_meas(self, params):
         """ Set the measurement group parameters
         """
-        synchronization = params["synchronization"]
+        synch_description = params["synch_description"]
         codec = CodecFactory().getCodec('json')
-        data = codec.encode(('', synchronization))
-        self.meas.write_attribute('synchronization', data[1])
+        data = codec.encode(('', synch_description))
+        self.meas.write_attribute('SynchDescription', data[1])
 
     def _add_attribute_listener(self, config):
         self.attr_listener = TangoAttributeListener()
@@ -225,7 +225,7 @@ class MeasSarTestTestCase(SarTestTestCase):
             print("Acquiring...")
             time.sleep(0.1)
         time.sleep(1)
-        repetitions = params['synchronization'][0][SynchParam.Repeats]
+        repetitions = params['synch_description'][0][SynchParam.Repeats]
         self._acq_asserts(chn_names, repetitions)
 
     def stop_meas_cont_acquisition(self, params, config):
@@ -269,13 +269,13 @@ class MeasSarTestTestCase(SarTestTestCase):
         SarTestTestCase.tearDown(self)
 
 
-synchronization1 = [{SynchParam.Delay: {SynchDomain.Time: 0},
+synch_description1 = [{SynchParam.Delay: {SynchDomain.Time: 0},
                      SynchParam.Active: {SynchDomain.Time: .01},
                      SynchParam.Total: {SynchDomain.Time: .02},
                      SynchParam.Repeats: 10}]
 
 params_1 = {
-    "synchronization": synchronization1,
+    "synch_description": synch_description1,
     "integ_time": 0.01,
     "name": '_exp_01'
 }

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -2481,16 +2481,16 @@ class MeasurementGroup(PoolElement):
     def setAcquisitionMode(self, acqMode):
         self.getAcquisitionModeObj().write(acqMode)
 
-    def getSynchronizationObj(self):
-        return self._getAttrEG('Synchronization')
+    def getSynchDescriptionObj(self):
+        return self._getAttrEG('SynchDescription')
 
-    def getSynchronization(self):
-        return self._getAttrValue('Synchronization')
+    def getSynchDescription(self):
+        return self._getAttrValue('SynchDescription')
 
-    def setSynchronization(self, synchronization):
+    def setSynchDescription(self, synch_description):
         codec = CodecFactory().getCodec('json')
-        _, data = codec.encode(('', synchronization))
-        self.getSynchronizationObj().write(data)
+        _, data = codec.encode(('', synch_description))
+        self.getSynchDescriptionObj().write(data)
         self._last_integ_time = None
 
     def _get_channels_for_elements(self, elements):
@@ -2839,7 +2839,7 @@ class MeasurementGroup(PoolElement):
             controllers or channels (default: `False` means return channels)
         :type ret_by_ctrl: bool
         :return: ordered dictionary where keys are **channel** names (or full
-            names if `ret_full_name=True`) and values are their synchronization
+            names if `ret_full_name=True`) and values are their timer
             configurations
         :rtype: dict(str, str)
         """
@@ -2894,7 +2894,7 @@ class MeasurementGroup(PoolElement):
             controllers or channels (default: `False` means return channels)
         :type ret_by_ctrl: bool
         :return: ordered dictionary where keys are **channel** names (or full
-            names if `ret_full_name=True`) and values are their synchronization
+            names if `ret_full_name=True`) and values are their monitor
             configurations
         :rtype: dict(str, str)
         """
@@ -2952,7 +2952,7 @@ class MeasurementGroup(PoolElement):
             controllers or channels (default: `False` means return channels)
         :type ret_by_ctrl: bool
         :return: ordered dictionary where keys are **channel** names (or full
-            names if `ret_full_name=True`) and values are their synchronization
+            names if `ret_full_name=True`) and values are their synchronizer
             configurations
         :rtype: dict(str, str)
         """
@@ -3315,12 +3315,13 @@ class MeasurementGroup(PoolElement):
         self.prepare()
         return self.count_raw(start_time)
 
-    def count_continuous(self, synchronization, value_buffer_cb=None):
+    def count_continuous(self, synch_description, value_buffer_cb=None):
         """Execute measurement process according to the given synchronization
         description.
 
-        :param synchronization: synchronization description
-        :type synchronization: list of groups with equidistant synchronizations
+        :param synch_description: synchronization description
+        :type synch_description: list of groups with equidistant
+          synchronizations
         :param value_buffer_cb: callback on value buffer updates
         :type value_buffer_cb: callable
         :return: state and eventually value buffers if no callback was passed
@@ -3336,7 +3337,7 @@ class MeasurementGroup(PoolElement):
         start_time = time.time()
         cfg = self.getConfiguration()
         cfg.prepare()
-        self.setSynchronization(synchronization)
+        self.setSynchDescription(synch_description)
         self.prepare()
         self.subscribeValueBuffer(value_buffer_cb)
         try:

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -3014,12 +3014,12 @@ class MeasurementGroup(PoolElement):
             synchronization configurations
         :rtype: dict<`str`, `sardana.pool.AcqSynchType`>
         """
-        # TODO: Implement solution to set the synchronization per channel when it
-        #  is allowed.
+        # TODO: Implement solution to set the synchronization per channel
+        #  when it is allowed.
         ctrls = self._get_ctrl_for_elements(elements)
         config = self.getConfiguration()
-        ctrls_sync = config._getCtrlsSynchronization(ctrls,
-                                                  use_fullname=ret_full_name)
+        ctrls_sync = \
+            config._getCtrlsSynchronization(ctrls, use_fullname=ret_full_name)
         if ret_by_ctrl:
             return ctrls_sync
         else:

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1879,9 +1879,7 @@ class MGConfiguration(object):
                 result[label] = None
                 continue
 
-            if key == 'synchronization':
-                value = AcqSynchType.get(value)
-            elif key in ['timer', 'monitor']:
+            if key in ['timer', 'monitor']:
                 value = self.channels[value]['label']
             elif key == 'synchronizer' and value != 'software':
                 value = DeviceProxy(value).alias()
@@ -2961,6 +2959,66 @@ class MeasurementGroup(PoolElement):
         ctrls = self._get_ctrl_for_elements(elements)
         config = self.getConfiguration()
         ctrls_sync = config._getCtrlsSynchronizer(ctrls,
+                                                  use_fullname=ret_full_name)
+        if ret_by_ctrl:
+            return ctrls_sync
+        else:
+            return self._get_value_per_channel(config, ctrls_sync,
+                                               use_fullname=ret_full_name)
+
+    def setSynchronization(self, synchronization, *elements, apply=True):
+        """Set the synchronization configuration for the given channels or
+        controller.
+
+        .. note:: Currently the controller's synchronization must be unique.
+           Hence this method will set it for the whole controller regardless of
+           the ``elements`` argument.
+
+        :param synchronization: synchronization type e.g. Trigger, Gate or
+          Start
+        :type synchronization: `sardana.pool.AcqSynchType`
+        :param elements: sequence of channels names or full names, no elements
+            means set to all
+        :type elements: list(str)
+        :param apply: `True` - apply on the server, `False` - do not apply yet
+            on the server and keep locally (default: `True`)
+        :type apply: bool
+        """
+        config = self.getConfiguration()
+        # TODO: Implement solution to set the synchronization per channel when
+        #  it is allowed.
+        ctrls = self._get_ctrl_for_elements(elements)
+        config._setCtrlsSynchronization(synchronization, ctrls,
+                                        apply_cfg=apply)
+
+    def getSynchronization(self, *elements, ret_full_name=False,
+                           ret_by_ctrl=False):
+        """Get the synchronization configuration of the given elements.
+
+        Channels and controllers are accepted as elements. Getting the output
+        from the controller means getting it from all channels of this
+        controller present in this measurement group, unless
+        `ret_by_ctrl=True`.
+
+        :param elements: sequence of element names or full names, no elements
+            means get from all
+        :type elements: list(str)
+        :param ret_full_name: whether keys in the returned dictionary are
+            full names or names (default: `False` means return names)
+        :type ret_full_name: bool
+        :param ret_by_ctrl: whether keys in the returned dictionary are
+            controllers or channels (default: `False` means return channels)
+        :type ret_by_ctrl: bool
+        :return: ordered dictionary where keys are **channel** names (or full
+            names if `ret_full_name=True`) and values are their
+            synchronization configurations
+        :rtype: dict<`str`, `sardana.pool.AcqSynchType`>
+        """
+        # TODO: Implement solution to set the synchronization per channel when it
+        #  is allowed.
+        ctrls = self._get_ctrl_for_elements(elements)
+        config = self.getConfiguration()
+        ctrls_sync = config._getCtrlsSynchronization(ctrls,
                                                   use_fullname=ret_full_name)
         if ret_by_ctrl:
             return ctrls_sync

--- a/src/sardana/taurus/core/tango/sardana/test/test_measgrpconf.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_measgrpconf.py
@@ -428,7 +428,7 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
             self._assertMultipleResults(result, elements, expected)
 
             mg.setSynchronization(AcqSynchType.Start, "_test_ct_ctrl_1",
-                               "_test_2d_ctrl_1")
+                                  "_test_2d_ctrl_1")
             result = mg.getSynchronization()
             expected = [AcqSynchType.Start, AcqSynchType.Start,
                         AcqSynchType.Start, AcqSynchType.Start, None]
@@ -436,7 +436,7 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
 
             with self.assertRaises(Exception):
                 mg.setSynchronization('asdf', "_test_ct_ctrl_1",
-                                   "_test_2d_ctrl_1")
+                                      "_test_2d_ctrl_1")
 
             # Check ret_full_name
             v = TangoDeviceNameValidator()

--- a/src/sardana/taurus/core/tango/sardana/test/test_measgrpconf.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_measgrpconf.py
@@ -18,7 +18,6 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
 
     def _assertResult(self, result, channels, expected_value):
         expected_channels = list(channels)
-        print(result)
         for channel, value in result.items():
             msg = "unexpected key: {}".format(channel)
             self.assertIn(channel, expected_channels, msg)
@@ -29,7 +28,6 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
 
     def _assertMultipleResults(self, result, channels, expected_values):
         expected_channels = list(channels)
-        print(result)
         for (channel, value), expected_value in zip(result.items(),
                                                     expected_values):
             msg = "unexpected key: {}".format(channel)
@@ -170,7 +168,6 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
             self._assertMultipleResults(plottype, elements, expected_values)
             with self.assertRaises(ValueError):
                 mg.setPlotType("asdf", elements[2])
-            print(mg.getPlotType())
 
             # Redefine elements
             elements = ["_test_ct_1_1", "_test_ct_1_2", "_test_ct_1_3"]
@@ -246,7 +243,6 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
                 mg.setPlotAxes(["<mov>", "<idx>"], elements[1])
             with self.assertRaises(ValueError):
                 mg.setPlotAxes(["<mov>"], elements[0])
-            print(mg.getPlotAxes())
 
             elements = ["_test_ct_1_1", "_test_ct_1_2", "_test_ct_1_3"]
             # Set values using the controller instead of channels
@@ -322,7 +318,6 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
                                      '_test_2d_1_2',
                                      "_test_mt_1_3/position"]):
         mg_name = str(uuid.uuid1())
-        print(mg_name)
         argin = [mg_name] + elements
         self.pool.CreateMeasurementGroup(argin)
         try:


### PR DESCRIPTION
As agreed in https://github.com/sardana-org/sardana/pull/867#issuecomment-561742834 this PR renames the MeasurementGroup's Synchronization Tango attribute, core property and Taurus extension methods.

In the above discussion there were two votes in favor of `SynchronizationDescription` (@teresanunez and @droldan) since this is more descriptive and one in favor of `SynchronizationPlan` (@rhomspuron) since this is shorter.
Finally I had chosen the name `SynchDescription` which I think is a good compromise between these two arguments. Hope you like it. 

This PR also:
* adds the `getSynchronization` and `setSynchtronization` MeasurementGroup configuration methods and their tests
* adds the synchronization parameter to `get_meas_conf` and `set_meas_conf` macro.

I will automerge if travis is green since this RP is just executing a rename which was previously agreed.