### PR TITLE
Remove backwards compatibility for measurement group start without preparation (30)

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2476,7 +2476,8 @@ class CTScan(CScan, CAcquisition):
             self.macro.checkPoint()
 
             self.macro.debug("Starting measurement group")
-
+            self.measurement_group.setNbStarts(1)
+            self.measurement_group.prepare()
             mg_id = self.measurement_group.start()
             if i == 0:
                 first_timestamp = time.time()

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -1342,16 +1342,8 @@ class PoolMeasurementGroup(PoolGroupElement):
         ..todo:: remove value and multiple arguments.
         """
         if self._pending_starts == 0:
-            msg = "starting acquisition without prior preparing is " \
-                  "deprecated since version Jan18."
-            self.warning(msg)
-            self.debug("Preparing with number_of_starts equal to 1")
-            nb_starts = self.nb_starts
-            self.set_nb_starts(1, propagate=0)
-            try:
-                self.prepare(multiple)
-            finally:
-                self.set_nb_starts(nb_starts, propagate=0)
+            msg = "prepare is mandatory before starting acquisition"
+            raise RuntimeError(msg)
         self._aborted = False
         self._pending_starts -= 1
         if not self._simulation_mode:

--- a/src/sardana/tango/pool/test/test_measurementgroup.py
+++ b/src/sardana/tango/pool/test/test_measurementgroup.py
@@ -220,6 +220,8 @@ class MeasSarTestTestCase(SarTestTestCase):
         self.prepare_meas(params)
         chn_names = self._add_attribute_listener(config)
         # Do acquisition
+        self.meas.write_attribute("NbStarts", 1)
+        self.meas.Prepare()
         self.meas.Start()
         while self.meas.State() == PyTango.DevState.MOVING:
             print("Acquiring...")
@@ -250,6 +252,8 @@ class MeasSarTestTestCase(SarTestTestCase):
                                         self.push_event)
         try:
             # starting timer (0.2 s) which will stop the measurement group
+            self.meas.write_attribute("NbStarts", 1)
+            self.meas.Prepare()
             self.meas.Start()
             threading.Timer(0.2, self.stopMeas).start()
             self.assertTrue(self.meas_finished.wait(5), "mg has not stopped")


### PR DESCRIPTION
As part of the Sardana 3 release we remove the deprecated features. See details in #1315.