### PR TITLE
Remove deprecated LoadOne backawards compatibility (26, 27, 48, 49)

### DIFF
--- a/doc/source/devel/howto_controllers/howto_countertimercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_countertimercontroller.rst
@@ -115,7 +115,7 @@ Here is an example of the possible implementation of
 
     class SpringfieldCounterTimerController(CounterTimerController):
 
-        def LoadOne(self, axis, value, repetitions):
+        def LoadOne(self, axis, value, repetitions, latency):
             self.springfield.LoadChannel(axis, value)
 
 .. _sardana-countertimercontroller-howto-value:
@@ -474,7 +474,7 @@ Here is an example of the possible implementation of
 
     class SpringfieldCounterTimerController(CounterTimerController):
 
-        def LoadOne(self, axis, value, repetitions):
+        def LoadOne(self, axis, value, repetitions, latency):
             self.springfield.LoadChannel(axis, value)
             self.springfield.SetRepetitions(repetitions)
             return value

--- a/doc/source/devel/howto_controllers/sf_ct_ctrl.py
+++ b/doc/source/devel/howto_controllers/sf_ct_ctrl.py
@@ -66,7 +66,7 @@ class SpringfieldBaseCounterTimerController(CounterTimerController):
         """acquire the specified counter"""
         self.springfield.StartChannel(axis)
 
-    def LoadOne(self, axis, value, repetitions):
+    def LoadOne(self, axis, value, repetitions, latency):
         self.springfield.LoadChannel(axis, value)
 
     def StopOne(self, axis):
@@ -112,7 +112,7 @@ class SpringfieldCounterTimerController(CounterTimerController):
         value = self.springfield.getValue(axis)
         return value
 
-    def LoadOne(self, axis, value, repetitions):
+    def LoadOne(self, axis, value, repetitions, latency):
         self.springfield.LoadChannel(axis, value)
 
     def StartOne(self, axis, position):

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -886,43 +886,12 @@ class PoolAcquisitionTimerable(PoolAcquisitionBase):
             pool_ctrl = channel.controller
             ctrl = pool_ctrl.ctrl
             ctrl.PreLoadAll()
-            try:
-                res = ctrl.PreLoadOne(axis, value, repetitions,
-                                      latency)
-            except TypeError:
-                try:
-                    res = ctrl.PreLoadOne(axis, value, repetitions)
-                    msg = ("PreLoadOne(axis, value, repetitions) is "
-                           "deprecated since version 2.7.0."
-                           "Use PreLoadOne(axis, value, repetitions, "
-                           "latency_time) instead.")
-                    self.warning(msg)
-                except TypeError:
-                    res = ctrl.PreLoadOne(axis, value)
-                    msg = ("PreLoadOne(axis, value) is deprecated since "
-                           "version 2.3.0. Use PreLoadOne(axis, value, "
-                           "repetitions, latency_time) instead.")
-                    self.warning(msg)
+            res = ctrl.PreLoadOne(axis, value, repetitions, latency)
             if not res:
                 msg = ("%s.PreLoadOne(%d) returned False" %
                        (pool_ctrl.name, axis))
                 raise Exception(msg)
-            try:
-                ctrl.LoadOne(axis, value, repetitions, latency)
-            except TypeError:
-                try:
-                    ctrl.LoadOne(axis, value, repetitions)
-                    msg = ("LoadOne(axis, value, repetitions) is"
-                           "deprecated since version Jan18."
-                           "Use LoadOne(axis, value, repetitions, "
-                           "latency_time) instead.")
-                    self.warning(msg)
-                except TypeError:
-                    ctrl.LoadOne(axis, value)
-                    msg = ("LoadOne(axis, value) is deprecated since "
-                           "version 2.3.0. Use LoadOne(axis, value, "
-                           "repetitions) instead.")
-                    self.warning(msg)
+            ctrl.LoadOne(axis, value, repetitions, latency)
             ctrl.LoadAll()
 
         with ActionContext(self):

--- a/src/sardana/pool/poolcontrollers/DummyOneDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyOneDController.py
@@ -248,7 +248,7 @@ class DummyOneDController(OneDController):
     def StartAll(self):
         self.start_time = time.time()
 
-    def LoadOne(self, axis, value, repetitions):
+    def LoadOne(self, axis, value, repetitions, latency_time):
         idx = axis - 1
         if value > 0:
             self.integ_time = value

--- a/src/sardana/pool/poolcontrollers/TaurusController.py
+++ b/src/sardana/pool/poolcontrollers/TaurusController.py
@@ -48,7 +48,7 @@ class TaurusCounterTimerController(CounterTimerController):
     def DeleteDevice(self, axis):
         self._axes_taurus_attr.pop(axis)
 
-    def LoadOne(self, axis, value):
+    def LoadOne(self, axis, value, repetitions, latency):
         pass
 
     def StateOne(self, axis):


### PR DESCRIPTION
As part of the Sardana 3 release we remove the deprecated features. See details in #1315.