### PR TITLE
Fix zip over pseudomotor physical position that is not iterable

### DIFF
--- a/src/sardana/pool/poolpseudomotor.py
+++ b/src/sardana/pool/poolpseudomotor.py
@@ -550,7 +550,11 @@ class PoolPseudoMotor(PoolBaseGroup, PoolElement):
 
         if items is None:
             items = {}
-        for new_position, element in zip(physical_positions.value, user_elements):
+
+         positions = physical_positions.value
+         if not hasattr(positions , "__iter__"):
+             positions = [positions]
+         for new_position, element in zip(positions, user_elements):
             if new_position is None:
                 raise PoolException("Cannot calculate motion: %s reports "
                                     "position to be None" % element.name)


### PR DESCRIPTION
When calc_all_physical returns a single position object that is not
iterable, zip of positions and elements fails.
This fix creates a list from a value that is not iterable