### PR TITLE
Fix appveyor configuration (python3)

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -25,7 +25,7 @@ install:
 
     # Upgrade/install distribution modules
     - "pip3 install --upgrade setuptools"
-    - "python3 -m pip install --upgrade pip"
+    - "python -m pip install --upgrade pip"
 
     # Install virtualenv
     - "pip3 install --upgrade virtualenv"
@@ -40,7 +40,7 @@ build_script:
     - "pip3 install --upgrade wheel"
 
     # Build sardana sdist, msi and wheel
-    - "python3 setup.py sdist bdist_wheel bdist_msi"
+    - "python setup.py sdist bdist_wheel bdist_msi"
     - ps: "ls dist"
 
     # Leave build virtualenv


### PR DESCRIPTION
In ccfd7066 I tried to adapt the appveyor configuration file to build python 3 packages without success. This PR is just trying to fix it and rebuild on appveyor without pushing to the release branch. Whenever I'm satisfied I will squash the attempting commits and push it to the release branch.