### PR TITLE
Remove Controller's (Taurus extension) getUsedAxis method (42)

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -670,12 +670,6 @@ class Controller(PoolElement):
             axes.append(elem.getAxis())
         return sorted(axes)
 
-    def getUsedAxis(self):
-        msg = ("getUsedAxis is deprecated since version 2.5.0. ",
-               "Use getUsedAxes instead.")
-        self.warning(msg)
-        self.getUsedAxes()
-
     def getLastUsedAxis(self):
         """Return the last used axis (the highest axis) in this controller
 


### PR DESCRIPTION
As part of the Sardana 3 release we remove the deprecated features. See details in #1315.