### PR TITLE
Add docs on how to access Tango in macros and controllers

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -291,13 +291,13 @@ graphviz_output_format = 'png'  # 'svg'
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'numpy': ('https://numpy.org/doc/stable', None),
     'ipython': ('http://ipython.org/ipython-doc/stable/', None),
     'pytango': ('https://pytango.readthedocs.io/en/stable/', None),
     'taurus': ('http://taurus-scada.org', None),
     'pyqt': ('https://www.riverbankcomputing.com/static/Docs/PyQt5/', None),
     'matplotlib': ('https://matplotlib.org/', None),
-    'guiqwt': ('https://pythonhosted.org/guiqwt/', None),
+    'guiqwt': ('https://guiqwt.readthedocs.io/en/latest/', None),
 }
 
 

--- a/doc/source/devel/api/sardana/pool/poolutil.rst
+++ b/doc/source/devel/api/sardana/pool/poolutil.rst
@@ -1,8 +1,20 @@
 .. currentmodule:: sardana.pool.poolutil
 
 :mod:`~sardana.pool.poolutil`
-=========================================
+=============================
 
 .. automodule:: sardana.pool.poolutil
 
+.. rubric:: Singletons
+
+.. autodata:: PoolUtil
+
 .. rubric:: Classes
+
+_PoolUtil
+---------
+
+.. autoclass:: _PoolUtil
+    :show-inheritance:
+    :members:
+    :undoc-members:

--- a/doc/source/devel/howto_controllers/howto_controller.rst
+++ b/doc/source/devel/howto_controllers/howto_controller.rst
@@ -538,6 +538,31 @@ Example::
         except:
             pass
 
+.. _sardana-controller-accessing-tango:
+
+Accessing Tango from your controllers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is a very common pattern that when integrating a new hardware (or
+eventually a software component) in Sardana you start from a Tango Device
+Server (either already existing one or you develop one as an intermediate
+layer). In this case your controller will need to access Tango and there are
+two ways od doing that, either with Taurus_ (using `taurus.Device`) or
+with PyTango_ (using `tango.DeviceProxy`). Please consult a similar discussion
+:ref:`sardana-macro-accessing-tango` on which one to use.
+
+For accessing Sardana elements e.g.: motors, experimental channels, etc.
+currently there is no Sardana :term:`API` and you will need to use one of the
+above methods.
+
+.. note::
+  For a very simplified integration of Tango devices in Sardana you may
+  consider using
+  `sardana-tango controllers <https://github.com/ALBA-Synchrotron/sardana-tango>`_.
+
+
+
+
 .. rubric:: Footnotes
 
 .. [#f1] Pseudo controllers don't need to manage their individual axis. Therefore,

--- a/doc/source/devel/howto_controllers/howto_controller.rst
+++ b/doc/source/devel/howto_controllers/howto_controller.rst
@@ -547,7 +547,7 @@ It is a very common pattern that when integrating a new hardware (or
 eventually a software component) in Sardana you start from a Tango Device
 Server (either already existing one or you develop one as an intermediate
 layer). In this case your controller will need to access Tango and there are
-two ways od doing that, either with Taurus_ (using `taurus.Device`) or
+two ways of doing that, either with Taurus_ (using `taurus.Device`) or
 with PyTango_ (using `tango.DeviceProxy`). Please consult a similar discussion
 :ref:`sardana-macro-accessing-tango` on which one to use.
 

--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -935,7 +935,7 @@ measurement group, etc.
 
 There exists different :term:`API` to access to Tango_ devices.
 
-First, to access to Sardana elements it is recommended to use the Sardana
+First, to access Sardana elements it is recommended to use the Sardana
 :term:`API`: e.g.: `~sardana.macroserver.macro.Macro.getMoveable` to obtain
 any moveable (motor or pseudo motor),
 `~sardana.macroserver.macro.Macro.getMeasurementGroup` to obtain a measurement

--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -468,7 +468,7 @@ this parameter any name but usually, by convention it is called ``self``).
 your macro to do all kinds of things, among others, to obtain the sardana
 elements. The :ref:`Macro API reference <sardana-macro-api>` describes all
 these functions and the
-:ref:`Sardana-Taurus extensions API reference <sardana-taurus-api>`
+:ref:`Sardana-Taurus model API reference <sardana-taurus-api>`
 describes the obtained sardana elements.
 
 Let's say you want to write a macro that explicitly moves a known *theta* motor

--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -250,6 +250,8 @@ includes :keyword:`for` and :keyword:`while` loops, :keyword:`if` ...
             wave_fft = numpy.fft.fft(wave)
             
 
+.. _sardana-macro-parameters:
+
 Adding parameters to your macro
 -------------------------------
 

--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -922,6 +922,49 @@ using the :meth:`~sardana.macroserver.macro.Hookable.appendHook` method::
     the macro. Using the method appends just one hook but does not affect
     the general hooks eventually attached to the macro.
 
+.. _sardana-macro-accessing-tango:
+
+Accessing Tango from your macros
+--------------------------------
+
+Your macros almost certainly will need to access Tango_ devices, either
+external, for example, coming from the vacuum system or any other
+arbitrary system integrated with Tango Device Server or internal to Sardana
+(Sardana elements are currently exported as Tango devices) e.g.: motors,
+measurement group, etc.
+
+There exists different :term:`API` to access to Tango_ devices.
+
+First, to access to Sardana elements it is recommended to use the Sardana
+:term:`API`: e.g.: `~sardana.macroserver.macro.Macro.getMoveable` to obtain
+any moveable (motor or pseudo motor),
+`~sardana.macroserver.macro.Macro.getMeasurementGroup` to obtain a measurement
+group.
+
+.. note::
+    By :ref:`adding parameters to your macro <sardana-macro-parameters>`
+    you get the same objects as if you were using the above methods.
+    Their classes are documented in:
+    :ref:`Sardana-Taurus model API reference <sardana-taurus-api>`
+
+Any external Tango device could be accessed with Taurus_ (using
+`taurus.Device`) or simply with PyTango_ (using `tango.DeviceProxy`).
+Taurus gives you some benefits over PyTango:
+
+- seamless attribute configuration management e.g.: unit aware attribute
+  read and write, simplified way to read/write attribute configuration, etc.
+- unique way to access different data sources e.g. Tango_, EPICS_,
+  `hdf5 <https://github.com/taurus-org/h5file-scheme>`_, etc.
+- simplified way to use Tango_ events
+
+However the above benefits are not for free and more precisely are for some
+extra time overhead (in milliseconds range).
+
+As a rule of thumb, if you you don't mind the extra overhead and value the
+simplified usage you should use Taurus. If you strive for very optimal access
+to Tango and don't need these benefits then most probably PyTango will work
+better for you.
+
 .. _sardana-macro-using-external-libraries:
 
 Using external python libraries

--- a/doc/source/users/faq.rst
+++ b/doc/source/users/faq.rst
@@ -92,6 +92,16 @@ write Sardana controllers and pseudo controllers can be found
 This documentation also includes the :term:`API` which can be used to interface
 to the specific hardware item.
 
+How to access Tango from within macros or controllers
+--------------------------------------------------------------------------------
+In your macros and controllers almost certainly you will need to access Tango
+devices (including Sardana elements) to read or write their attributes,
+execute commands, etc. There exist different ways of accessing them: Sardana,
+Taurus or PyTango :term:`API`. See more on which to choose in this chapters:
+
+* :ref:`sardana-macro-accessing-tango`
+* :ref:`sardana-controller-accessing-tango`
+
 How to add your own file format?
 --------------------------------
 Documentation how to add your own file format can be found here **<LINK>**.

--- a/src/sardana/pool/poolutil.py
+++ b/src/sardana/pool/poolutil.py
@@ -43,6 +43,16 @@ class _PoolUtil(object):
         return self
 
     def get_device(self, *args, **kwargs):
+        """Factory method to create a single instance the `tango.DeviceProxy`
+        per controller instance.
+
+        :param ctrl_name: Controller name to which assign the proxy object
+        :type ctrl_name: `str`
+        :param device_name: Tango device name
+        :type device_name: `str`
+        :return: single device proxy object
+        :rtype: `tango.DeviceProxy`
+        """
         ctrl_name = args[0]
         device_name = args[1]
         with self._lock:
@@ -52,12 +62,20 @@ class _PoolUtil(object):
             dev = ctrl_devs.get(device_name)
             if dev is None:
                 import PyTango
-                ctrl_devs[device_name] = dev = PyTango.DeviceProxy(device_name)
+                ctrl_devs[device_name] = dev = \
+                    PyTango.DeviceProxy(device_name)
         return dev
 
     get_motor = get_phy_motor = get_pseudo_motor = get_motor_group = \
-        get_exp_channel = get_ct_channel = get_zerod_channel = get_oned_channel = \
-        get_twod_channel = get_pseudo_counter_channel = get_measurement_group = \
-        get_com_channel = get_ioregister = get_device
+        get_exp_channel = get_ct_channel = get_zerod_channel = \
+        get_oned_channel = get_twod_channel = get_pseudo_counter_channel = \
+        get_measurement_group = get_com_channel = get_ioregister = get_device
 
+
+#: Singleton instance of the `~sardana.pool.poolutil._PoolUtil` class.
+#:
+#: It is a factory of `tango.DeviceProxy` objects and ensures only one
+#: instance of such objects is created for the whole process.
+#: Please refer to the `~sardana.pool.poolutil._PoolUtil` API on the available
+#: methods.
 PoolUtil = _PoolUtil()

--- a/src/sardana/pool/poolutil.py
+++ b/src/sardana/pool/poolutil.py
@@ -43,7 +43,7 @@ class _PoolUtil(object):
         return self
 
     def get_device(self, *args, **kwargs):
-        """Factory method to create a single tango.DeviceProxy` instance
+        """Factory method to create a single `tango.DeviceProxy` instance
         per controller instance.
 
         :param ctrl_name: Controller name to which assign the proxy object

--- a/src/sardana/pool/poolutil.py
+++ b/src/sardana/pool/poolutil.py
@@ -62,8 +62,7 @@ class _PoolUtil(object):
             dev = ctrl_devs.get(device_name)
             if dev is None:
                 import PyTango
-                ctrl_devs[device_name] = dev = \
-                    PyTango.DeviceProxy(device_name)
+                ctrl_devs[device_name] = dev = PyTango.DeviceProxy(device_name)
         return dev
 
     get_motor = get_phy_motor = get_pseudo_motor = get_motor_group = \

--- a/src/sardana/pool/poolutil.py
+++ b/src/sardana/pool/poolutil.py
@@ -43,7 +43,7 @@ class _PoolUtil(object):
         return self
 
     def get_device(self, *args, **kwargs):
-        """Factory method to create a single instance the `tango.DeviceProxy`
+        """Factory method to create a single tango.DeviceProxy` instance
         per controller instance.
 
         :param ctrl_name: Controller name to which assign the proxy object


### PR DESCRIPTION
This documentation was requested by one of our scientists at ALBA. When migrating user macros to Python 3 we discovered that user macros were using several different ways of accessing to Tango devices. 

I tried to summarize what possibilities we have and give a simple rule of thumb on which one to use.

There is one more way which I have not documented yet. The `Macro.getDevice()` which currently does not give any benefit over `taurus.Device()`. But with the recent investigation of @tiagocoutinho on how Tango (and CORBA) optimizes socket connection from the client to the server I think we could change this method and make it maintain the reference to the `taurus.Device`. It is similarly done for the internal Sardana elements getters e.g. `getMotor`. @tiagocoutinho, if I understood well the connection is closed after some inactivity period. This way the only penalty of such a change would be the memory footprint of a `tango.DeviceProxy` and `taurus.Device` objects. What about the ZMQ socket for the configuration events?

Also I have not added to the _Accessing Tango from your controllers_ the possibility to use `sardana.pool.poolutil.PoolUtil` singleton. I think it has not real benefit over maintaining a reference to the `tango.DeviceProxy` in the controller itself. Unless we change the `PoolUtil` and maintain a gloabl proxy instead of one per controller instance.