### PR TITLE
Remove redundant protection in PoolElement.start() and waitFinish()

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -477,7 +477,6 @@ class PoolElement(BaseElement, TangoDevice):
     def start(self, *args, **kwargs):
         evt_wait = self._getEventWait()
         evt_wait.connect(self.getAttribute("state"))
-        evt_wait.lock()
         try:
             evt_wait.waitEvent(DevState.MOVING, equal=False)
             self.__go_time = 0
@@ -488,8 +487,6 @@ class PoolElement(BaseElement, TangoDevice):
         except:
             evt_wait.disconnect()
             raise
-        finally:
-            evt_wait.unlock()
         ts2 = evt_wait.getRecordedEvents().get(DevState.MOVING, ts2)
         return (ts2,)
 
@@ -514,14 +511,12 @@ class PoolElement(BaseElement, TangoDevice):
         if id is not None:
             id = id[0]
         evt_wait = self._getEventWait()
-        evt_wait.lock()
         try:
             evt_wait.waitEvent(DevState.MOVING, after=id, equal=False,
                                timeout=timeout, retries=retries)
         finally:
             self.__go_end_time = time.time()
             self.__go_time = self.__go_end_time - self.__go_start_time
-            evt_wait.unlock()
             evt_wait.disconnect()
 
     @reservedOperation


### PR DESCRIPTION
A deadlock may happen between a thread using the said methods and
the *Tango Event Consumer* thread. The first one locks the `AttrEventWait`
object while the second one locks the Tango event system.

It was observed when using the Sardana-Taurus model extension of
the measurement group which executes `PoolElement.start()` which
basically waits for the measurement group being in a state != MOVING,
then executes the `Start` command and then wait for state == MOVING.
What happens is that while executing the `Start` command the GC enters
and destroys some Taurus device created previously. Meanwhile,
a state event already arrives and `AttrEventWait.fireEvent()` triggered
from the `TangoAttribute.push_event()` waits for the lock.
This lock will never get released cause the `DeviceProxy.unsubscribe_event()`
from the `TanogAttribute.__del__()` waits for the Tango event callback
to finish. And here we have a deadlock.

The `AttrEventWait` locking/unlocking in `PoolElement.start()`
and `PoolElement.waitFinish()` role is to:

1. Do not process State events from the moment of lock. `waitEvent()`
   locks in the next instructions but there is still some unprotected period.
2. Do not process State events right after the `Start` command.
3. In case of `PoolElement.start()` protect `__go_time` and `__go_start_time`
   from being modified by another thread - these however are unprotected
   as soon as we leave the method.
4. In case of `PoolElement.waitFinish()` protect `__go_time` and `__go_end_time`
   from being modified by another thread - these however are unprotected
   as soon as we leave the method.

The protections 1. and 2. are not really needed. If we eliminate the lock from
`start()` and `waitFinish()` then the eventual events would be processed
by `AttrEventWait.fireEvent()`. This processing updates the internal map
of events which later on is interpreted by `AttrEventWait.waitEvent()`
to determine if a given event already arrived or not.
So we will realize anyway that it arrived.

Remove the redundant protection.