### PR TITLE
Fix showscan offline broken in #1260

### DIFF
--- a/src/sardana/spock/magic.py
+++ b/src/sardana/spock/magic.py
@@ -83,7 +83,7 @@ def showscan(self, parameter_s=''):
     """
     params = parameter_s.split()
     door = get_door()
-    online, scan_nb = False, None
+    scan_nb = None
     if len(params) > 0:
         if params[0].lower() == 'online':
             try:
@@ -117,7 +117,7 @@ def showscan(self, parameter_s=''):
             return
         else:
             scan_nb = int(params[0])
-            door.show_scan(scan_nb)
+    door.show_scan(scan_nb)
 
 
 def spsplot(self, parameter_s=''):


### PR DESCRIPTION
Showscan without arguments should open showscan offline. When scan ID
is given as argument it should open the corresponding scan.