### PR TITLE
Reset MGConfiguration tango internals also if changes proceeds from the same object

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1499,8 +1499,6 @@ class MGConfiguration(object):
         # representing channel data as received in raw data
         self.non_tango_channels = None
 
-        self.initialized = False
-
     def _build(self):
         # internal channel structure that groups channels by tango device so
         # they can be read as a group minimizing this way the network requests

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1393,6 +1393,34 @@ class MGConfiguration(object):
         self.set_data(data)
 
     def set_data(self, data, force=False):
+        # dict<str, list[DeviceProxy, CaselessDict<str, dict>]>
+        # where key is a device name and value is a list with two elements:
+        #  - A device proxy or None if there was an error building it
+        #  - A dict where keys are attribute names and value is a reference to
+        #    a dict representing channel data as received in raw data
+        self.tango_dev_channels = None
+
+        # Number of elements in tango_dev_channels in error (could not build
+        # DeviceProxy, probably)
+        self.tango_dev_channels_in_error = 0
+
+        # dict<str, tuple<str, str, TangoChannelInfo>>
+        # where key is a channel name and value is a tuple of three elements:
+        #  - device name
+        #  - attribute name
+        #  - attribute information or None if there was an error trying to get
+        #    the information
+        self.tango_channels_info = None
+
+        # Number of elements in tango_channels_info_in_error in error
+        # (could not build attribute info, probably)
+        self.tango_channels_info_in_error = 0
+
+        # dict<str, dict>
+        # where key is a channel name and data is a reference to a dict
+        # representing channel data as received in raw data
+        self.non_tango_channels = None
+
         # object each time
         if isinstance(data, str):
             data = CodecFactory().decode(('json', data))
@@ -1471,33 +1499,6 @@ class MGConfiguration(object):
             ctrl = self._get_ctrl_for_element(channel_name)
             if ctrl not in self.controller_list_name:
                 self.controller_list_name.append(ctrl)
-        # dict<str, list[DeviceProxy, CaselessDict<str, dict>]>
-        # where key is a device name and value is a list with two elements:
-        #  - A device proxy or None if there was an error building it
-        #  - A dict where keys are attribute names and value is a reference to
-        #    a dict representing channel data as received in raw data
-        self.tango_dev_channels = None
-
-        # Number of elements in tango_dev_channels in error (could not build
-        # DeviceProxy, probably)
-        self.tango_dev_channels_in_error = 0
-
-        # dict<str, tuple<str, str, TangoChannelInfo>>
-        # where key is a channel name and value is a tuple of three elements:
-        #  - device name
-        #  - attribute name
-        #  - attribute information or None if there was an error trying to get
-        #    the information
-        self.tango_channels_info = None
-
-        # Number of elements in tango_channels_info_in_error in error
-        # (could not build attribute info, probably)
-        self.tango_channels_info_in_error = 0
-
-        # dict<str, dict>
-        # where key is a channel name and data is a reference to a dict
-        # representing channel data as received in raw data
-        self.non_tango_channels = None
 
     def _build(self):
         # internal channel structure that groups channels by tango device so


### PR DESCRIPTION
This PR fixes #1415. What happens there is that the the same `MeasurementGroup` sardana-taurus model extension object is present in the MacroServer when one runs the `set_meas_conf` macro and when one runs a scan.
The `MGConfiguration.set_data()` is trying to optimize the objects recreation and was doing that also for Tango objects dictionaries. This dictionaries however apart from storing the Tango DeviceProxies also store the configuration info. If we don't reset these dictionaries then the configuration info gets outdated. This was affecting the

https://github.com/sardana-org/sardana/blob/ffbe5f36e6a11a2c2eb4cfd59e6f39dd1185c2de/src/sardana/macroserver/scan/gscan.py#L669

what in consecuence was delivering outdated `data_desc` in the RecordData event.

Note, my patch is very trivial, further refactoring could be done after the release. @rhomspuron, what do you think?

@sardana-org/integrators it is read for review. Thanks to all!