### PR TITLE
Fix fast measurement group acquisitions

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -718,7 +718,8 @@ class ct(Macro, Hookable, _ct):
                 names = self.countable_elem.ElementList
                 elements = [self.getObj(name) for name in names]
                 self.dump_information(elements)
-                raise ValueError("Acquisition ended with {}".format(state))
+                raise ValueError("Acquisition ended with {}".format(
+                    state.name.capitalize()))
 
         for postAcqHook in self.getHooks('post-acq'):
             postAcqHook()
@@ -816,7 +817,8 @@ class uct(Macro, _ct):
                 names = self.countable_elem.ElementList
                 elements = [self.getObj(name) for name in names]
                 self.dump_information(elements)
-                raise ValueError("Acquisition ended with {}".format(state))
+                raise ValueError("Acquisition ended with {}".format(
+                    state.name.capitalize()))
         self.setData(Record(data))
         self.printAllValues()
 

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -549,8 +549,11 @@ class PoolAcquisition(PoolAction):
                 pseudo_elem.clear_value_buffer()
 
         if self._hw_acq_args is not None:
+            self._hw_acq._wait()
+            self._hw_acq._set_busy()
             self._hw_acq.run(*self._hw_acq_args.args,
-                             **self._hw_acq_args.kwargs)
+                             **self._hw_acq_args.kwargs,
+                             cb=self._hw_acq._set_ready)
 
         if self._sw_acq_args is not None\
                 or self._sw_start_acq_args is not None\
@@ -558,8 +561,11 @@ class PoolAcquisition(PoolAction):
             self._synch.add_listener(self)
 
         if self._synch_args is not None:
+            self._synch._wait()
+            self._synch._set_busy()
             self._synch.run(*self._synch_args.args,
-                            **self._synch_args.kwargs)
+                            **self._synch_args.kwargs,
+                            cb=self._synch._set_ready)
 
     def _get_action_for_element(self, element):
         elem_type = element.get_type()
@@ -672,6 +678,8 @@ class PoolAcquisitionBase(PoolAction):
         on a provisional basis. Backwards incompatible changes
         (up to and including removal of the module) may occur if
         deemed necessary by the core developers.
+
+    .. todo: Think of moving the ready/busy mechanism to PoolAction
     """
 
     def __init__(self, main_element, name):

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -736,9 +736,9 @@ class PoolAcquisitionTimerable(PoolAcquisitionBase):
         # self.add_finish_hook(self.clear_value_buffers, True)
 
     def _set_acquiring(self, acquiring):
-        # HACK for properly setting the Value Tango attribute quality
-        # To remove it either use the concept of quality for
-        # SardanaValue or use the AcquisitionState (see #1352)
+        """HACK for properly setting the Value Tango attribute quality
+        To remove it either use the concept of quality for
+        SardanaValue or use the AcquisitionState (see #1352)"""
         for channel in self._channels:
             element = channel.configuration.element
             setattr(element, "_acquiring", acquiring)

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -724,7 +724,6 @@ class PoolAcquisitionTimerable(PoolAcquisitionBase):
         self._pool_ctrl_dict_ref = None
         self._pool_ctrl_dict_value = None
 
-
         # TODO: for the moment we can not clear value buffers at the end of
         # the acquisition. This is because of the pseudo counters that are
         # based on channels synchronized by hardware and software.

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -1540,10 +1540,7 @@ class Pool0DAcquisition(PoolAcquisitionBase):
             self.raw_read_state_info(ret=states)
 
         for acquirable, state_info in list(states.items()):
-            # first update the element state so that value calculation
-            # that is done after takes the updated state into account
             state_info = acquirable._from_ctrl_state_info(state_info)
-            acquirable.set_state_info(state_info, propagate=0)
             set_state_info = functools.partial(acquirable.set_state_info,
                                                state_info,
                                                propagate=2,

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -329,6 +329,7 @@ class PoolAcquisition(PoolAction):
                 self._sw_start_acq._wait()
                 self._sw_start_acq._set_busy()
                 self.debug('Executing software start acquisition.')
+                self._sw_start_acq._started = True
                 get_thread_pool().add(self._sw_start_acq.run,
                                       self._sw_start_acq._set_ready,
                                       *self._sw_start_acq_args.args,
@@ -351,6 +352,7 @@ class PoolAcquisition(PoolAction):
                     self._sw_acq._set_busy()
                     self.debug('Executing software acquisition.')
                     self._sw_acq_args.kwargs.update({'index': index})
+                    self._sw_acq._started = True
                     get_thread_pool().add(self._sw_acq.run,
                                           self._sw_acq._set_ready,
                                           *self._sw_acq_args.args,

--- a/src/sardana/pool/poolaction.py
+++ b/src/sardana/pool/poolaction.py
@@ -356,7 +356,8 @@ class PoolAction(Logger):
                 raise
             finally:
                 self._started = False
-            get_thread_pool().add(self._asynch_action_loop, None, context)
+            cb = kwargs.pop("cb", None)
+            get_thread_pool().add(self._asynch_action_loop, cb, context)
 
     def start_action(self, *args, **kwargs):
         """Start procedure for this action. Default implementation raises

--- a/src/sardana/pool/poolbasechannel.py
+++ b/src/sardana/pool/poolbasechannel.py
@@ -30,6 +30,7 @@ __all__ = ["Value", "PoolBaseChannel"]
 
 __docformat__ = 'restructuredtext'
 
+from sardana.sardanadefs import AttrQuality
 from sardana.sardanaattribute import SardanaAttribute
 from sardana.sardanabuffer import SardanaBuffer
 from sardana.pool.poolelement import PoolElement
@@ -241,19 +242,24 @@ class PoolBaseChannel(PoolElement):
             :class:`~sardana.sardanavalue.SardanaValue`"""
         return self.acquisition.read_value()[self]
 
-    def put_value(self, value, propagate=1):
+    def put_value(self, value, quality=AttrQuality.Valid, propagate=1):
         """Sets a value.
 
         :param value:
             the new value
         :type value:
             :class:`~sardana.sardanavalue.SardanaValue`
+        :param quality:
+            the new quality
+        :type quality:
+            :class:`~sardana.AttrQuality`
         :param propagate:
             0 for not propagating, 1 to propagate, 2 propagate with priority
         :type propagate:
             int
         """
         val_attr = self._value
+        val_attr.set_quality(quality)
         val_attr.set_value(value, propagate=propagate)
         return val_attr
 

--- a/src/sardana/pool/poolbasegroup.py
+++ b/src/sardana/pool/poolbasegroup.py
@@ -89,7 +89,8 @@ class PoolBaseGroup(PoolContainer):
     def _calculate_element_state(self, elem, elem_state_info):
         u_state, u_status = elem_state_info
         if u_status is None:
-            u_status = '%s is None' % elem.name
+            state_str = "None" if u_state is None else State.whatis(u_state)
+            u_status = '{} is {}'.format(elem.name, state_str)
         else:
             u_status = u_status.split("\n", 1)[0]
         return u_state, u_status

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -1033,13 +1033,15 @@ class PoolMeasurementGroup(PoolGroupElement):
         # check if software synchronizer is occupied
         synch_soft = self.acquisition._synch._synch_soft
         acq_sw = self.acquisition._sw_acq
+        acq_sw_start = self.acquisition._sw_start_acq
         acq_0d = self.acquisition._0d_acq
-        if state in (State.On, State.Unknown) \
-            and (synch_soft.is_started() or
-                 acq_sw._is_started() or
-                 acq_0d._is_started()):
+        if (state == State.Unknown
+            and (synch_soft.is_started()
+                 or acq_sw._is_busy()
+                 or acq_sw_start._is_busy()
+                 or acq_0d._is_busy())):
             state = State.Moving
-            status += "/nSoftware synchronization is in progress"
+            status += "\nSoftware synchronization is in progress"
         return state, status
 
     def on_element_changed(self, evt_src, evt_type, evt_value):

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -1035,11 +1035,11 @@ class PoolMeasurementGroup(PoolGroupElement):
         acq_sw = self.acquisition._sw_acq
         acq_sw_start = self.acquisition._sw_start_acq
         acq_0d = self.acquisition._0d_acq
-        if (state == State.Unknown
+        if (state in (State.On, State.Unknown)
             and (synch_soft.is_started()
-                 or acq_sw._is_busy()
-                 or acq_sw_start._is_busy()
-                 or acq_0d._is_busy())):
+                 or acq_sw._is_started()
+                 or acq_sw_start._is_started()
+                 or acq_0d._is_started())):
             state = State.Moving
             status += "\nSoftware synchronization is in progress"
         return state, status

--- a/src/sardana/pool/poolpseudocounter.py
+++ b/src/sardana/pool/poolpseudocounter.py
@@ -166,6 +166,8 @@ class Value(SardanaAttribute):
                                      "values (you gave %d)" % (obj.name, l_u, l_v))
             ctrl, axis = obj.controller, obj.axis
             result = ctrl.calc(axis, physical_values)
+            if result.error:
+                self._exc_info = result.exc_info
         except SardanaException as se:
             self._exc_info = se.exc_info
             result = SardanaValue(exc_info=se.exc_info)

--- a/src/sardana/pool/poolsynchronization.py
+++ b/src/sardana/pool/poolsynchronization.py
@@ -254,7 +254,7 @@ class PoolSynchronization(PoolAction):
 
         # Triggering loop
         # TODO: make nap configurable (see motion or acquisition loops)
-        nap = 0.2
+        nap = 0.01
         while True:
             self.read_state_info(ret=states)
             if not self.is_triggering(states):

--- a/src/sardana/pool/poolsynchronization.py
+++ b/src/sardana/pool/poolsynchronization.py
@@ -30,6 +30,7 @@ for the synchronization"""
 __all__ = ["PoolSynchronization", "SynchDescription", "TGChannel"]
 
 import time
+import threading
 from functools import partial
 from taurus.core.util.log import DebugIt
 from sardana import State
@@ -117,6 +118,8 @@ class PoolSynchronization(PoolAction):
     """Synchronization action.
 
     It coordinates trigger/gate elements and software synchronizer.
+
+    .. todo: Think of moving the ready/busy mechanism to PoolAction
     """
 
     def __init__(self, main_element, name="Synchronization"):
@@ -130,6 +133,23 @@ class PoolSynchronization(PoolAction):
         soft_synch_name = main_element.name + "-SoftSynch"
         self._synch_soft = FunctionGenerator(name=soft_synch_name)
         self._listener = None
+        self._ready = threading.Event()
+        self._ready.set()
+
+    def _is_ready(self):
+        return self._ready.is_set()
+
+    def _wait(self, timeout=None):
+        return self._ready.wait(timeout)
+
+    def _set_ready(self, _=None):
+        self._ready.set()
+
+    def _is_busy(self):
+        return not self._ready.is_set()
+
+    def _set_busy(self):
+        self._ready.clear()
 
     def add_listener(self, listener):
         self._listener = listener

--- a/src/sardana/pool/test/test_acquisition.py
+++ b/src/sardana/pool/test/test_acquisition.py
@@ -84,7 +84,7 @@ class AcquisitionTestCase(BasePoolTestCase):
 
     def wait_finish(self):
         # waiting for acquisition and synchronization to finish
-        while (self.acquisition.is_running()
+        while (self.acquisition._is_busy()
                or self.synchronization.is_running()):
             time.sleep(.1)
 
@@ -160,16 +160,16 @@ class DummyAcquisitionTestCase(AcquisitionTestCase, TestCase):
         _, type_, index = args
         name = type_.name
         if name == "active":
-            if self.sw_acq_busy.is_set():
+            if self.sw_acq._is_busy():
                 # skipping acquisition cause the previous on is ongoing
                 return
             else:
-                self.sw_acq_busy.set()
+                self.sw_acq._set_busy()
                 args = self.sw_acq_args
                 kwargs = self.sw_acq_kwargs
                 kwargs['index'] = index
                 get_thread_pool().add(self.sw_acq.run,
-                                      None,
+                                      self.sw_acq._set_ready,
                                       *args,
                                       **kwargs)
 
@@ -209,18 +209,8 @@ class DummyAcquisitionTestCase(AcquisitionTestCase, TestCase):
         # creating acquisition actions
         self.hw_acq = self.create_action(PoolAcquisitionHardware, [ct_1_1])
         self.sw_acq = self.create_action(PoolAcquisitionSoftware, [ct_2_1])
-        # Since we deposit the software acquisition action on the PoolThread's
-        # queue we can not rely on the action's state - one may still wait
-        # in the queue (its state has not changed to running yet) and we would
-        # be depositing another one. This way we may be starting multiple
-        # times the same action (with the same elements involved), what results
-        # in "already involved in operation" errors.
-        # Use an external Event flag to mark if we have any software
-        # acquisition action pending.
-        self.sw_acq_busy = threading.Event()
-        self.sw_acq.add_finish_hook(self.sw_acq_busy.clear)
         self.sw_acq_args = (sw_ctrls, integ_time, sw_master)
-        self.sw_acq_kwargs = {}
+        self.sw_acq_kwargs = dict(synch=True)
 
         total_interval = active_interval + passive_interval
         group = {
@@ -236,7 +226,7 @@ class DummyAcquisitionTestCase(AcquisitionTestCase, TestCase):
         self.synchronization.run(synch_ctrls, synch_description)
         # waiting for acquisition and synchronization to finish
         while (self.hw_acq.is_running()
-               or self.sw_acq.is_running()
+               or self.sw_acq._is_busy()
                or self.synchronization.is_running()):
             time.sleep(.1)
         self.do_asserts(repetitions, jobs_before)
@@ -260,17 +250,17 @@ class BaseAcquisitionSoftwareTestCase(AcquisitionTestCase):
         _, type_, value = args
         name = type_.name
         if name == "active":
-            if self.acq_busy.is_set():
+            if self.acquisition._is_busy():
                 # skipping acquisition cause the previous on is ongoing
                 return
             else:
-                self.acq_busy.set()
+                self.acquisition._set_busy()
                 acq_args = list(self.acq_args)
                 acq_kwargs = self.acq_kwargs
                 index = value
                 acq_args[3] = index
                 get_thread_pool().add(self.acquisition.run,
-                                      None,
+                                      self.acquisition._set_ready,
                                       *acq_args,
                                       **acq_kwargs)
 
@@ -291,18 +281,8 @@ class BaseAcquisitionSoftwareTestCase(AcquisitionTestCase):
         # creating acquisition actions
         self.acquisition = self.create_action(PoolAcquisitionSoftware,
                                               [self.channel])
-        # Since we deposit the software acquisition action on the PoolThread's
-        # queue we can not rely on the action's state - one may still wait
-        # in the queue (its state has not changed to running yet) and we would
-        # be depositing another one. This way we may be starting multiple
-        # times the same action (with the same elements involved), what results
-        # in "already involved in operation" errors.
-        # Use an external Event flag to mark if we have any software
-        # acquisition action pending.
-        self.acq_busy = threading.Event()
-        self.acquisition.add_finish_hook(self.acq_busy.clear)
         self.acq_args = (ctrls, integ_time, master, None)
-        self.acq_kwargs = {}
+        self.acq_kwargs = dict(synch=True)
 
         total_interval = integ_time + latency_time
         group = {
@@ -331,7 +311,6 @@ class BaseAcquisitionSoftwareStartTestCase(AcquisitionTestCase):
 
     def setUp(self):
         """Create test actors (controllers and elements)"""
-        TestCase.setUp(self)
         AcquisitionTestCase.setUp(self)
 
     def event_received(self, *args, **kwargs):
@@ -339,7 +318,9 @@ class BaseAcquisitionSoftwareStartTestCase(AcquisitionTestCase):
         _, type_, value = args
         name = type_.name
         if name == "start":
-            get_thread_pool().add(self.acquisition.run, None,
+            self.acquisition._set_busy()
+            get_thread_pool().add(self.acquisition.run,
+                                  self.acquisition._set_ready,
                                   *self.acq_args,
                                   **self.acq_kwargs)
 
@@ -361,7 +342,7 @@ class BaseAcquisitionSoftwareStartTestCase(AcquisitionTestCase):
         self.acquisition = self.create_action(PoolAcquisitionSoftwareStart,
                                               [self.channel])
         self.acq_args = (ctrls, integ_time, master, repetitions, latency_time)
-        self.acq_kwargs = {}
+        self.acq_kwargs = dict(synch=True)
 
         total_interval = integ_time + latency_time
         group = {
@@ -423,6 +404,12 @@ class BaseAcquisitionHardwareTestCase(AcquisitionTestCase):
         self.wait_finish()
         self.do_asserts(repetitions, jobs_before)
 
+    def wait_finish(self):
+        # waiting for acquisition and synchronization to finish
+        while (self.acquisition.is_running()
+               or self.synchronization.is_running()):
+            time.sleep(.1)
+
     def tearDown(self):
         AcquisitionTestCase.tearDown(self)
         TestCase.tearDown(self)
@@ -452,7 +439,7 @@ class Acquisition2DSoftwareTriggerTestCase(BaseAcquisitionSoftwareTestCase,
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionSoftwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
@@ -471,7 +458,7 @@ class Acquisition2DSoftwareTriggerRefTestCase(BaseAcquisitionSoftwareTestCase,
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionSoftwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuerefbuffer")
 
@@ -494,7 +481,7 @@ class AcquisitionCTSoftwareStartTestCase(
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionSoftwareStartTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
@@ -512,7 +499,7 @@ class Acquisition2DSoftwareStartTestCase(
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionSoftwareStartTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
@@ -535,7 +522,7 @@ class Acquisition2DSoftwareStartRefTestCase(
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionSoftwareStartTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuerefbuffer")
 
@@ -576,7 +563,7 @@ class Acquisition2DHardwareStartTestCase(BaseAcquisitionHardwareTestCase,
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionHardwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
@@ -595,7 +582,7 @@ class Acquisition2DHardwareStartRefTestCase(
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionHardwareTestCase.setUp(self)
         self.channel_ctrl.set_log_level(10)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuerefbuffer")
@@ -619,7 +606,7 @@ class AcquisitionCTHardwareTriggerTestCase(BaseAcquisitionHardwareTestCase,
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionHardwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
@@ -637,7 +624,7 @@ class Acquisition2DHardwareTriggerTestCase(BaseAcquisitionHardwareTestCase,
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionHardwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
@@ -656,7 +643,7 @@ class Acquisition2DHardwareTriggerRefTestCase(BaseAcquisitionHardwareTestCase,
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionHardwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuerefbuffer")
 
@@ -679,7 +666,7 @@ class AcquisitionCTHardwareGateTestCase(BaseAcquisitionHardwareTestCase,
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionHardwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
@@ -697,7 +684,7 @@ class Acquisition2DHardwareGateTestCase(BaseAcquisitionHardwareTestCase,
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionHardwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
@@ -716,7 +703,7 @@ class Acquisition2DHardwareGateRefTestCase(BaseAcquisitionHardwareTestCase,
     def setUp(self):
         """Create test actors (controllers and elements)"""
         TestCase.setUp(self)
-        AcquisitionTestCase.setUp(self)
+        BaseAcquisitionHardwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuerefbuffer")
 

--- a/src/sardana/sardanaattribute.py
+++ b/src/sardana/sardanaattribute.py
@@ -37,7 +37,7 @@ import weakref
 import datetime
 
 from .sardanaevent import EventGenerator, EventType
-from .sardanadefs import ScalarNumberFilter
+from .sardanadefs import ScalarNumberFilter, AttrQuality
 from .sardanavalue import SardanaValue
 
 
@@ -54,6 +54,7 @@ class SardanaAttribute(EventGenerator):
         self._r_value = None
         self._last_event_value = None
         self._w_value = None
+        self._quality = AttrQuality.Valid
         self.filter = lambda a, b: True
         self.config = SardanaAttributeConfiguration()
         if initial_value is not None:
@@ -212,6 +213,12 @@ class SardanaAttribute(EventGenerator):
         if self.has_write_value():
             return self._w_value
 
+    def get_quality(self):
+        return self._quality
+
+    def set_quality(self, quality):
+        self._quality = quality
+
     def get_exc_info(self):
         """Returns the exception information (like :func:`sys.exc_info`) about
         last attribute readout or None if last read did not generate an
@@ -291,6 +298,8 @@ class SardanaAttribute(EventGenerator):
                      "current read value for this attribute")
     w_value = property(get_write_value, set_write_value,
                        "current write value for this attribute")
+    quality = property(get_quality, set_quality,
+                       "current quality for this attribute")
     timestamp = property(get_timestamp, doc="the read timestamp")
     w_timestamp = property(get_write_timestamp, doc="the write timestamp")
     error = property(in_error)

--- a/src/sardana/sardanadefs.py
+++ b/src/sardana/sardanadefs.py
@@ -29,8 +29,8 @@
 import collections
 
 __all__ = ["EpsilonError", "SardanaServer", "ServerRunMode", "State",
-           "DataType", "DataFormat", "DataAccess", "DTYPE_MAP", "R_DTYPE_MAP",
-           "DACCESS_MAP",
+           "DataType", "DataFormat", "DataAccess", "AttrQuality",
+           "DTYPE_MAP", "R_DTYPE_MAP", "DACCESS_MAP",
            "from_dtype_str", "from_access_str", "to_dtype_dformat",
            "to_daccess", "InvalidId", "InvalidAxis", "ElementType",
            "Interface", "Interfaces", "InterfacesExpanded",
@@ -43,6 +43,7 @@ __all__ = ["EpsilonError", "SardanaServer", "ServerRunMode", "State",
 __docformat__ = 'restructuredtext'
 
 import math
+from enum import IntEnum
 
 from taurus.core.util.enumeration import Enumeration
 
@@ -119,6 +120,21 @@ DataAccess = Enumeration("DataAccess", (
     "ReadOnly",
     "ReadWrite",
     "Invalid"))
+
+
+class AttrQuality(IntEnum):
+    """Attribute quality factor"""
+
+    #: Attribute is valid
+    Valid = 0
+    #: Attribute is invalid
+    Invalid = 1
+    #: Attribute is in alarm
+    Alarm = 2
+    #: Attribute is changing e.g. element is in operation
+    Changing = 3
+    #: Attribute is in warning
+    Warning = 4
 
 #: dictionary dict<data type, :class:`sardana.DataType`>
 DTYPE_MAP = {

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -61,7 +61,8 @@ from taurus.core.util.log import Logger
 
 import sardana
 from sardana import State, SardanaServer, DataType, DataFormat, InvalidId, \
-    DataAccess, to_dtype_dformat, to_daccess, Release, ServerRunMode
+    DataAccess, to_dtype_dformat, to_daccess, Release, ServerRunMode, \
+    AttrQuality
 from sardana.sardanaexception import SardanaException, AbortException
 from sardana.sardanavalue import SardanaValue
 from sardana.util.wrap import wraps
@@ -426,14 +427,27 @@ TFORMAT_MAP = {
 }
 R_TFORMAT_MAP = dict((v, k) for k, v in list(TFORMAT_MAP.items()))
 
-#: dictionary dict<:class:`sardana.DataAccess`, :class:`PyTango.AttrWriteType`>
+
+#: dictionary dict<:class:`sardana.AttrQuality`, :class:`PyTango.AttrQuality`>
+TQUALITY_MAP = {
+    AttrQuality.Valid: PyTango.AttrQuality.ATTR_VALID,
+    AttrQuality.Invalid: PyTango.AttrQuality.ATTR_INVALID,
+    AttrQuality.Alarm: PyTango.AttrQuality.ATTR_ALARM,
+    AttrQuality.Changing: PyTango.AttrQuality.ATTR_CHANGING,
+    AttrQuality.Warning: PyTango.AttrQuality.ATTR_WARNING
+}
+
+
+R_TQUALITY_MAP = dict((v, k) for k, v in list(TQUALITY_MAP.items()))
+
+
+#: dictionary dict<:class:`sardana.AttrQuality`, :class:`PyTango.AttrQuality`>
 TACCESS_MAP = {
     DataAccess.ReadOnly: READ,
     DataAccess.ReadWrite: READ_WRITE,
 }
 
 R_TACCESS_MAP = dict((v, k) for k, v in list(TACCESS_MAP.items()))
-
 
 def exception_str(etype=None, value=None, sep='\n'):
     if etype is None:
@@ -494,6 +508,16 @@ def from_tango_type_format(dtype, dformat=PyTango.SCALAR):
     :rtype: tuple< :obj:`~sardana.DataType`, :obj:`~sardana.DataFormat` >"""
     return R_TTYPE_MAP[dtype], R_TFORMAT_MAP[dformat]
 
+
+def to_tango_quality(quality):
+    """Transforms a :obj:`~sardana.AttrQuality` into a
+    :obj:`~PyTango.AttrQuality`
+
+    :param access: the quality to be transformed
+    :type access: :obj:`~sardana.AttrQuality`
+    :return: the tango attribute quality
+    :rtype: :obj:`PyTango.AttrQuality`"""
+    return TQUALITY_MAP[quality]
 
 def to_tango_attr_info(attr_name, attr_info):
     if isinstance(attr_info, DataInfo):

--- a/src/sardana/tango/pool/CTExpChannel.py
+++ b/src/sardana/tango/pool/CTExpChannel.py
@@ -138,8 +138,10 @@ class CTExpChannel(PoolTimerableDevice):
                 value = "None"
             elif name == "value":
                 w_value = event_source.get_value_attribute().w_value
-                state = self.ct.get_state()
-                if state == State.Moving:
+                # HACK for properly setting the Value Tango attribute quality
+                # To remove it either use the concept of quality for
+                # SardanaValue or use the AcquisitionState (see #1352)
+                if self.ct._acquiring:
                     quality = AttrQuality.ATTR_CHANGING
 
         self.set_attribute(attr, value=value, w_value=w_value,

--- a/src/sardana/tango/pool/CTExpChannel.py
+++ b/src/sardana/tango/pool/CTExpChannel.py
@@ -39,7 +39,8 @@ from taurus.core.util.log import DebugIt
 
 from sardana import State, SardanaServer
 from sardana.sardanaattribute import SardanaAttribute
-from sardana.tango.core.util import to_tango_type_format, exception_str
+from sardana.tango.core.util import to_tango_type_format, to_tango_quality, \
+    exception_str
 
 from sardana.tango.pool.PoolDevice import PoolTimerableDevice, \
     PoolTimerableDeviceClass
@@ -137,12 +138,9 @@ class CTExpChannel(PoolTimerableDevice):
             if name == "timer" and value is None:
                 value = "None"
             elif name == "value":
-                w_value = event_source.get_value_attribute().w_value
-                # HACK for properly setting the Value Tango attribute quality
-                # To remove it either use the concept of quality for
-                # SardanaValue or use the AcquisitionState (see #1352)
-                if self.ct._acquiring:
-                    quality = AttrQuality.ATTR_CHANGING
+                value_attr = event_source.get_value_attribute()
+                w_value = value_attr.w_value
+                quality = to_tango_quality(value_attr.quality)
 
         self.set_attribute(attr, value=value, w_value=w_value,
                            timestamp=timestamp, quality=quality,

--- a/src/sardana/tango/pool/test/base_sartest.py
+++ b/src/sardana/tango/pool/test/base_sartest.py
@@ -169,7 +169,8 @@ class SarTestTestCase(BasePoolTestCase):
                 _cleanup_device(elem_name)
             try:
                 self.pool.DeleteElement(elem_name)
-            except:
+            except Exception as e:
+                print(e)
                 dirty_elems.append(elem_name)
 
         for ctrl_name in self.ctrl_list:

--- a/src/sardana/tango/pool/test/test_measurementgroup.py
+++ b/src/sardana/tango/pool/test/test_measurementgroup.py
@@ -228,23 +228,37 @@ class MeasSarTestTestCase(SarTestTestCase):
         repetitions = params['synch_description'][0][SynchParam.Repeats]
         self._acq_asserts(chn_names, repetitions)
 
+    def push_event(self, event):
+        value = event.attr_value.value
+        self.meas_state = value
+        if value == PyTango.DevState.MOVING:
+            self.meas_started = True
+        elif self.meas_started and value == PyTango.DevState.ON:
+            self.meas_finished.set()
+
     def stop_meas_cont_acquisition(self, params, config):
         '''Helper method to do measurement and stop it'''
         self.create_meas(config)
         self.prepare_meas(params)
+        self.meas_state = None
+        self.meas_started = False
+        self.meas_finished = threading.Event()
         chn_names = self._add_attribute_listener(config)
         # Do measurement
-        self.meas.Start()
-        # starting timer (0.2 s) which will stop the measurement group
-        threading.Timer(0.2, self.stopMeas).start()
-        while self.meas.State() == PyTango.DevState.MOVING:
-            print("Acquiring...")
-            time.sleep(0.1)
-        state = self.meas.State()
+        id_ = self.meas.subscribe_event("State",
+                                        PyTango.EventType.CHANGE_EVENT,
+                                        self.push_event)
+        try:
+            # starting timer (0.2 s) which will stop the measurement group
+            self.meas.Start()
+            threading.Timer(0.2, self.stopMeas).start()
+            self.assertTrue(self.meas_finished.wait(5), "mg has not stopped")
+        finally:
+            self.meas.unsubscribe_event(id_)
         desired_state = PyTango.DevState.ON
         msg = 'mg state after stop is %s (should be %s)' %\
-            (state, desired_state)
-        self.assertEqual(state, desired_state, msg)
+            (self.meas_state, desired_state)
+        self.assertEqual(self.meas_state, desired_state, msg)
         for name in chn_names:
             channel = PyTango.DeviceProxy(name)
             state = channel.state()
@@ -276,7 +290,18 @@ synch_description1 = [{SynchParam.Delay: {SynchDomain.Time: 0},
 
 params_1 = {
     "synch_description": synch_description1,
-    "integ_time": 0.01,
+    "integ_time": 0.1,
+    "name": '_exp_01'
+}
+
+synch_description2 = [{SynchParam.Delay: {SynchDomain.Time: 0},
+                     SynchParam.Active: {SynchDomain.Time: 0.1},
+                     SynchParam.Total: {SynchDomain.Time: 0.15},
+                     SynchParam.Repeats: 10}]
+
+params_2 = {
+    "synch_description": synch_description2,
+    "integ_time": 0.1,
     "name": '_exp_01'
 }
 doc_1 = 'Synchronized acquisition with two channels from the same controller'\
@@ -361,11 +386,11 @@ doc_6 = 'Stop of the synchronized acquisition with four channels from two'\
 @insertTest(helper_name='meas_cont_acquisition', test_method_doc=doc_3,
             params=params_1, config=config_3)
 @insertTest(helper_name='stop_meas_cont_acquisition', test_method_doc=doc_4,
-            params=params_1, config=config_1)
+            params=params_2, config=config_1)
 @insertTest(helper_name='stop_meas_cont_acquisition', test_method_doc=doc_5,
-            params=params_1, config=config_2)
+            params=params_2, config=config_2)
 @insertTest(helper_name='stop_meas_cont_acquisition', test_method_doc=doc_6,
-            params=params_1, config=config_3)
+            params=params_2, config=config_3)
 class TangoAcquisitionTestCase(MeasSarTestTestCase, unittest.TestCase):
     """Integration test of TGGeneration and Acquisition actions."""
 

--- a/src/sardana/tango/pool/test/test_measurementgroup.py
+++ b/src/sardana/tango/pool/test/test_measurementgroup.py
@@ -295,9 +295,9 @@ params_1 = {
 }
 
 synch_description2 = [{SynchParam.Delay: {SynchDomain.Time: 0},
-                     SynchParam.Active: {SynchDomain.Time: 0.1},
-                     SynchParam.Total: {SynchDomain.Time: 0.15},
-                     SynchParam.Repeats: 10}]
+                       SynchParam.Active: {SynchDomain.Time: 0.1},
+                       SynchParam.Total: {SynchDomain.Time: 0.15},
+                       SynchParam.Repeats: 10}]
 
 params_2 = {
     "synch_description": synch_description2,

--- a/src/sardana/taurus/core/tango/sardana/test/test_measgrpstress.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_measgrpstress.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+import uuid
+from unittest import TestCase
+
+from tango import DevState
+from taurus import Device
+from taurus.test.base import insertTest
+
+from .test_pool import is_numerical
+from sardana.pool.pooldefs import AcqSynchType
+from sardana.taurus.core.tango.sardana.pool import registerExtensions
+from sardana.tango.pool.test.base_sartest import SarTestTestCase
+
+
+@insertTest(helper_name="stress_count",
+            test_method_doc="stress count with CT (hardware trigger) and 0D",
+            elements=["_test_ct_1_1", "_test_0d_1_1"], repeats=100,
+            synchronizer="_test_tg_1_1", synchronization=AcqSynchType.Trigger)
+@insertTest(helper_name="stress_count",
+            test_method_doc="stress count with CT (software trigger) and 0D",
+            elements=["_test_ct_1_1", "_test_0d_1_1"], repeats=100,
+            synchronizer="software", synchronization=AcqSynchType.Trigger)
+@insertTest(helper_name="stress_count",
+            test_method_doc="stress count with CT (hardware start)",
+            elements=["_test_ct_1_1"], repeats=100,
+            synchronizer="_test_tg_1_1", synchronization=AcqSynchType.Start)
+@insertTest(helper_name="stress_count",
+            test_method_doc="stress count with CT (software start)",
+            elements=["_test_ct_1_1"], repeats=100,
+            synchronizer="software", synchronization=AcqSynchType.Start)
+@insertTest(helper_name="stress_count",
+            test_method_doc="stress count with CT (hardware trigger)",
+            elements=["_test_ct_1_1"], repeats=100,
+            synchronizer="_test_tg_1_1", synchronization=AcqSynchType.Trigger)
+@insertTest(helper_name="stress_count",
+            test_method_doc="count with CT (software trigger)",
+            elements=["_test_ct_1_1"], repeats=100,
+            synchronizer="software", synchronization=AcqSynchType.Trigger)
+class TestStressMeasurementGroup(SarTestTestCase, TestCase):
+
+    def setUp(self):
+        SarTestTestCase.setUp(self)
+        registerExtensions()
+
+    def stress_count(self, elements, repeats, synchronizer, synchronization):
+        mg_name = str(uuid.uuid1())
+        argin = [mg_name] + elements
+        self.pool.CreateMeasurementGroup(argin)
+        try:
+            mg = Device(mg_name)
+            mg.setSynchronizer(synchronizer, elements[0], apply=False)
+            mg.setSynchronization(synchronization, elements[0])
+            for i in range(repeats):
+                state, values = mg.count(.001)
+                self.assertEqual(state, DevState.ON,
+                                 "wrong state after measurement")
+                for channel_name, value in values.items():
+                    msg = "Value (%s) for %s is not numerical" % \
+                          (value, channel_name)
+                    self.assertTrue(is_numerical(value), msg)
+        finally:
+            mg.cleanUp()
+            self.pool.DeleteElement(mg_name)
+
+    def tearDown(self):
+        SarTestTestCase.tearDown(self)

--- a/src/sardana/taurus/core/tango/sardana/test/test_measgrpstress.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_measgrpstress.py
@@ -77,10 +77,10 @@ class TestStressMeasurementGroup(SarTestTestCase, TestCase):
             for i in range(repeats):
                 state, values = mg.count(.001)
                 self.assertEqual(state, DevState.ON,
-                                 "wrong state after measurement")
+                                 "wrong state after measurement {}".format(i))
                 for channel_name, value in values.items():
-                    msg = "Value (%s) for %s is not numerical" % \
-                          (value, channel_name)
+                    msg = ("Value {} for {} is not numerical in "
+                           "measurement {}").format(value, channel_name, i)
                     self.assertTrue(is_numerical(value), msg)
         finally:
             mg.cleanUp()


### PR DESCRIPTION
When trying to get some base line numbers for #161 I realized that fast repetitions of measurement group counts is buggy. There were basically two major issues which this PR solves:

* The software synchronized acquisition action from one execution of the measurement could find the previous acquisition still in progress. This was solved for acquisition within one measurement with multiple repeats but was buggy for multimple measurements with one repeat. 292fcea and 076a015 fixes it.
* Pre-mature setting of state used for determining the *Value* Tango attribute quality (CHANGING when state is MOVING and VALID when state is ON) was causing that the measurement group state event was being pushed too early - more details in 054ebab and 90db657

This PR also:
* itnroduces attribute quality in Sardana - d860ed5
* add stress tests for measurements - 6d529b0
* fixes #1188 - 2113a7c 
* fixes some other minor issues