### PR TITLE
Document how to properly deal with exceptions in macros

### DIFF
--- a/doc/source/devel/api/api_macro.rst
+++ b/doc/source/devel/api/api_macro.rst
@@ -42,3 +42,23 @@ imacro decorator
     :members:
     :undoc-members:
 
+StopException
+-------------
+
+.. autoclass:: StopException
+    :members:
+    :undoc-members:
+
+AbortException
+--------------
+
+.. autoclass:: AbortException
+    :members:
+    :undoc-members:
+
+InterruptException
+------------------
+
+.. autoclass:: InterruptException
+    :members:
+    :undoc-members:

--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -13,6 +13,10 @@ Writing macros
 This chapter provides the necessary information to write macros in sardana. The
 complete macro :term:`API` can be found :ref:`here <sardana-macro-api>`.
 
+.. contents:: Table of contents
+    :depth: 3
+    :backlinks: entry
+
 What is a macro
 ---------------
 

--- a/doc/source/devel/howto_macros/macros_general.rst
+++ b/doc/source/devel/howto_macros/macros_general.rst
@@ -866,6 +866,55 @@ of user's interruption you must override the
     withing the :meth:`~sardana.macroserver.macro.Macro.on_stop` or
     :meth:`~sardana.macroserver.macro.Macro.on_abort`.
 
+.. _sardana-macro-exception-handling:
+
+Handling exceptions
+-------------------
+
+Please refer to the
+`Python Errors and Exceptions <https://docs.python.org/3/tutorial/errors.html>`_
+documentation on how to deal with exceptions in your macro code.
+
+.. important::
+    :ref:`sardana-macro-handling-macro-stop-and-abort` is internally implemented
+    using Python exceptions. So, your ``except`` clause can not simply catch any
+    exception type without re-raising it - this would ignore the macro stop/abort
+    request done in the ``try ... except`` block. If you still would like to
+    use the broad catching, you need to catch and raise the stop/abort exception
+    first:
+
+    .. code-block:: python
+        :emphasize-lines: 7
+
+        import time
+
+        from sardana.macroserver.macro import macro, StopException
+
+        @macro()
+        def exception_macro(self):
+            self.output("Starting stoppable process")
+            try:
+                for i in range(10):
+                    self.output("In iteration: {}".format(i))
+                    time.sleep(1)
+            except StopException:
+                raise
+            except Exception:
+                self.warning("Exception, but we continue")
+            self.output("After 'try ... except' block")
+
+    If you do not program lines 12-13 and you stop your macro within
+    the ``try ... except`` block then the macro will continue and print the
+    output from line 16.
+
+    You may choose to catch and re-raise:
+    `~sardana.macroserver.macro.StopException`,
+    `~sardana.macroserver.macro.AbortException` or
+    `~sardana.macroserver.macro.InterruptException`. The last one will
+    take care of stopping and aborting at the same time.
+
+
+
 .. _sardana-macro-adding-hooks-support:
 
 Adding hooks support

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -33,7 +33,8 @@ import numbers
 __all__ = ["OverloadPrint", "PauseEvent", "Hookable", "ExecMacroHook",
            "MacroFinder", "Macro", "macro", "iMacro", "imacro",
            "MacroFunc", "Type", "Table", "List", "ViewOption",
-           "LibraryError", "Optional"]
+           "LibraryError", "Optional", "StopException", "AbortException",
+           "InterruptException"]
 
 __docformat__ = 'restructuredtext'
 
@@ -60,7 +61,7 @@ from sardana.util.thread import _asyncexc
 from sardana.macroserver.msparameter import Type, ParamType, Optional
 from sardana.macroserver.msexception import StopException, AbortException, \
     ReleaseException, MacroWrongParameterType, UnknownEnv, UnknownMacro, \
-    LibraryError
+    LibraryError, InterruptException
 from sardana.macroserver.msoptions import ViewOption
 
 from sardana.taurus.core.tango.sardana.pool import PoolElement


### PR DESCRIPTION
In our control room our operators started using macros for the accelerators operation. They migrated a set of python scripts into macros. We have observed that in their scripts (now macros) they were using broad exception types in the `except` clause.
This may interfer with the macro stopping/aborting. 484af30 warns about it.

Since the [How to develop macros](https://sardana-controls.org/devel/howto_macros/macros_general.html) documentation already growed to a big chapter I take a profit of this PR to add a table of contats (TOC) in order to faciltate navigation. The section headers are now links to the chapter in the TOC.
It looks more or less like this:

![image](https://user-images.githubusercontent.com/6735649/102603893-bddd7480-4123-11eb-9bcb-a082a4eeb58a.png)

@sardana-org/integrators could you please take a look on this. Thanks a lot!