### PR TITLE
Remove deprecated Door's Abort command (41)

### DIFF
--- a/src/sardana/tango/macroserver/Door.py
+++ b/src/sardana/tango/macroserver/Door.py
@@ -354,19 +354,12 @@ class Door(SardanaDevice):
     def read_MacroStatus(self, attr):
         attr.set_value('', '')
 
-    def Abort(self):
-        self.debug("Abort is deprecated. Use StopMacro instead")
-        return self.StopMacro()
-
     def AbortMacro(self):
         macro = self.getRunningMacro()
         if macro is None:
             return
         self.debug("aborting %s" % macro._getDescription())
         self.macro_executor.abort()
-
-    def is_Abort_allowed(self):
-        return True
 
     def ReleaseMacro(self):
         macro = self.getRunningMacro()
@@ -472,9 +465,6 @@ class DoorClass(SardanaDeviceClass):
 
     #    Command definitions
     cmd_list = {
-        'Abort':
-            [[DevVoid, ""],
-             [DevVoid, ""]],
         'PauseMacro':
             [[DevVoid, ""],
              [DevVoid, ""]],


### PR DESCRIPTION
As part of the Sardana 3 release we remove the deprecated features. See details in #1315.