### PR TITLE
Remove deprecated IOR predefined_values (25)

### DIFF
--- a/src/sardana/pool/controller.py
+++ b/src/sardana/pool/controller.py
@@ -1523,10 +1523,6 @@ class IORegisterController(Controller, Readable):
     """Base class for a IORegister controller. Inherit from this class to
     implement your own IORegister controller for the device pool.
     """
-    #:
-    #: .. deprecated:: 1.0
-    #:     use :attr:`~Controller.axis_attributes` instead
-    predefined_values = ()
 
     #: A :class:`dict` containing the standard attributes present on each axis
     #: device

--- a/src/sardana/pool/poolcontrollers/DummyIORController.py
+++ b/src/sardana/pool/poolcontrollers/DummyIORController.py
@@ -35,8 +35,6 @@ class DummyIORController(IORegisterController):
 
     MaxDevice = 1024
 
-    predefined_values = "0", "Online", "1", "Offline", "2", "Standby"
-
     def __init__(self, inst, props, *args, **kwargs):
         IORegisterController.__init__(self, inst, props, *args, **kwargs)
         self.myvalue = 1

--- a/src/sardana/pool/poolmetacontroller.py
+++ b/src/sardana/pool/poolmetacontroller.py
@@ -320,9 +320,6 @@ class ControllerClass(SardanaClass):
             self.dict_extra['counter_roles'] = self.counter_roles
             self.dict_extra['pseudo_counter_roles'] = self.pseudo_counter_roles
 
-        if ElementType.IORegister in types:
-            self.dict_extra['predefined_values'] = klass.predefined_values
-
         init_args = inspect.getargspec(klass.__init__)
         if init_args.varargs is None or init_args.keywords is None:
             self.api_version = 0


### PR DESCRIPTION
As part of the Sardana 3 release we remove the deprecated features. See details in #1315.