### PR TITLE
Run sardana tests with pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   # run flake8 check on all python files in the project
   - if [ $TEST == "flake8" ]; then ci/flake8_diff.sh; fi
   # run the full testsuite
-  - if [ $TEST == "testsuite" ]; then docker exec sardana-test sardanatestsuite; fi
+  - if [ $TEST == "testsuite" ]; then docker exec sardana-test pytest /usr/local/lib/python3.5/dist-packages/sardana; fi
   # build docs
   - if [ $TEST == "doc" ]; then docker exec -t sardana-test /bin/bash -c "cd /sardana ; sphinx-build -W doc/source/ build/sphinx/html" ; fi
   - if [ $TEST == "doc" ]; then docker exec -t sardana-test /bin/bash -c "touch /sardana/build/sphinx/html/.nojekyll" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   # run flake8 check on all python files in the project
   - if [ $TEST == "flake8" ]; then ci/flake8_diff.sh; fi
   # run the full testsuite
-  - if [ $TEST == "testsuite" ]; then docker exec sardana-test pytest /usr/local/lib/python3.5/dist-packages/sardana-*.egg/sardana; fi
+  - if [ $TEST == "testsuite" ]; then docker exec -t sardana-test /bin/bash -c "pytest /usr/local/lib/python3.5/dist-packages/sardana-*.egg/sardana"; fi
   # build docs
   - if [ $TEST == "doc" ]; then docker exec -t sardana-test /bin/bash -c "cd /sardana ; sphinx-build -W doc/source/ build/sphinx/html" ; fi
   - if [ $TEST == "doc" ]; then docker exec -t sardana-test /bin/bash -c "touch /sardana/build/sphinx/html/.nojekyll" ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   # run flake8 check on all python files in the project
   - if [ $TEST == "flake8" ]; then ci/flake8_diff.sh; fi
   # run the full testsuite
-  - if [ $TEST == "testsuite" ]; then docker exec sardana-test pytest /usr/local/lib/python3.5/dist-packages/sardana; fi
+  - if [ $TEST == "testsuite" ]; then docker exec sardana-test pytest /usr/local/lib/python3.5/dist-packages/sardana-*.egg/sardana; fi
   # build docs
   - if [ $TEST == "doc" ]; then docker exec -t sardana-test /bin/bash -c "cd /sardana ; sphinx-build -W doc/source/ build/sphinx/html" ; fi
   - if [ $TEST == "doc" ]; then docker exec -t sardana-test /bin/bash -c "touch /sardana/build/sphinx/html/.nojekyll" ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ This file follows the formats and conventions from [keepachangelog.com]
 * `showscan online_raw` magic command in spock (#1260)
 * `online` kwarg in `SpockBaseDoor` constructor (#1260)
 * `sardana.requirements` (#1185)
+* `sardanatestsuite` and `sardana.test.testsuite.*` utility functions (#1347)
 
 
 ## [2.8.5] 2020-04-27

--- a/doc/source/devel/howto_test/test_general.rst
+++ b/doc/source/devel/howto_test/test_general.rst
@@ -29,23 +29,19 @@ revealing the bug.
 The first tests implemented are focused on Unit Tests, but the same framework
 should be used for integration and system tests as well.
 
-The sardana.test module includes testsuite.py. This file provides an 
-auto-discovering suite for all tests implemented in Sardana.
-
 The following are some key points to keep in mind when using this framework:
 
-- The Sardana Test Framework is based on :mod:`unittest` which should be 
-  imported from :mod:`taurus.external` in order to be compatible with all 
-  versions of python supported by Taurus. 
-
-- all test-related code is contained in submodules named `test` which appear 
+* Most of the tests in the Sardana Test Framework use :mod:`unittest`.
+  Since Sardana Jan20 we decided to move to `pytest <https://docs.pytest.org>`_
+  and we plan to gradually migrate the already existing tests.
+* All test-related code is contained in submodules named ``test`` which appear
   in any module of Sardana.
-  
-- test-related code falls in one of these three categories: 
-    * Actual test code (classes that derive from unittest.TestCase)
-    * Utility classes/functions (code to simplify development of test code)
-    * Resources (accessory files required by some test). They are located in 
-      subdirectories named `res` situated inside the folders named `test`. 
+* Test related code falls in one of these three categories:
+
+  * Actual test code (classes that derive from unittest.TestCase)
+  * Utility classes/functions (code to simplify development of test code)
+  * Resources (accessory files required by some test). They are located in
+    subdirectories named ``res`` situated inside the folders named ``test``.
 
 For a more complete description of the conventions on how to write tests with
 the Sardana Testing Framework, please refer to the 

--- a/doc/source/devel/howto_test/test_run_commands.rst
+++ b/doc/source/devel/howto_test/test_run_commands.rst
@@ -10,35 +10,13 @@ Run tests from command line
 Run test suite
 --------------
 
-Running the Sardana test suite from command line can be done in two
-different ways:
+We recommend using pytest to run Sardana tests. Please refer to
+`pytest documentation <https://docs.pytest.org/en/latest/usage.html>`_
+on how to execute tests.
 
-1) Sardana tests can be executed using the `setuptools` test command prior to
-   the installation by executing the following command from within the sardana
-   project directory:
-   
-       python setup.py test
-
-   This will execute only a subset of all the sardana tests - the unit test suite.
-   The functional tests, that require the :ref:`sardana-test-sar_demo`, are
-   excluded on purpose.
-
-2) The complete Sardana test suite, that includes the unit and the functional tests
-   can be executed only after the Sardana installation by executing the
-   `sardanatestsuite` script.
-
-Run a single test
------------------
-
-Executing a single test from command line is done by doing:
-
-       python -m unittest test_name
-
-Where test_name is the test module that has to be run.
-
-That can be done with more verbosity by indicating the option -v.
-
-       python -m unittest -v test_name 
+.. note::
+  Currently the majority of the Sardana tests are written using unittest.
+  We plan to gradually migrate them to pytest.
 
 .. _sardana-test-sar_demo:
 
@@ -46,7 +24,8 @@ sar_demo test environment
 -------------------------
 
 Some of the Sardana tests e.g. the ones that test the macros, require a running Sardana
-instance with the sar_demo macro executed previosly. By default the tests will try to
+instance with the sar_demo macro executed previously. By default the tests will try to
 connect to the `door/demo1/1` door in order to run the macros there. The default door
-name can be changed in the `sardanacustomsettings` module.
+name can be changed with the `sardana.sardanacustomsettings.UNITTEST_DOOR_NAME`
+module.
 

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,5 @@ setup(name='sardana',
       entry_points=entry_points,
       provides=provides,
       requires=requires,
-      install_requires=install_requires,
-      test_suite='sardana.test.testsuite.get_sardana_unitsuite',
+      install_requires=install_requires
       )

--- a/src/sardana/tango/macroserver/test/base.py
+++ b/src/sardana/tango/macroserver/test/base.py
@@ -82,7 +82,7 @@ class BaseMacroServerTestCase(object):
                     db.put_device_property(self.ms_name,
                                            {key: values})
             # start MS server
-            self._msstarter.startDs()
+            self._msstarter.startDs(wait_seconds=20)
             self.door = PyTango.DeviceProxy(self.door_name)
         except Exception as e:
             # force tearDown in order to eliminate the MacroServer

--- a/src/sardana/tango/pool/test/base.py
+++ b/src/sardana/tango/pool/test/base.py
@@ -66,7 +66,7 @@ class BasePoolTestCase(object):
                 db.put_device_property(self.pool_name,
                                        {key: values})
         # start Pool server
-        self._starter.startDs()
+        self._starter.startDs(wait_seconds=20)
         # register extensions so the test methods can use them
         self.pool = PyTango.DeviceProxy(self.pool_name)
 

--- a/src/sardana/tango/pool/test/test_persistence.py
+++ b/src/sardana/tango/pool/test/test_persistence.py
@@ -68,7 +68,7 @@ class PersistenceTestCase(BasePoolTestCase, unittest.TestCase):
                                  self.elem_name])
         # Restart Pool
         self._starter.stopDs(hard_kill=True)
-        self._starter.startDs()
+        self._starter.startDs(wait_seconds=20)
         # Check if the element exists
         try:
             obj = PyTango.DeviceProxy(self.elem_name)

--- a/src/sardana/test/testsuite.py
+++ b/src/sardana/test/testsuite.py
@@ -24,102 +24,15 @@
 ##############################################################################
 
 """
-This module defines the test suite for the whole sardana package
-Usage::
-
-  from sardana.test import testsuite
-  testsuite.run()
-
+DEPRECATED
 """
 
 __docformat__ = 'restructuredtext'
 
-import os
-import re
-import unittest
-import sardana
-
-
-def _filter_suite(suite, exclude_pattern, ret=None):
-    """removes TestCases from a suite based on regexp matching on the Test id"""
-    if ret is None:
-        ret = unittest.TestSuite()
-    for e in suite:
-        if isinstance(e, unittest.TestCase):
-            if re.match(exclude_pattern, e.id()):
-                print("Excluded %s" % e.id())
-                continue
-            ret.addTest(e)
-        else:
-            _filter_suite(e, exclude_pattern, ret=ret)
-    return ret
-
-
-def get_sardana_suite(exclude_pattern='(?!)'):
-    """discover all tests in sardana, except those matching `exclude_pattern`"""
-    loader = unittest.defaultTestLoader
-    start_dir = os.path.dirname(sardana.__file__)
-    suite = loader.discover(
-        start_dir, top_level_dir=os.path.dirname(start_dir))
-    return _filter_suite(suite, exclude_pattern)
-
-
-def get_sardana_unitsuite():
-    """Provide test suite with only unit tests. These exclude:
-        - functional tests of macros that requires the "sar_demo environment"
-    """
-    pattern = 'sardana\.macroserver\.macros\.test*|' +\
-              'sardana\.tango\.pool\.test*'
-    return get_sardana_suite(exclude_pattern=pattern)
-
-
-def run(exclude_pattern='(?!)'):
-    '''Runs all tests for the sardana package
-
-    :returns: the test runner result
-    :rtype: unittest.result.TestResult
-    '''
-    # discover all tests within the sardana/src directory
-    suite = get_sardana_suite(exclude_pattern=exclude_pattern)
-    # use the basic text test runner that outputs to sys.stderr
-    runner = unittest.TextTestRunner(descriptions=True, verbosity=2)
-    # run the test suite
-    result = runner.run(suite)
-    return result
-
 
 def main():
+    print("sardanatestsuite was removed in Sardana Jan20. "
+          "Use pytest to run tests.")
     import sys
-    import argparse
-    from sardana import Release
+    sys.exit(1)
 
-    parser = argparse.ArgumentParser(description='Main test suite for Sardana')
-    # TODO: Define the default exclude patterns as a sardanacustomsettings
-    # variable.
-    help = """regexp pattern matching test ids to be excluded.
-    (e.g. 'sardana\.pool\..*' would exclude sardana.pool tests)
-    """
-    parser.add_argument('-e', '--exclude-pattern',
-                        dest='exclude_pattern',
-                        default='(?!)',
-                        help=help)
-    parser.add_argument('--version', action='store_true', default=False,
-                        help="show program's version number and exit")
-    args = parser.parse_args()
-
-    if args.version:
-        print(Release.version)
-        sys.exit(0)
-
-    ret = run(exclude_pattern=args.exclude_pattern)
-
-    # calculate exit code (0 if OK and 1 otherwise)
-    if ret.wasSuccessful():
-        exit_code = 0
-    else:
-        exit_code = 1
-    sys.exit(exit_code)
-
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
Current sardanatestsuite duplicates some tests. Approx 50 tests are executed twice making the whole test sute longer of more than 4 min.
See for example: [this job](https://api.travis-ci.org/v3/job/694553069/log.txt) where:
```
test_meas_cont_acquisition_4 (sardana.pool.test.test_measurementgroup.AcquisitionTestCase)
```
is executed twice.
It seems like a bug in Python unittest - it is already `TestLoader.discover()` which returns duplicated tests.

Instead of investigating it change the test runner to pytest which could open doors for other interesting features comming with pytest.

Note that previously I have installed the latest pytest in sardana-test docker image.