### PR TITLE
Fix premature end of acquisition on Windows

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 3.0.2-alpha
+current_version = 3.0.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This file follows the formats and conventions from [keepachangelog.com]
 
 ## [Unreleased]
 
-## [3.0.2]
+## [3.0.2] 2020-08-22
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the formats and conventions from [keepachangelog.com]
 
-## [Unreleased]
+## [3.0.2]
 
 ### Added
 
@@ -932,7 +932,7 @@ Main improvements since sardana 1.5.0 (aka Jan15):
 
 
 [keepachangelog.com]: http://keepachangelog.com
-[Unreleased]: https://github.com/sardana-org/sardana/compare/2.8.6...HEAD
+[3.0.2]: https://github.com/sardana-org/sardana/compare/3.0.2...2.8.6
 [2.8.6]: https://github.com/sardana-org/sardana/compare/2.8.6...2.8.5
 [2.8.5]: https://github.com/sardana-org/sardana/compare/2.8.5...2.8.4
 [2.8.4]: https://github.com/sardana-org/sardana/compare/2.8.4...2.8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the formats and conventions from [keepachangelog.com]
 
+## [Unreleased]
+
 ## [3.0.2]
 
 ### Added
@@ -932,6 +934,7 @@ Main improvements since sardana 1.5.0 (aka Jan15):
 
 
 [keepachangelog.com]: http://keepachangelog.com
+[Unreleased]: https://github.com/sardana-org/sardana/compare/3.0.2...HEAD
 [3.0.2]: https://github.com/sardana-org/sardana/compare/3.0.2...2.8.6
 [2.8.6]: https://github.com/sardana-org/sardana/compare/2.8.6...2.8.5
 [2.8.5]: https://github.com/sardana-org/sardana/compare/2.8.5...2.8.4

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -19,6 +19,30 @@ environment:
           PYTHON_ARCH: "32"
           CONDA_PY: "35"
 
+      # Python 3.6 (64)
+        - PYTHON_DIR: "C:\\Python36-x64"
+          PYTHON_VERSION: "3.6"
+          PYTHON_ARCH: "64"
+          CONDA_PY: "36"
+
+      # Python 3.6
+        - PYTHON_DIR: "C:\\Python36"
+          PYTHON_VERSION: "3.6"
+          PYTHON_ARCH: "32"
+          CONDA_PY: "36"
+
+      # Python 3.7 (64)
+        - PYTHON_DIR: "C:\\Python37-x64"
+          PYTHON_VERSION: "3.7"
+          PYTHON_ARCH: "64"
+          CONDA_PY: "37"
+
+      # Python 3.7
+        - PYTHON_DIR: "C:\\Python37"
+          PYTHON_VERSION: "3.7"
+          PYTHON_ARCH: "32"
+          CONDA_PY: "37"
+
 install:
     # Add Python to PATH
     - "SET PATH=%PYTHON_DIR%;%PYTHON_DIR%\\Scripts;%PATH%"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -43,6 +43,18 @@ environment:
           PYTHON_ARCH: "32"
           CONDA_PY: "37"
 
+      # Python 3.8 (64)
+        - PYTHON_DIR: "C:\\Python38-x64"
+          PYTHON_VERSION: "3.8"
+          PYTHON_ARCH: "64"
+          CONDA_PY: "38"
+
+      # Python 3.8
+        - PYTHON_DIR: "C:\\Python38"
+          PYTHON_VERSION: "3.8"
+          PYTHON_ARCH: "32"
+          CONDA_PY: "38"
+
 install:
     # Add Python to PATH
     - "SET PATH=%PYTHON_DIR%;%PYTHON_DIR%\\Scripts;%PATH%"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -7,28 +7,28 @@ environment:
         VENV_TEST_DIR: "venv_test"
 
     matrix:
-        # Python 2.7 (64)
-        - PYTHON_DIR: "C:\\Python27-x64"
-          PYTHON_VERSION: "2.7"
+        # Python 3.5 (64)
+        - PYTHON_DIR: "C:\\Python35-x64"
+          PYTHON_VERSION: "3.5"
           PYTHON_ARCH: "64"
-          CONDA_PY: "27"
+          CONDA_PY: "35"
 
-        # Python 2.7
-        - PYTHON_DIR: "C:\\Python27"
-          PYTHON_VERSION: "2.7"
+        # Python 3.5
+        - PYTHON_DIR: "C:\\Python35"
+          PYTHON_VERSION: "3.5"
           PYTHON_ARCH: "32"
-          CONDA_PY: "27"
+          CONDA_PY: "35"
 
 install:
     # Add Python to PATH
     - "SET PATH=%PYTHON_DIR%;%PYTHON_DIR%\\Scripts;%PATH%"
 
     # Upgrade/install distribution modules
-    - "pip install --upgrade setuptools"
-    - "python -m pip install --upgrade pip"
+    - "pip3 install --upgrade setuptools"
+    - "python3 -m pip install --upgrade pip"
 
     # Install virtualenv
-    - "pip install --upgrade virtualenv"
+    - "pip3 install --upgrade virtualenv"
     - "virtualenv --version"
 
 build_script:
@@ -37,10 +37,10 @@ build_script:
     - "%VENV_BUILD_DIR%\\Scripts\\activate.bat"
 
     # Install wheel
-    - "pip install --upgrade wheel"
+    - "pip3 install --upgrade wheel"
 
     # Build sardana sdist, msi and wheel
-    - "python setup.py sdist bdist_wheel bdist_msi"
+    - "python3 setup.py sdist bdist_wheel bdist_msi"
     - ps: "ls dist"
 
     # Leave build virtualenv

--- a/doc/source/devel/howto_test/test_general.rst
+++ b/doc/source/devel/howto_test/test_general.rst
@@ -32,7 +32,7 @@ should be used for integration and system tests as well.
 The following are some key points to keep in mind when using this framework:
 
 * Most of the tests in the Sardana Test Framework use :mod:`unittest`.
-  Since Sardana Jan20 we decided to move to `pytest <https://docs.pytest.org>`_
+  Since Sardana 3.0.2 we decided to move to `pytest <https://docs.pytest.org>`_
   and we plan to gradually migrate the already existing tests.
 * All test-related code is contained in submodules named ``test`` which appear
   in any module of Sardana.

--- a/src/sardana/macroserver/macros/examples/scans.py
+++ b/src/sardana/macroserver/macros/examples/scans.py
@@ -99,7 +99,7 @@ class ascan_demo(Macro):
         return self._gScan.data  # the GScan provides scan data
 
     def _get_nr_points(self):
-        msg = ("nr_points is deprecated since version Jan20. "
+        msg = ("nr_points is deprecated since version 3.0.2. "
                "Use nb_points instead.")
         self.warning(msg)
         return self.nb_points
@@ -184,7 +184,7 @@ class ascanr(Macro, Hookable):
         return self._gScan.data
 
     def _get_nr_points(self):
-        msg = ("nr_points is deprecated since version Jan20. "
+        msg = ("nr_points is deprecated since version 3.0.2. "
                "Use nb_points instead.")
         self.warning(msg)
         return self.nb_points
@@ -296,7 +296,7 @@ class toothedtriangle(Macro, Hookable):
         return self._gScan.data
 
     def _get_nr_points(self):
-        msg = ("nr_points is deprecated since version Jan20. "
+        msg = ("nr_points is deprecated since version 3.0.2. "
                "Use nb_points instead.")
         self.warning(msg)
         return self.nb_points

--- a/src/sardana/macroserver/macros/examples/specific_experiments.py
+++ b/src/sardana/macroserver/macros/examples/specific_experiments.py
@@ -123,7 +123,7 @@ class xas_acq(Macro, Hookable):
         return self._gScan.data  # the GScan provides scan data
 
     def _get_nr_points(self):
-        msg = ("nr_points is deprecated since version Jan20. "
+        msg = ("nr_points is deprecated since version 3.0.2. "
                "Use nb_points instead.")
         self.warning(msg)
         return self.nb_points

--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -336,7 +336,7 @@ class aNscan(Hookable):
         scan.data.initRecords(missing_records)
 
     def _get_nr_points(self):
-        msg = ("nr_points is deprecated since version Jan20. "
+        msg = ("nr_points is deprecated since version 3.0.2. "
                "Use nb_points instead.")
         self.warning(msg)
         return self.nb_points
@@ -964,7 +964,7 @@ motor2 sqrt(y*x+3)
             yield step
 
     def _get_nr_points(self):
-        msg = ("nr_points is deprecated since version Jan20. "
+        msg = ("nr_points is deprecated since version 3.0.2. "
                "Use nb_points instead.")
         self.warning(msg)
         return self.nb_points
@@ -1826,7 +1826,7 @@ class meshct(Macro, Hookable):
         scan.data.initRecords(missing_records)
 
     def _get_nr_points(self):
-        msg = ("nr_points is deprecated since version Jan20. "
+        msg = ("nr_points is deprecated since version 3.0.2. "
                "Use nb_points instead.")
         self.warning(msg)
         return self.nb_points
@@ -1875,7 +1875,7 @@ class timescan(Macro, Hookable):
         return self.nr_interv
 
     def _get_nr_points(self):
-        msg = ("nr_points is deprecated since version Jan20. "
+        msg = ("nr_points is deprecated since version 3.0.2. "
                "Use nb_points instead.")
         self.warning(msg)
         return self.nb_points

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -924,7 +924,7 @@ class MeasurementConfiguration(object):
                 channel_data:
             if self._value_ref_compat:
                 msg = 'value_ref_pattern/value_ref_enabled is deprecated ' \
-                      'for non-referable channels since Jul20. Re-apply ' \
+                      'for non-referable channels since 3.0.2. Re-apply ' \
                       'configuration in order to upgrade.'
                 self._parent.warning(msg)
                 channel_data.pop('value_ref_enabled')

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,7 +47,7 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = 'version = '3.0.2-alpha''
+version = 'version = '3.0.2''
 
 description = "instrument control and data acquisition system"
 

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,7 +47,7 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = 'version = '3.0.2''
+version = '3.0.2'
 
 description = "instrument control and data acquisition system"
 

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,7 +47,7 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '3.0.2-alpha'
+version = 'version = '3.0.2-alpha''
 
 description = "instrument control and data acquisition system"
 

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -479,6 +479,11 @@ class PoolElement(BaseElement, TangoDevice):
         evt_wait.connect(self.getAttribute("state"))
         try:
             evt_wait.waitEvent(DevState.MOVING, equal=False)
+            # Clear event set to not confuse the value coming from the
+            # connection with the event of of end of the operation
+            # in the next wait event. This was observed on Windows where
+            # the time stamp resolution is very poor.
+            evt_wait.clearEventSet()
             self.__go_time = 0
             self.__go_start_time = ts1 = time.time()
             self._start(*args, **kwargs)

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -2333,7 +2333,7 @@ class MGConfiguration(object):
 
         :param timer: <str> timer name
         """
-        self._mg().warning("setTimer() is deprecated since Jul20. "
+        self._mg().warning("setTimer() is deprecated since 3.0.2. "
                            "Global measurement group timer does not exist")
         result = self._get_ctrl_for_channel([timer], unique=True)
 
@@ -2344,13 +2344,13 @@ class MGConfiguration(object):
 
     def getTimer(self):
         """DEPRECATED"""
-        self._mg().warning("getTimer() is deprecated since Jul20. "
+        self._mg().warning("getTimer() is deprecated since 3.0.2. "
                            "Global measurement group timer does not exist")
         return self._getTimer()
 
     def getMonitor(self):
         """DEPRECATED"""
-        self._mg().warning("getMonitor() is deprecated since Jul20. "
+        self._mg().warning("getMonitor() is deprecated since 3.0.2. "
                            "Global measurement group monitor does not exist")
         return self._getMonitor()
 
@@ -3080,19 +3080,19 @@ class MeasurementGroup(PoolElement):
 
     def getMonitorName(self):
         """DEPRECATED"""
-        self.warning("getMonitorName() is deprecated since Jul20. "
+        self.warning("getMonitorName() is deprecated since 3.0.2. "
                      "Global measurement group monitor does not exist.")
         return self.getConfiguration()._getMonitorName()
 
     def getTimerName(self):
         """DEPRECATED"""
-        self.warning("getTimerName() is deprecated since Jul20. "
+        self.warning("getTimerName() is deprecated since 3.0.2. "
                      "Global measurement group timer does not exist.")
         return self.getConfiguration()._getTimerName()
 
     def getTimerValue(self):
         """DEPRECATED"""
-        self.warning("getTimerValue() is deprecated since Jul20. "
+        self.warning("getTimerValue() is deprecated since 3.0.2. "
                      "Global measurement group timer does not exist.")
         return self.getConfiguration()._getTimerValue()
 
@@ -3102,7 +3102,7 @@ class MeasurementGroup(PoolElement):
         :param channels: (seq<str>) a sequence of strings indicating
            channel names
         '''
-        self.warning("enableChannels() in deprecated since Jul20. "
+        self.warning("enableChannels() in deprecated since 3.0.2. "
                      "Use setEnabled() instead.")
         self.setEnabled(True, *channels)
 
@@ -3112,7 +3112,7 @@ class MeasurementGroup(PoolElement):
         :param channels: (seq<str>) a sequence of strings indicating
            channel names
         '''
-        self.warning("enableChannels() in deprecated since Jul20. "
+        self.warning("enableChannels() in deprecated since 3.0.2. "
                      "Use setEnabled() instead.")
         self.setEnabled(False, *channels)
 

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/dooroutput.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/dooroutput.py
@@ -153,7 +153,7 @@ class DoorDebug(Qt.QPlainTextEdit):
 
         from taurus.core.util.log import warning
 
-        msg = ("DoorDebug is deprecated since version Jan20. "
+        msg = ("DoorDebug is deprecated since version 3.0.2. "
                "Use DoorOutput 'Show debug details' feature instead.")
         warning(msg)
 

--- a/src/sardana/test/testsuite.py
+++ b/src/sardana/test/testsuite.py
@@ -31,7 +31,7 @@ __docformat__ = 'restructuredtext'
 
 
 def main():
-    print("sardanatestsuite was removed in Sardana Jan20. "
+    print("sardanatestsuite was removed in Sardana 3.0.2. "
           "Use pytest to run tests.")
     import sys
     sys.exit(1)


### PR DESCRIPTION
#1069 demonstrated that poor time precision on Windows affects the `AttributeEventWait` mechanism of events recognition.

During Jul20 release (3.0.2) tests the same problem was found in the `PoolElement.waitFinish()` and more preciselly in the measurement group's acquisitions.

The following debugging traces demonstrates it:

1. Lines starting from _waitEvent..._ print the `AttributeEventWait.waitEvent()` arguments.
2. Lines with the dictionary string representation print the _event set_ at the beginning of each iteration which looks for the event condition.

```
SardanaTP.W002 DEBUG    2020-08-26 08:53:15,111 Door/demo1/1.Macro[ct]: Counting for 1.0 sec
SardanaTP.W002 OUTPUT   2020-08-26 08:53:15,111 Door/demo1/1.Macro[ct]: Wed Aug 26 08:53:15 2020
SardanaTP.W002 OUTPUT   2020-08-26 08:53:15,111 Door/demo1/1.Macro[ct]:
waitEvent tango://pc255.cells.es:10000/mntgrp/pool_demo1_1/mntgrp03/state MOVING 0 False None -1 False
{<DevState.ON: 0>: 1598457195.5808291}
waitEvent tango://pc255.cells.es:10000/mntgrp/pool_demo1_1/mntgrp03/state MOVING 1598457195.5808291 True None -1 False
{<DevState.ON: 0>: 1598457195.5808291, <DevState.MOVING: 6>: 1598457195.5808291}
waitEvent tango://pc255.cells.es:10000/mntgrp/pool_demo1_1/mntgrp03/state MOVING 1598457195.5808291 False 0.1 -1 False
{<DevState.ON: 0>: 1598457195.5808291, <DevState.MOVING: 6>: 1598457195.5808291}
SardanaTP.W002 INFO     2020-08-26 08:53:16,252 Door/demo1/1.Macro[ct]: Elements ended acquisition with:
ct20:
       State: Moving (08:53:15.738000)
      Status: ct20 is On
              Stopped (08:53:16.256000)
ct21:
       State: Moving (08:53:15.927000)
      Status: ct21 is On
              Stopped (08:53:16.257000)
ct22:
       State: Moving (08:53:16.085000)
      Status: ct22 is On
              Stopped (08:53:16.257000)
ct23:
       State: Moving (08:53:16.223000)
      Status: ct23 is On
              Stopped (08:53:16.257000)
SardanaTP.W002 DEBUG    2020-08-26 08:53:16,268 Door/demo1/1.MacroExecutor: Sending exception event
SardanaTP.W002 DEBUG    2020-08-26 08:53:16,268 Door/demo1/1.MacroExecutor: [ENDEX] (MacroServerException) runMacro ct
SardanaTP.W002 DEBUG    2020-08-26 08:53:16,268 Door/demo1/1: Traceback (most recent call last):
  File "c:\miniconda\envs\py3qt5\lib\site-packages\sardana\macroserver\msmacromanager.py", line 1653, in runMacro
    for step in macro_obj.exec_():
  File "c:\miniconda\envs\py3qt5\lib\site-packages\sardana\macroserver\macro.py", line 2329, in exec_
    res = self.run(*self._in_pars)
  File "c:\miniconda\envs\py3qt5\lib\site-packages\sardana\macroserver\macros\standard.py", line 724, in run
    state.name.capitalize()))
ValueError: Acquisition ended with Moving
```

Here we can see three calls to the `AttributeEventWait.waitEvent()`:
1. Waiting for the measurement group in the condition to start the next acquisition: **state != MOVING & timestamp >= 0**
2. Waiting for the measurement group to really start the acqusition (right after calling the `Start()` command): **state == MOVING & timestamp >= 1598457195.5808291**
3. Waiting for the measurement group to finish the acqusition: **state != MOVING & timestamp >= 1598457195.5808291**

In the first call the event set only contains the ON event from 1598457195.5808291. It is the one corresponding to the event subscription.
In the second call the event set contains two events: ON from 1598457195.5808291 and MOVING from 1598457195.5808291. The ON event persist in the event set since the previous call already.
In the third call, in the first iteration, the event set contains two events: ON from 1598457195.5808291 and MOVING from 1598457195.5808291. Both the events persist in the event set since the previos call. This makes that the condition (>= for the timestamp) is already met in the first iteration leading to the premature end of the acquisition.

As we can see in the above example all the timestamps are equal. I have observed on Windows 10 VM the following time resolution:

```
In [2]: for i in range(30):
   ...:     print(time.time())
   ...:
1598461326.9014206
1598461326.9014206
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9331322
```

This PR proposes the same solution as #1069 - to clear the event set before executing the command. 
Note that alternativelly we could either think of refactoring the whole _event synchronization_ mechanism or think of different ways of determining time e.g. `time.clock()`. But clearing the event set already proved to solve the issue.

It is a release critical bug on Windows. @sardana-org/integrators could you please review it. Many thanks!