### PR TITLE
Fix premature end of acquisition on Windows

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -479,6 +479,11 @@ class PoolElement(BaseElement, TangoDevice):
         evt_wait.connect(self.getAttribute("state"))
         try:
             evt_wait.waitEvent(DevState.MOVING, equal=False)
+            # Clear event set to not confuse the value coming from the
+            # connection with the event of of end of the operation
+            # in the next wait event. This was observed on Windows where
+            # the time stamp resolution is very poor.
+            evt_wait.clearEventSet()
             self.__go_time = 0
             self.__go_start_time = ts1 = time.time()
             self._start(*args, **kwargs)


### PR DESCRIPTION
(This PR suggests the same changes as #1396 but goes to the release-Jul20 branch)

#1069 demonstrated that poor time precision on Windows affects the `AttributeEventWait` mechanism of events recognition.

During Jul20 release (3.0.2) tests the same problem was found in the `PoolElement.waitFinish()` and more preciselly in the measurement group's acquisitions.

The following debugging traces demonstrates it:

1. Lines starting from _waitEvent..._ print the `AttributeEventWait.waitEvent()` arguments.
2. Lines with the dictionary string representation print the _event set_ at the beginning of each iteration which looks for the event condition.

```
SardanaTP.W002 DEBUG    2020-08-26 08:53:15,111 Door/demo1/1.Macro[ct]: Counting for 1.0 sec
SardanaTP.W002 OUTPUT   2020-08-26 08:53:15,111 Door/demo1/1.Macro[ct]: Wed Aug 26 08:53:15 2020
SardanaTP.W002 OUTPUT   2020-08-26 08:53:15,111 Door/demo1/1.Macro[ct]:
waitEvent tango://pc255.cells.es:10000/mntgrp/pool_demo1_1/mntgrp03/state MOVING 0 False None -1 False
{<DevState.ON: 0>: 1598457195.5808291}
waitEvent tango://pc255.cells.es:10000/mntgrp/pool_demo1_1/mntgrp03/state MOVING 1598457195.5808291 True None -1 False
{<DevState.ON: 0>: 1598457195.5808291, <DevState.MOVING: 6>: 1598457195.5808291}
waitEvent tango://pc255.cells.es:10000/mntgrp/pool_demo1_1/mntgrp03/state MOVING 1598457195.5808291 False 0.1 -1 False
{<DevState.ON: 0>: 1598457195.5808291, <DevState.MOVING: 6>: 1598457195.5808291}
SardanaTP.W002 INFO     2020-08-26 08:53:16,252 Door/demo1/1.Macro[ct]: Elements ended acquisition with:
ct20:
       State: Moving (08:53:15.738000)
      Status: ct20 is On
              Stopped (08:53:16.256000)
ct21:
       State: Moving (08:53:15.927000)
      Status: ct21 is On
              Stopped (08:53:16.257000)
ct22:
       State: Moving (08:53:16.085000)
      Status: ct22 is On
              Stopped (08:53:16.257000)
ct23:
       State: Moving (08:53:16.223000)
      Status: ct23 is On
              Stopped (08:53:16.257000)
SardanaTP.W002 DEBUG    2020-08-26 08:53:16,268 Door/demo1/1.MacroExecutor: Sending exception event
SardanaTP.W002 DEBUG    2020-08-26 08:53:16,268 Door/demo1/1.MacroExecutor: [ENDEX] (MacroServerException) runMacro ct
SardanaTP.W002 DEBUG    2020-08-26 08:53:16,268 Door/demo1/1: Traceback (most recent call last):
  File "c:\miniconda\envs\py3qt5\lib\site-packages\sardana\macroserver\msmacromanager.py", line 1653, in runMacro
    for step in macro_obj.exec_():
  File "c:\miniconda\envs\py3qt5\lib\site-packages\sardana\macroserver\macro.py", line 2329, in exec_
    res = self.run(*self._in_pars)
  File "c:\miniconda\envs\py3qt5\lib\site-packages\sardana\macroserver\macros\standard.py", line 724, in run
    state.name.capitalize()))
ValueError: Acquisition ended with Moving
```

Here we can see three calls to the `AttributeEventWait.waitEvent()`:
1. Waiting for the measurement group in the condition to start the next acquisition: **state != MOVING & timestamp >= 0**
2. Waiting for the measurement group to really start the acqusition (right after calling the `Start()` command): **state == MOVING & timestamp >= 1598457195.5808291**
3. Waiting for the measurement group to finish the acqusition: **state != MOVING & timestamp >= 1598457195.5808291**

In the first call the event set only contains the ON event from 1598457195.5808291. It is the one corresponding to the event subscription.
In the second call the event set contains two events: ON from 1598457195.5808291 and MOVING from 1598457195.5808291. The ON event persist in the event set since the previous call already.
In the third call, in the first iteration, the event set contains two events: ON from 1598457195.5808291 and MOVING from 1598457195.5808291. Both the events persist in the event set since the previos call. This makes that the condition (>= for the timestamp) is already met in the first iteration leading to the premature end of the acquisition.

As we can see in the above example all the timestamps are equal. I have observed on Windows 10 VM the following time resolution:

```
In [2]: for i in range(30):
   ...:     print(time.time())
   ...:
1598461326.9014206
1598461326.9014206
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9163754
1598461326.9331322
```

This PR proposes the same solution as #1069 - to clear the event set before executing the command. 
Note that alternativelly we could either think of refactoring the whole _event synchronization_ mechanism or think of different ways of determining time e.g. `time.clock()`. But clearing the event set already proved to solve the issue.

It is a release critical bug on Windows. @sardana-org/integrators could you please review it. Many thanks!