### PR TITLE
Remove deprecated FileRecorder macro hint (7)

### DIFF
--- a/src/sardana/macroserver/macros/examples/specific_experiments.py
+++ b/src/sardana/macroserver/macros/examples/specific_experiments.py
@@ -41,7 +41,7 @@ class xas_acq(Macro, Hookable):
 
     Perform an X-ray absorption scan experiment. Data is stored in a NXxas-compliant file.
     """
-    hints = {'FileRecorder': 'NXxas_FileRecorder', 'scan': 'xas_acq', 'allowsHooks': (
+    hints = {'scan': 'xas_acq', 'allowsHooks': (
         'pre-move', 'post-move', 'pre-acq', 'post-acq', 'post-step')}
     # env = ('MonochromatorEnergy', )#'AbsorbedBeam', 'IncomingBeam',
     # 'Monitor') #this hints that the macro requires the ActiveMntGrp

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -213,7 +213,7 @@ class GScan(Logger):
     - DataHandler with the following recorders:
     - OutputRecorder (depends on ``OutputCols`` environment variable)
     - SharedMemoryRecorder (depends on ``SharedMemory`` environment variable)
-    - FileRecorder (depends on ``ScanDir`` and ``ScanData``
+    - FileRecorder (depends on ``ScanDir``, ``ScanData`` and ``ScanRecorder``
       environment variables)
     - ScanDataEnvironment with the following contents:
 

--- a/src/sardana/macroserver/scan/recorder/storage.py
+++ b/src/sardana/macroserver/scan/recorder/storage.py
@@ -304,21 +304,14 @@ class BaseNAPI_FileRecorder(BaseNEXUS_FileRecorder):
 def FileRecorder(filename, macro, **pars):
     ext = os.path.splitext(filename)[1].lower() or '.spec'
     rec_manager = macro.getMacroServer().recorder_manager
-
-    hinted_recorder = getattr(macro, 'hints', {}).get('FileRecorder', None)
-    if hinted_recorder is not None:
-        macro.deprecated("FileRecorder macro hints are deprecated. "
-                         "Use ScanRecorder variable instead.")
-        klass = rec_manager.getRecorderClass(hinted_recorder)
+    klasses = rec_manager.getRecorderClasses(
+        filter=BaseFileRecorder, extension=ext)
+    len_klasses = len(klasses)
+    if len_klasses == 0:
+        klass = rec_manager.getRecorderClass('SPEC_FileRecorder')
+    elif len_klasses == 1:
+        klass = list(klasses.values())[0]
     else:
-        klasses = rec_manager.getRecorderClasses(
-            filter=BaseFileRecorder, extension=ext)
-        len_klasses = len(klasses)
-        if len_klasses == 0:
-            klass = rec_manager.getRecorderClass('SPEC_FileRecorder')
-        elif len_klasses == 1:
-            klass = list(klasses.values())[0]
-        else:
-            raise AmbiguousRecorderError('Choice of recorder for %s '
-                                         'extension is ambiguous' % ext)
+        raise AmbiguousRecorderError('Choice of recorder for %s '
+                                     'extension is ambiguous' % ext)
     return klass(filename=filename, macro=macro, **pars)


### PR DESCRIPTION
As part of the Sardana 3 release we remove the deprecated features. See details in #1315.

