### PR TITLE
Avoid extra state readout at the end of acquisition

### DIFF
--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -1042,7 +1042,6 @@ class PoolAcquisitionHardware(PoolAcquisitionBase):
             i += 1
 
         with ActionContext(self):
-            self.raw_read_state_info(ret=states)
             self.raw_read_value(ret=values)
             self.raw_read_value_ref(ret=value_refs)
 
@@ -1154,7 +1153,6 @@ class PoolAcquisitionSoftware(PoolAcquisitionBase):
                 self.debug("Details", exc_info=1)
 
         with ActionContext(self):
-            self.raw_read_state_info(ret=states)
             self.raw_read_value(ret=values)
             self.raw_read_value_ref(ret=value_refs)
 
@@ -1262,7 +1260,6 @@ class PoolAcquisitionSoftwareStart(PoolAcquisitionBase):
             i += 1
 
         with ActionContext(self):
-            self.raw_read_state_info(ret=states)
             self.raw_read_value(ret=values)
             self.raw_read_value_ref(ret=value_refs)
 


### PR DESCRIPTION
Acquisition's `action_loop()` exits the state poll loop when none of the
elements is in Moving or Running state. This indicates that the acquisition
has finished. This last state readout should be propagated to the
channels. Avoid the extra state readout which actually could change the
end acquisition state. This also introduces a small performance improvement - #161 