### PR TITLE
Remove deprecated ParamRepeat (4)

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -32,7 +32,7 @@ import numbers
 
 __all__ = ["OverloadPrint", "PauseEvent", "Hookable", "ExecMacroHook",
            "MacroFinder", "Macro", "macro", "iMacro", "imacro",
-           "MacroFunc", "Type", "ParamRepeat", "Table", "List", "ViewOption",
+           "MacroFunc", "Type", "Table", "List", "ViewOption",
            "LibraryError", "Optional"]
 
 __docformat__ = 'restructuredtext'
@@ -57,8 +57,7 @@ from sardana.sardanadefs import State
 from sardana.util.wrap import wraps
 from sardana.util.thread import _asyncexc
 
-from sardana.macroserver.msparameter import Type, ParamType, ParamRepeat, \
-    Optional
+from sardana.macroserver.msparameter import Type, ParamType, Optional
 from sardana.macroserver.msexception import StopException, AbortException, \
     ReleaseException, MacroWrongParameterType, UnknownEnv, UnknownMacro, \
     LibraryError

--- a/src/sardana/macroserver/macros/examples/parameters.py
+++ b/src/sardana/macroserver/macros/examples/parameters.py
@@ -193,7 +193,8 @@ class pt7(Macro):
 
 
 class pt7d1(Macro):
-    """Macro with a list of pair Motor,Float. Default value for last ParamRepeat element.
+    """Macro with a list of pair Motor,Float. Default value for last
+    repeat parameter element.
     Usages from Spock, ex.:
     pt7d1 [[mot1 1] [mot2 3]]
     pt7d1 mot1 1 mot2 3
@@ -214,7 +215,8 @@ class pt7d1(Macro):
 
 
 class pt7d2(Macro):
-    """Macro with a list of pair Motor,Float. Default value for both ParamRepeat elements.
+    """Macro with a list of pair Motor,Float. Default value for both
+    repeat parameters elements.
     Usages from Spock, ex.:
     pt7d2 [[mot1 1] [mot2 3]]
     pt7d2 mot1 1 mot2 3
@@ -252,9 +254,8 @@ class pt8(Macro):
 
 
 class pt9(Macro):
-    """Same as macro pt7 but with old style ParamRepeat. If you are writing
-    a macro with variable number of parameters for the first time don't even
-    bother to look at this example since it is DEPRECATED.
+    """Same as macro pt7 but with min and max number of repetitions of the
+    repeat parameter.
     Usages from Spock, ex.:
     pt9 [[mot1 1][mot2 3]]
     pt9 mot1 1 mot2 3

--- a/src/sardana/macroserver/macros/examples/scans.py
+++ b/src/sardana/macroserver/macros/examples/scans.py
@@ -429,11 +429,13 @@ class reg2scan(Macro):
 
 class reg3scan(Macro):
     """reg3scan.
-    Do an absolute scan of the specified motors with different number of intervals for each region.
-    It uses the gscan framework. All the motors will be drived to the same position in each step
+    Do an absolute scan of the specified motors with different number of
+    intervals for each region. It uses the gscan framework.
+    All the motors will be drived to the same position in each step
 
-    NOTE: Due to a ParamRepeat limitation, integration time has to be
-    specified before the regions.
+    .. note::
+        integration time is specified before the regions to facilitate
+        input of parameters in Spock.
     """
 
     hints = {'scan': 'reg3scan'}

--- a/src/sardana/macroserver/msmetamacro.py
+++ b/src/sardana/macroserver/msmetamacro.py
@@ -35,7 +35,7 @@ import operator
 
 from sardana import InvalidId, ElementType
 from sardana.sardanameta import SardanaLibrary, SardanaClass, SardanaFunction
-from sardana.macroserver.msparameter import Type, ParamRepeat
+from sardana.macroserver.msparameter import Type
 import collections
 
 MACRO_TEMPLATE = """class @macro_name@(Macro):
@@ -150,18 +150,13 @@ class Parameterizable(object):
         '''Builds a list of parameters, each of them represented by a dictionary
         containing information: name, type, default_value, description, min and
         max values. In case of simple parameters, type is the parameter type.
-        In case of ParamRepeat, type is a list containing definition of the
-        param repeat.
+        In case of repeat parameter, type is a list containing its definition.
         '''
         ret = []
         param_def = param_def or ()
         for p in param_def:
             t = p[1]
             ret_p = {'min': None, 'max': None}
-            # take care of old ParamRepeat
-            if isinstance(t, ParamRepeat):
-                ret_p = {'min': 1, 'max': None}
-                t = t.obj()
 
             if isinstance(t, collections.Sequence) and not isinstance(t, str):
                 ret_p = {'min': 1, 'max': None}
@@ -183,7 +178,7 @@ class Parameterizable(object):
 
         info = [str(len(param_def))]
         for name, type_class, def_val, desc in param_def:
-            repeat = isinstance(type_class, ParamRepeat)
+            repeat = isinstance(type_class, list)
             info.append(name)
             type_name = (repeat and 'ParamRepeat') or type_class
             info.append(type_name)
@@ -205,7 +200,7 @@ class Parameterizable(object):
 
         info = [str(len(result_def))]
         for name, type_class, def_val, desc in result_def:
-            repeat = isinstance(type_class, ParamRepeat)
+            repeat = isinstance(type_class, list)
             info.append(name)
             type_name = (repeat and 'ParamRepeat') or type_class
             info.append(type_name)

--- a/src/sardana/macroserver/msparameter.py
+++ b/src/sardana/macroserver/msparameter.py
@@ -29,7 +29,7 @@ macros"""
 __all__ = ["WrongParam", "MissingParam", "SupernumeraryParam",
            "UnknownParamObj", "WrongParamType", "MissingRepeat",
            "SupernumeraryRepeat", "TypeNames", "Type", "ParamType",
-           "ParamRepeat", "ElementParamType", "ElementParamInterface",
+           "ElementParamType", "ElementParamInterface",
            "AttrParamType", "AbstractParamTypes", "ParamDecoder"]
 
 __docformat__ = 'restructuredtext'
@@ -184,26 +184,6 @@ class ParamType(MSBaseObject):
         kwargs = MSBaseObject.serialize(self, *args, **kwargs)
         kwargs['composed'] = False
         return kwargs
-
-
-class ParamRepeat(object):
-    # opts: min, max
-
-    def __init__(self, *param_def, **opts):
-        self.param_def = param_def
-        self.opts = {'min': 1, 'max': None}
-        self.opts.update(opts)
-        self._obj = list(param_def)
-        self._obj.append(self.opts)
-
-    def items(self):
-        return list(self.opts.items())
-
-    def __getattr__(self, name):
-        return self.opts[name]
-
-    def obj(self):
-        return self._obj
 
 
 class ElementParamType(ParamType):


### PR DESCRIPTION
Also correct some examples and docstrings.

As part of the Sardana 3 release we remove the deprecated features. See details in #1315.