### PR TITLE
Execute per measurement preparation in mesh

### DIFF
--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -709,6 +709,7 @@ class mesh(Macro, Hookable):
         self.starts = numpy.array([m1_start_pos, m2_start_pos], dtype='d')
         self.finals = numpy.array([m1_final_pos, m2_final_pos], dtype='d')
         self.nr_intervs = numpy.array([m1_nr_interv, m2_nr_interv], dtype='i')
+        self.nb_points = (m1_nr_interv + 1) * (m2_nr_interv + 1)
         self.integ_time = integ_time
         self.bidirectional_mode = bidirectional
 


### PR DESCRIPTION
Per measurement preparation in deterministic scans is done based on the `integ_time` and ~`nb_starts`~ `nb_points` attribute presence in the macro obj.

Add ~`nb_starts`~ `nb_points` attribute to the mesh macro.

This PR is the outcome of a pair-programming session with @13bscsaamjad. Can some of @sardana-org/integrators take a look, please. Many thanks!