### PR TITLE
Allow to programmatically disable *deterministic scan* optimization

### DIFF
--- a/doc/source/devel/api/sardana/macroserver/scan.rst
+++ b/doc/source/devel/api/sardana/macroserver/scan.rst
@@ -26,8 +26,8 @@ GScan
     :show-inheritance:
     :members:
 
-GScan
------
+Scan
+----
 
 .. inheritance-diagram:: SScan
     :parts: 1

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1067,6 +1067,15 @@ class SScan(GScan):
 
     @property
     def deterministic_scan(self):
+        """Check if the scan is a deterministic scan.
+
+        Scan is considered as deterministic scan if
+        the `~sardana.macroserver.macro.Macro` specialization owning
+        the scan object contains ``nb_points`` and ``integ_time`` attributes.
+
+        Scan flow depends on this property (some optimizations are applied).
+        These can be disabled by setting this property to `False`.
+        """
         if self._deterministic_scan is None:
             macro = self.macro
             if hasattr(macro, "nb_points") and hasattr(macro, "integ_time"):

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1058,23 +1058,42 @@ class GScan(Logger):
 class SScan(GScan):
     """Step scan"""
 
+    def __init__(self, macro, generator=None, moveables=[], env={},
+                 constraints=[], extrainfodesc=[]):
+        GScan.__init__(self, macro, generator=generator, moveables=moveables,
+                       env=env, constraints=constraints,
+                       extrainfodesc=extrainfodesc)
+        self._deterministic_scan = None
+
+    @property
+    def deterministic_scan(self):
+        if self._deterministic_scan is None:
+            macro = self.macro
+            if hasattr(macro, "nb_points") and hasattr(macro, "integ_time"):
+                self._deterministic_scan = True
+            else:
+                self._deterministic_scan = False
+        return self._deterministic_scan
+
+    @deterministic_scan.setter
+    def deterministic_scan(self, value):
+        self._deterministic_scan = value
+
     def scan_loop(self):
         lstep = None
         macro = self.macro
         scream = False
 
-        self._deterministic_scan = False
         if hasattr(macro, "nb_points"):
             nb_points = float(macro.nb_points)
-            if hasattr(macro, "integ_time"):
-                integ_time = macro.integ_time
-                self.measurement_group.putIntegrationTime(integ_time)
-                self.measurement_group.setNbStarts(nb_points)
-                self.measurement_group.prepare()
-                self._deterministic_scan = True
             scream = True
         else:
             yield 0.0
+
+        if self.deterministic_scan:
+            self.measurement_group.putIntegrationTime(macro.integ_time)
+            self.measurement_group.setNbStarts(macro.nb_points)
+            self.measurement_group.prepare()
 
         self._sum_motion_time = 0
         self._sum_acq_time = 0
@@ -1157,7 +1176,7 @@ class SScan(GScan):
         # Acquire data
         self.debug("[START] acquisition")
         try:
-            if self._deterministic_scan:
+            if self.deterministic_scan:
                 state, data_line = mg.count_raw()
             else:
                 state, data_line = mg.count(integ_time)


### PR DESCRIPTION
Deterministic scan optimization of measurement is not compatible with
attaching measurements on the same measurement group as hooks.

Add deterministic_scan property to allow disabling this optimization.

You can try it with the following example:

```python
import functools

from sardana.macroserver.macro import macro, Type
from sardana.macroserver.scan import SScan


def count(parent):
    parent.output("In count")
    mnt_grp = parent.getObj(parent.getEnv("ActiveMntGrp"),
                            type_class=Type.MeasurementGroup)
    state, data = mnt_grp.count(0.2)
    parent.output(data)


@macro([["moveable", Type.Moveable, None, "moveable to get position"]])
def custom_scan(self, moveable):
    """Testing custom_scan macro"""
    self.output("In custom_scan")
    ret = self.createMacro("ascan", moveable, "0", "1", "1", "0.1")
    my_scan, _ = ret
    hook_function = functools.partial(count, self)
    my_scan.appendHook((hook_function, ["pre-acq"]))
    my_scan._gScan.deterministic_scan = False
    self.runMacro(my_scan)
```
Fixes #1426