### PR TITLE
Fix double unit shown in motor widget

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -595,6 +595,7 @@ class PoolMotorTVReadWidget(TaurusWidget):
         self.layout().addLayout(limits_layout, 0, 0)
 
         self.lbl_read = TaurusLabel()
+        self.lbl_read.setFgRole('rvalue.magnitude')
         self.lbl_read.setBgRole('quality')
         self.lbl_read.setSizePolicy(Qt.QSizePolicy(
             Qt.QSizePolicy.Expanding, Qt.QSizePolicy.Fixed))


### PR DESCRIPTION
When the motor position has units defined, the taurus motor widget shows the units in two places as can be seen here:
![image](https://user-images.githubusercontent.com/2684070/94570333-0b59ec00-026f-11eb-9515-7f77bf4da32a.png)


This PR proposes to fix it and only show on the right side of the GUI as it was before