### PR TITLE
Fix problems with non-timerable channels in expconf

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
@@ -524,7 +524,15 @@ class BaseMntGrpChannelModel(TaurusBaseModel):
         taurus_role = self.role(index.column())
         if taurus_role == ChannelView.Synchronization:
             ch_name, ch_data = index.internalPointer().itemData()
-            unitdict = self.getPyData(ctrlname=ch_data['_controller_name'])
+            ctrlname = ch_data['_controller_name']
+            if ctrlname.startswith("__"):
+                return None
+            ch_info = self.getAvailableChannels()[ch_name]
+            if ch_info['type'] not in ('CTExpChannel',
+                                       'OneDExpChannel',
+                                       'TwoDExpChannel'):
+                return None
+            unitdict = self.getPyData(ctrlname=ctrlname)
             key = self.data_keys_map[taurus_role]
             synchronization = unitdict[key]
             return AcqSynchType[synchronization]

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
@@ -83,7 +83,7 @@ from sardana.taurus.core.tango.sardana.pool import getChannelConfigs
 DEFAULT_STRING_LENGTH = 80
 
 
-def createChannelDict(channel, index=None, **kwargs):
+def  createChannelDict(channel, index=None, **kwargs):
     from taurus.core.tango import FROM_TANGO_TO_STR_TYPE
     import PyTango
     import numpy
@@ -494,20 +494,18 @@ class BaseMntGrpChannelModel(TaurusBaseModel):
         taurus_role = self.role(index.column())
         if taurus_role == ChannelView.Channel:  # channel column is not editable
             return flags
-        elif taurus_role == ChannelView.Synchronization:
+        elif taurus_role in (ChannelView.Timer,
+                             ChannelView.Monitor,
+                             ChannelView.Synchronizer,
+                             ChannelView.Synchronization):
             ch_name, ch_data = index.internalPointer().itemData()
             if not ch_data['_controller_name'].startswith("__"):
                 ch_info = self.getAvailableChannels()[ch_name]
-                # only timer/monitor columns of counter timers are editable
-                if ch_info['type'] in ('CTExpChannel', 'OneDExpChannel', 'TwoDExpChannel'):
+                # only timerable channels accept these configurations
+                if ch_info['type'] in ('CTExpChannel',
+                                       'OneDExpChannel',
+                                       'TwoDExpChannel'):
                     flags |= Qt.Qt.ItemIsEditable
-        elif taurus_role in (ChannelView.Timer, ChannelView.Monitor):
-            ch_name, ch_data = index.internalPointer().itemData()
-            if not ch_data['_controller_name'].startswith("__"):
-                #ch_info = self.getAvailableChannels()[ch_name]
-                # if 'CTExpChannel' == ch_info['type']: #only timer/monitor columns of counter timers are editable
-                #    flags |= Qt.Qt.ItemIsEditable
-                flags |= Qt.Qt.ItemIsEditable
         else:
             flags |= Qt.Qt.ItemIsEditable
         return flags

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py
@@ -83,7 +83,7 @@ from sardana.taurus.core.tango.sardana.pool import getChannelConfigs
 DEFAULT_STRING_LENGTH = 80
 
 
-def  createChannelDict(channel, index=None, **kwargs):
+def createChannelDict(channel, index=None, **kwargs):
     from taurus.core.tango import FROM_TANGO_TO_STR_TYPE
     import PyTango
     import numpy


### PR DESCRIPTION
This issue was discovered in the release manual tests. 
When adding an external channel e.g. Tango attribute and then scrolling the contents of the channel's editor in the expconf the following exception was being raised:

```
Traceback (most recent call last):
  File "/home/zreszela/workspace/sardana/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py", line 529, in data
    return None
KeyError: 'synchronization'
```

Similar error was also observed for PseudoCounters:

```
Traceback (most recent call last):
  File "/home/zreszela/workspace/sardana/src/sardana/taurus/qt/qtgui/extra_sardana/measurementgroup.py", line 532, in data
    synchronization = unitdict[key]
KeyError: 'synchronization'
```

This PR fixes it.
It also improves the expconf and allows to edit: Timer, Monitor, Synchronizer and Synchronization columns for the timerable channels only.

I will auto-merge it since it will be tested anyway in the release manual tests on CentOS. Feel free to comment anyway. Thanks to all!