### PR TITLE
Remove deprecated Controller API (8-14, 31)

### DIFF
--- a/src/sardana/pool/controller.py
+++ b/src/sardana/pool/controller.py
@@ -111,10 +111,6 @@ class Controller(object):
 
     #: A sequence of :obj:`str` representing the controller features
     ctrl_features = []
-    #:
-    #: .. deprecated:: 1.0
-    #:     use :attr:`~Controller.axis_attributes` instead
-    ctrl_extra_attributes = {}
 
     #: A :class:`dict` containing controller properties where:
     #:
@@ -492,9 +488,7 @@ class Controller(object):
         .. versionadded:: 1.0"""
         ret = copy.deepcopy(self.standard_axis_attributes)
         axis_attrs = copy.deepcopy(self.axis_attributes)
-        old_axis_attrs = copy.deepcopy(self.ctrl_extra_attributes)
         ret.update(axis_attrs)
-        ret.update(old_axis_attrs)
         return ret
 
     def SendToCtrl(self, stream):

--- a/src/sardana/pool/controller.py
+++ b/src/sardana/pool/controller.py
@@ -331,14 +331,6 @@ class Controller(object):
         :param int axis: axis number"""
         pass
 
-    @property
-    def inst_name(self):
-        """**Controller API**. The controller instance name.
-
-        .. deprecated:: 1.0
-            use :meth:`~Controller.GetName` instead"""
-        return self._inst_name
-
     def GetName(self):
         """**Controller API**. The controller instance name.
 

--- a/src/sardana/pool/controller.py
+++ b/src/sardana/pool/controller.py
@@ -109,11 +109,6 @@ class Controller(object):
     :keyword kwargs:
     """
 
-    #:
-    #: .. deprecated:: 1.0
-    #:     use :attr:`~Controller.ctrl_properties` instead
-    class_prop = {}
-
     #: A sequence of :obj:`str` representing the controller features
     ctrl_features = []
     #:

--- a/src/sardana/pool/controller.py
+++ b/src/sardana/pool/controller.py
@@ -415,36 +415,18 @@ class Controller(object):
     def SetAxisExtraPar(self, axis, parameter, value):
         """**Controller API**. Override if necessary.
         Called to set a parameter with a value on the given axis. Default
-        implementation calls deprecated :meth:`~Controller.SetExtraAttributePar`
-        which, by default, raises :exc:`NotImplementedError`.
+        implementation raises :exc:`NotImplementedError`.
 
         .. versionadded:: 1.0"""
-        return self.SetExtraAttributePar(axis, parameter, value)
+        raise NotImplementedError("SetAxisExtraPar must be defined in the "
+                                  "controller")
 
     def GetAxisExtraPar(self, axis, parameter):
         """**Controller API**. Override if necessary.
         Called to get a parameter value on the given axis. Default
-        implementation calls deprecated :meth:`~Controller.GetExtraAttributePar`
-        which, by default, raises :exc:`NotImplementedError`.
+        implementation raises :exc:`NotImplementedError`.
 
         .. versionadded:: 1.0"""
-        return self.GetExtraAttributePar(axis, parameter)
-
-    def SetExtraAttributePar(self, axis, parameter, value):
-        """**Controller API**. Called to set a parameter with a value on the
-        given axis. Default implementation raises :exc:`NotImplementedError`.
-
-        .. deprecated:: 1.0
-            use :meth:`~Controller.SetAxisExtraPar` instead"""
-        raise NotImplementedError("SetAxisExtraPar must be defined in the "
-                                  "controller")
-
-    def GetExtraAttributePar(self, axis, parameter):
-        """**Controller API**. Called to get a parameter value on the given
-        axis. Default implementation raises :exc:`NotImplementedError`.
-
-        .. deprecated:: 1.0
-            use :meth:`~Controller.GetAxisExtraPar` instead"""
         raise NotImplementedError("GetAxisExtraPar must be defined in the "
                                   "controller")
 

--- a/src/sardana/pool/controller.py
+++ b/src/sardana/pool/controller.py
@@ -397,20 +397,20 @@ class Controller(object):
     def SetAxisPar(self, axis, parameter, value):
         """**Controller API**. Override is MANDATORY.
         Called to set a parameter with a value on the given axis. Default
-        implementation calls deprecated :meth:`~Controller.SetPar` which, by
-        default, raises :exc:`NotImplementedError`.
+        implementation raises :exc:`NotImplementedError`.
 
         .. versionadded:: 1.0"""
-        return self.SetPar(axis, parameter, value)
+        raise NotImplementedError("SetAxisPar must be defined in the "
+                                  "controller")
 
     def GetAxisPar(self, axis, parameter):
         """**Controller API**. Override is MANDATORY.
         Called to get a parameter value on the given axis. Default
-        implementation calls deprecated :meth:`~Controller.GetPar` which, by
-        default, raises :exc:`NotImplementedError`.
+        implementation raises :exc:`NotImplementedError`.
 
         .. versionadded:: 1.0"""
-        return self.GetPar(axis, parameter)
+        raise NotImplementedError("GetAxisPar must be defined in the "
+                                  "controller")
 
     def SetAxisExtraPar(self, axis, parameter, value):
         """**Controller API**. Override if necessary.
@@ -429,25 +429,6 @@ class Controller(object):
 
         .. versionadded:: 1.0"""
         return self.GetExtraAttributePar(axis, parameter)
-
-    def SetPar(self, axis, parameter, value):
-        """**Controller API**. Called to set a parameter with a value on
-        the given axis. Default implementation raises
-        :exc:`NotImplementedError`.
-
-        .. deprecated:: 1.0
-            use :meth:`~Controller.SetAxisPar` instead"""
-        raise NotImplementedError("SetAxisPar must be defined in the "
-                                  "controller")
-
-    def GetPar(self, axis, parameter):
-        """**Controller API**. Called to get a parameter value on the given
-        axis. Default implementation raises :exc:`NotImplementedError`.
-
-        .. deprecated:: 1.0
-            use :meth:`~Controller.GetAxisPar` instead"""
-        raise NotImplementedError("GetAxisPar must be defined in the "
-                                  "controller")
 
     def SetExtraAttributePar(self, axis, parameter, value):
         """**Controller API**. Called to set a parameter with a value on the
@@ -778,13 +759,7 @@ class MotorController(Controller, Startable, Stopable, Readable):
         - step_per_unit
 
     These parameters are configured through the
-    :meth:`~Controller.GetAxisPar`/:meth:`~Controller.SetAxisPar`
-    API (in version <1.0 the methods were called
-    :meth:`~Controller.GetPar`/:meth:`~Controller.SetPar`. Default
-    :meth:`~Controller.GetAxisPar` and
-    :meth:`~Controller.SetAxisPar` still call
-    :meth:`~Controller.GetPar` and :meth:`~Controller.SetPar`
-    respectively in order to maintain backward compatibility).
+    :meth:`~Controller.GetAxisPar`/:meth:`~Controller.SetAxisPar` API.
     """
 
     #: A constant representing no active switch.

--- a/src/sardana/pool/poolcontrollers/HklPseudoMotorController.py
+++ b/src/sardana/pool/poolcontrollers/HklPseudoMotorController.py
@@ -117,8 +117,10 @@ class DiffracBasis(PseudoMotorController):
 
     """ The PseudoMotor controller for the diffractometer"""
 
-    class_prop = {'DiffractometerType': {Type: str,
-                                         Description: 'Type of the diffractometer, e.g. E6C'},  # noqa
+    ctrl_properties = {
+        'DiffractometerType': {
+            Type: str,
+            Description: 'Type of the diffractometer, e.g. E6C'},
     }
 
     ctrl_attributes = {'Crystal': {Type: str,

--- a/src/sardana/pool/poolmetacontroller.py
+++ b/src/sardana/pool/poolmetacontroller.py
@@ -269,17 +269,10 @@ class ControllerClass(SardanaClass):
 
         self.ctrl_properties = props = CaselessDict()
         self.ctrl_properties_descriptions = []
-        dep_msg = ("Defining the controller property description using a "
-                   + "string is deprecated, use "
-                   + "sardana.pool.controller.Description constant instead.")
-
         for k, v in list(klass.ctrl_properties.items()):
             props[k] = DataInfo.toDataInfo(k, v)
             if Description in v:
                 self.ctrl_properties_descriptions.append(v[Description])
-            elif 'Description' in v:
-                self.warning(dep_msg)
-                self.ctrl_properties_descriptions.append(v['Description'])
 
         self.dict_extra['properties'] = tuple(klass.ctrl_properties)
         self.dict_extra['properties_desc'] = self.ctrl_properties_descriptions

--- a/src/sardana/pool/poolmetacontroller.py
+++ b/src/sardana/pool/poolmetacontroller.py
@@ -289,8 +289,6 @@ class ControllerClass(SardanaClass):
             ctrl_attrs[k] = DataInfo.toDataInfo(k, v)
 
         self.axis_attributes = axis_attrs = CaselessDict()
-        for k, v in list(klass.ctrl_extra_attributes.items()):  # old member
-            axis_attrs[k] = DataInfo.toDataInfo(k, v)
         for k, v in list(klass.axis_attributes.items()):
             axis_attrs[k] = DataInfo.toDataInfo(k, v)
 

--- a/src/sardana/pool/poolmetacontroller.py
+++ b/src/sardana/pool/poolmetacontroller.py
@@ -272,13 +272,6 @@ class ControllerClass(SardanaClass):
         dep_msg = ("Defining the controller property description using a "
                    + "string is deprecated, use "
                    + "sardana.pool.controller.Description constant instead.")
-        for k, v in list(klass.class_prop.items()):  # old member
-            props[k] = DataInfo.toDataInfo(k, v)
-            if Description in v:
-                self.ctrl_properties_descriptions.append(v[Description])
-            elif 'Description' in v:
-                self.warning(dep_msg)
-                self.ctrl_properties_descriptions.append(v['Description'])
 
         for k, v in list(klass.ctrl_properties.items()):
             props[k] = DataInfo.toDataInfo(k, v)


### PR DESCRIPTION
As part of the Sardana 3 release we remove the deprecated features. See details in #1315.