### PR TITLE
Fix timescan with referable channels

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2769,7 +2769,8 @@ class TScan(GScan, CAcquisition):
         yield 0
         measurement_group.setNbStarts(1)
         measurement_group.count_continuous(synch_description,
-                                           self.value_buffer_changed)
+                                           self.value_buffer_changed,
+                                           self.value_ref_buffer_changed)
         self.debug("Waiting for value buffer events to be processed")
         self.wait_value_buffer()
         self.join_thread_pool()

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -3367,7 +3367,8 @@ class MeasurementGroup(PoolElement):
         self.prepare()
         return self.count_raw(start_time)
 
-    def count_continuous(self, synch_description, value_buffer_cb=None):
+    def count_continuous(self, synch_description, value_buffer_cb=None,
+                         value_ref_buffer_cb=None):
         """Execute measurement process according to the given synchronization
         description.
 
@@ -3376,6 +3377,9 @@ class MeasurementGroup(PoolElement):
           synchronizations
         :param value_buffer_cb: callback on value buffer updates
         :type value_buffer_cb: callable
+        :param value_ref_buffer_cb: callback on value reference
+          buffer updates
+        :type value_ref_buffer_cb: callable
         :return: state and eventually value buffers if no callback was passed
         :rtype: tuple<list<DevState>,<list>>
 
@@ -3392,10 +3396,12 @@ class MeasurementGroup(PoolElement):
         self.setSynchDescription(synch_description)
         self.prepare()
         self.subscribeValueBuffer(value_buffer_cb)
+        self.subscribeValueRefBuffer(value_ref_buffer_cb)
         try:
             self.count_raw(start_time)
         finally:
             self.unsubscribeValueBuffer(value_buffer_cb)
+            self.unsubscribeValueRefBuffer(value_ref_buffer_cb)
         state = self.getStateEG().readValue()
         if state == Fault:
             msg = "Measurement group ended acquisition with Fault state"


### PR DESCRIPTION
`timescan` and `TScan` does not handle the referable channels. Subscribe to them to make `tiemscan` compatible with referable channels.

Fix #1399.

@13bscsaamjad could you please review and test this one? Many thanks!