### PR TITLE
Fix continuous readout of value references in hardware synchronized acquisition

### DIFF
--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -1081,6 +1081,9 @@ class PoolAcquisitionHardware(PoolAcquisitionTimerable):
                 self.read_value(ret=values)
                 for acquirable, value in list(values.items()):
                     self._process_value_buffer(acquirable, value)
+                self.read_value_ref(ret=value_refs)
+                for acquirable, value_ref in list(value_refs.items()):
+                    self._process_value_ref_buffer(acquirable, value_ref)
 
             time.sleep(nap)
             i += 1

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -812,6 +812,30 @@ class PoolAcquisitionTimerable(PoolAcquisitionBase):
         finally:
             self._value_info.finish_one()
 
+    def _process_value_buffer(self, acquirable, value, final=False):
+        final_str = "final " if final else ""
+        if is_value_error(value):
+            self.error("Loop %sread value error for %s" % (final_str,
+                                                           acquirable.name))
+            msg = "Details: " + "".join(
+                traceback.format_exception(*value.exc_info))
+            self.debug(msg)
+            acquirable.put_value(value, propagate=2)
+        else:
+            acquirable.extend_value_buffer(value, propagate=2)
+
+    def _process_value_ref_buffer(self, acquirable, value_ref, final=False):
+        final_str = "final " if final else ""
+        if is_value_error(value_ref):
+            self.error("Loop read ref %svalue error for %s" %
+                       (final_str, acquirable.name))
+            msg = "Details: " + "".join(
+                traceback.format_exception(*value_ref.exc_info))
+            self.debug(msg)
+            acquirable.put_value_ref(value_ref, propagate=2)
+        else:
+            acquirable.extend_value_ref_buffer(value_ref, propagate=2)
+
     def in_acquisition(self, states):
         """Determines if we are in acquisition or if the acquisition has ended
         based on the current unit trigger modes and states returned by the
@@ -1056,15 +1080,7 @@ class PoolAcquisitionHardware(PoolAcquisitionTimerable):
             if not i % nb_states_per_value:
                 self.read_value(ret=values)
                 for acquirable, value in list(values.items()):
-                    if is_value_error(value):
-                        self.error("Loop read value error for %s" %
-                                   acquirable.name)
-                        msg = "Details: " + "".join(
-                            traceback.format_exception(*value.exc_info))
-                        self.debug(msg)
-                        acquirable.put_value(value)
-                    else:
-                        acquirable.extend_value_buffer(value)
+                    self._process_value_buffer(acquirable, value)
 
             time.sleep(nap)
             i += 1
@@ -1076,24 +1092,11 @@ class PoolAcquisitionHardware(PoolAcquisitionTimerable):
         for acquirable, state_info in list(states.items()):
             if acquirable in values:
                 value = values[acquirable]
-                if is_value_error(value):
-                    self.error("Loop final read value error for: %s" %
-                               acquirable.name)
-                    msg = "Details: " + "".join(
-                        traceback.format_exception(*value.exc_info))
-                    self.debug(msg)
-                    acquirable.put_value(value)
-                else:
-                    acquirable.extend_value_buffer(value, propagate=2)
+                self._process_value_buffer(acquirable, value, final=True)
             if acquirable in value_refs:
                 value_ref = value_refs[acquirable]
-                if is_value_error(value_ref):
-                    self.error("Loop final read value ref error for: %s" %
-                               acquirable.name)
-                    msg = "Details: " + "".join(
-                        traceback.format_exception(*value_ref.exc_info))
-                    self.debug(msg)
-                acquirable.extend_value_ref_buffer(value_ref, propagate=2)
+                self._process_value_ref_buffer(acquirable, value_ref,
+                                               final=True)
             state_info = acquirable._from_ctrl_state_info(state_info)
             set_state_info = functools.partial(acquirable.set_state_info,
                                                state_info,

--- a/src/sardana/pool/test/test_acquisition.py
+++ b/src/sardana/pool/test/test_acquisition.py
@@ -27,7 +27,7 @@ import threading
 
 import numpy
 
-from unittest import TestCase
+from unittest import TestCase, mock
 from taurus.test import insertTest
 
 from sardana.sardanautils import is_number, is_pure_str
@@ -592,6 +592,14 @@ class Acquisition2DHardwareStartRefTestCase(
         axis = self.channel.axis
         self.channel_ctrl.set_axis_par(axis, "value_ref_enabled", True)
 
+    def acquire(self, integ_time, repetitions, latency_time):
+        ctrl = self.channel_ctrl.ctrl
+        with mock.patch.object(ctrl, "RefOne",
+                               wraps=ctrl.RefOne) as mock_RefOne:
+            BaseAcquisitionHardwareTestCase.acquire(self, integ_time,
+                                                    repetitions, latency_time)
+            assert mock_RefOne.call_count > 1
+
 
 @insertTest(helper_name='acquire', integ_time=0.01, repetitions=10,
             latency_time=0.02)
@@ -651,6 +659,14 @@ class Acquisition2DHardwareTriggerRefTestCase(BaseAcquisitionHardwareTestCase,
         self.channel.value_ref_enabled = True
         axis = self.channel.axis
         self.channel_ctrl.set_axis_par(axis, "value_ref_enabled", True)
+
+    def acquire(self, integ_time, repetitions, latency_time):
+        ctrl = self.channel_ctrl.ctrl
+        with mock.patch.object(ctrl, "RefOne",
+                               wraps=ctrl.RefOne) as mock_RefOne:
+            BaseAcquisitionHardwareTestCase.acquire(self, integ_time,
+                                                    repetitions, latency_time)
+            assert mock_RefOne.call_count > 1
 
 
 @insertTest(helper_name='acquire', integ_time=0.01, repetitions=10,

--- a/src/sardana/pool/test/test_acquisition.py
+++ b/src/sardana/pool/test/test_acquisition.py
@@ -567,6 +567,14 @@ class Acquisition2DHardwareStartTestCase(BaseAcquisitionHardwareTestCase,
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
+    def acquire(self, integ_time, repetitions, latency_time):
+        ctrl = self.channel_ctrl.ctrl
+        with mock.patch.object(ctrl, "ReadOne",
+                               wraps=ctrl.ReadOne) as mock_ReadOne:
+            BaseAcquisitionHardwareTestCase.acquire(self, integ_time,
+                                                    repetitions, latency_time)
+            assert mock_ReadOne.call_count > 1
+
 
 @insertTest(helper_name='acquire', integ_time=0.01, repetitions=10,
             latency_time=0.02)
@@ -618,6 +626,14 @@ class AcquisitionCTHardwareTriggerTestCase(BaseAcquisitionHardwareTestCase,
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
 
+    def acquire(self, integ_time, repetitions, latency_time):
+        ctrl = self.channel_ctrl.ctrl
+        with mock.patch.object(ctrl, "ReadOne",
+                               wraps=ctrl.ReadOne) as mock_ReadOne:
+            BaseAcquisitionHardwareTestCase.acquire(self, integ_time,
+                                                    repetitions, latency_time)
+            assert mock_ReadOne.call_count > 1
+
 
 @insertTest(helper_name='acquire', integ_time=0.01, repetitions=10,
             latency_time=0.02)
@@ -635,6 +651,14 @@ class Acquisition2DHardwareTriggerTestCase(BaseAcquisitionHardwareTestCase,
         BaseAcquisitionHardwareTestCase.setUp(self)
         self.data_listener = AttributeListener(dtype=object,
                                                attr_name="valuebuffer")
+
+    def acquire(self, integ_time, repetitions, latency_time):
+        ctrl = self.channel_ctrl.ctrl
+        with mock.patch.object(ctrl, "ReadOne",
+                               wraps=ctrl.ReadOne) as mock_ReadOne:
+            BaseAcquisitionHardwareTestCase.acquire(self, integ_time,
+                                                    repetitions, latency_time)
+            assert mock_ReadOne.call_count > 1
 
 
 @insertTest(helper_name='acquire', integ_time=0.01, repetitions=10,


### PR DESCRIPTION
@jordiandreu and @rhomspuron found a bug in hardware synchronized by start trigger acquisitions with referable channels.
The controller's `RefOne()` are called only once at the end of the acquisition but should be also called continuously during the acqusition.

This PR fixes it. I've also added tests, both, to reveal the problem and some regression tests for the `ReadOne()` calls which curently work fine. 