### PR TITLE
Add protections to scanstats macro

### DIFF
--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -1905,6 +1905,10 @@ class scanstats(Macro):
             self.warning("for now the scanstats macro can only be executed as"
                          " a post-scan hook")
             return
+        if not hasattr(parent, "motors"):
+            self.warning("scan must involve at least one moveable "
+                         "to calculate statistics")
+            return
 
         active_meas_grp = self.getEnv("ActiveMntGrp")
         meas_grp = self.getMeasurementGroup(active_meas_grp)


### PR DESCRIPTION
This PR adds some additional protections to the `scanstats` macro:
* return from the macro if the parent scan does not involve moveable e.g. `timescan`
* return from the macro if there is no enabled scalar channel in the measurement group e.g. 1D and 2D channels are not allowed (these may be referable)

There is one more thing which maybe could be improved. If we use software synchronization in continuous measurements some acquisitions may be skipped and channel will report `NaN`. How should the statistics behave in this case. What we have now is:
```
Door_zreszela_1 [20]: ascanct mot01 0 1 10 0.1
Operation will be saved in /tmp/test.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #328 started at Fri Aug 28 12:41:01 2020. It will take at least 0:00:00
 #Pt No    mot01      ct01     gct01       dt   
Motor positions and relative timestamp (dt) columns contains theoretical values
   0         0        0.1     2.98023e-08   0.001  
   1        0.1       0.1     1.52588e-05   0.101  
   2        0.2       0.1       nan      0.201  
   3        0.3       0.1     0.00195312   0.301  
   4        0.4       0.1      0.0625    0.401  
   5        0.5       0.1       nan      0.501  
   6        0.6       0.1       0.5      0.601  
   7        0.7       0.1       nan      0.701  
   8        0.8       0.1        1       0.801  
   9        0.9       0.1       0.5      0.901  
Correcting overshoot...
   10        1        0.1       nan      1.001  
Operation saved in /tmp/test.h5 (HDF5::NXscan)
Scan #328 ended at Fri Aug 28 12:41:02 2020, taking 0:00:01.453304. Dead time 100.0% (motion dead time 100.0%)
Statistics for movable: mot01
     gct01  ct01
----------------
MIN    nan   0.1
MAX    nan   0.1
MIN@   0.2     0
MAX@   0.2     0
MEAN   nan   0.1
INT    nan   1.1
COM    nan   0.5
FWHM   nan     1
CEN    nan   0.5
```
@dschick could you please review the already done changes and comment on the `NaN` case.