### PR TITLE
Include TriggetGate elements in the per-measurement preparation

### DIFF
--- a/doc/source/devel/api/api_controller.rst
+++ b/doc/source/devel/api/api_controller.rst
@@ -13,6 +13,7 @@ Controller API reference
     * :class:`ZeroDController` - 0D controller API
     * :class:`PseudoMotorController` - PseudoMotor controller API
     * :class:`PseudoCounterController` - PseudoCounter controller API
+    * :class:`TriggerGateController` - Trigger/Gate controller API
     * :class:`IORegisterController` - IORegister controller API
 
 .. _sardana-controller-data-type:

--- a/doc/source/devel/api/sardana/pool/controller.rst
+++ b/doc/source/devel/api/sardana/pool/controller.rst
@@ -44,6 +44,7 @@
     * :class:`OneDController`    
     * :class:`TwoDController`
     * :class:`PseudoCounterController`
+    * :class:`TriggerGateController`
     * :class:`IORegisterController`
 
 
@@ -215,6 +216,17 @@ Pseudo Counter Controller API
     :members:
     :undoc-members:
 
+
+Trigger/Gate Controller API
+---------------------------
+
+.. inheritance-diagram:: TriggerGateController
+    :parts: 1
+
+.. autoclass:: TriggerGateController
+    :show-inheritance:
+    :members:
+    :undoc-members:
 
 IO Register Controller API
 ----------------------------

--- a/doc/source/devel/howto_controllers/howto_triggergatecontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_triggergatecontroller.rst
@@ -89,6 +89,18 @@ The state should be a member of :obj:`~sardana.sardanadefs.State` (For backward
 compatibility reasons, it is also supported to return one of
 :class:`PyTango.DevState`). The status could be any string.
 
+.. _sardana-TriggerGateController-howto-prepare:
+
+Prepare for measurement
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To prepare a trigger for a measurement you can use the
+:meth:`~sardana.pool.controller.TriggerGateController.PrepareOne` method which
+receives as an argument the number of starts of the whole measurement.
+This information may be used to prepare the hardware for generating
+multiple events (triggers or gates) in a complex measurement
+e.g. :ref:`sardana-macros-scanframework-determscan`.
+
 .. _sardana-TriggerGateController-howto-load:
 
 Load synchronization description

--- a/doc/source/devel/howto_macros/scan_framework.rst
+++ b/doc/source/devel/howto_macros/scan_framework.rst
@@ -195,6 +195,7 @@ the most basic features of a continuous scan:: ::
    (with more elaborated waypoint generator), see the code of 
    :class:`~sardana.macroserver.macros.scan.meshc`
 
+.. _sardana-macros-scanframework-determscan:
 
 Deterministic scans
 -------------------

--- a/src/sardana/pool/controller.py
+++ b/src/sardana/pool/controller.py
@@ -912,6 +912,18 @@ class TriggerGateController(Controller, Synchronizer, Stopable, Startable):
     def __init__(self, inst, props, *args, **kwargs):
         Controller.__init__(self, inst, props, *args, **kwargs)
 
+    # TODO: Implement a Preparable interface and move this method
+    #  and the Loadable.PrepareOne() there.
+    def PrepareOne(self, nb_starts):
+        """**Controller API**. Override if necessary.
+        Called to prepare the trigger/gate axis with the measurement
+        parameters.
+        Default implementation does nothing.
+
+        :param int nb_starts: number of starts
+        """
+        pass
+
 
 class ZeroDController(Controller, Readable, Stopable):
     """Base class for a 0D controller. Inherit from this class to

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -499,6 +499,9 @@ class PoolAcquisition(PoolAction):
 
         config.changed = False
 
+        # Call synchronizer controllers prepare method
+        self._prepare_synch_ctrls(ctrls_synch, nb_starts)
+
         # Call hardware and software start controllers prepare method
         ctrls = ctrls_hw + ctrls_sw_start
         self._prepare_ctrls(ctrls, value, repetitions, latency,
@@ -510,6 +513,7 @@ class PoolAcquisition(PoolAction):
         self._prepare_ctrls(ctrls_sw, value, repetitions, latency,
                             nb_starts)
 
+
     @staticmethod
     def _prepare_ctrls(ctrls, value, repetitions, latency, nb_starts):
         for ctrl in ctrls:
@@ -517,6 +521,14 @@ class PoolAcquisition(PoolAction):
             pool_ctrl = ctrl.element
             pool_ctrl.ctrl.PrepareOne(axis, value, repetitions, latency,
                                       nb_starts)
+
+    @staticmethod
+    def _prepare_synch_ctrls(ctrls, nb_starts):
+        for ctrl in ctrls:
+            for chn in ctrl.get_channels():
+                axis = chn.axis
+                pool_ctrl = ctrl.element
+                pool_ctrl.ctrl.PrepareOne(axis, nb_starts)
 
     def is_running(self):
         """Checks if acquisition is running.

--- a/src/sardana/pool/poolcontrollers/DummyTriggerGateController.py
+++ b/src/sardana/pool/poolcontrollers/DummyTriggerGateController.py
@@ -72,6 +72,9 @@ class DummyTriggerGateController(TriggerGateController):
             print(e)
         return sta, status
 
+    def PrepareOne(self, axis, nb_starts):
+        self._log.debug('PrepareOne(%d): entering...' % axis)
+
     def PreStartAll(self):
         pass
 


### PR DESCRIPTION
Trigger/gate elements could be prepared for multiple starts in a deterministic scan and benefit from it.

- Add PrepareOne() to TriggerGate controller.
- Call preparation methods in PoolAcquision.preapre()
- Implement empty `PrepareOne` in DummyTriggerGateController
- Document the new feature

Implements #1432

This PR is the outcome of a pair-programming session with @13bscsaamjad.