### PR TITLE
Use proper python3 executable regardeless of installation

### DIFF
--- a/src/sardana/spock/magic.py
+++ b/src/sardana/spock/magic.py
@@ -31,6 +31,7 @@ __all__ = ['expconf', 'showscan', 'spsplot', 'debug_completer',
            'post_mortem', 'macrodata', 'edmac', 'spock_late_startup_hook',
            'spock_pre_prompt_hook']
 
+from sardana.util.whichpython import which_python_executable
 from .genutils import MSG_DONE, MSG_FAILED
 from .genutils import get_ipapi
 from .genutils import page, get_door, get_macro_server, ask_yes_no, arg_split
@@ -60,7 +61,8 @@ def expconf(self, parameter_s=''):
     import subprocess
     import sys
     fname = sys.modules[ExpDescriptionEditor.__module__].__file__
-    args = ['python3', fname, doorname]
+    python_executable = which_python_executable()
+    args = [python_executable, fname, doorname]
     if parameter_s == '--auto-update':
         args.insert(2, parameter_s)
     subprocess.Popen(args)
@@ -108,7 +110,9 @@ def showscan(self, parameter_s=''):
             import subprocess
             import sys
             fname = sys.modules[ShowScanOnline.__module__].__file__
-            args = ['python3', fname, doorname, '--taurus-log-level=error']
+            python_executable = which_python_executable()
+            args = [python_executable, fname, doorname,
+                    '--taurus-log-level=error']
             subprocess.Popen(args)
             return
         else:

--- a/src/sardana/util/whichpython.py
+++ b/src/sardana/util/whichpython.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+""""""
+
+__all__ = ["which_python_executable"]
+
+
+from taurus.core.util.whichexecutable import whichfile
+
+
+def which_python_executable():
+    """Return full path to python executable.
+
+    On some OS Python 3 is executed with python3 but in conda environments it
+    is executed with python. Return Python 3 executable regardless of the
+    Python installation.
+    """
+    executable = whichfile("python3")
+    if executable is None:
+        executable = whichfile("python")
+    return executable


### PR DESCRIPTION
On some OS Python 3 is executed with python3 but in conda environments it is executed with python. Use proper Python 3 executable regardless of the Python installation.

@sardana-org/integrators could you please take a look. IMO it is release critical.
Many thanks!