### PR TITLE
Allow running Spock without Qt bindings

### DIFF
--- a/src/sardana/spock/inputhandler.py
+++ b/src/sardana/spock/inputhandler.py
@@ -25,17 +25,9 @@
 
 """Spock submodule. It contains an input handler"""
 
-__all__ = ['SpockInputHandler', 'InputHandler']
+__all__ = ['SpockInputHandler']
 
 __docformat__ = 'restructuredtext'
-
-import sys
-from multiprocessing import Process, Pipe
-
-from taurus.core import TaurusManager
-from taurus.core.util.singleton import Singleton
-from taurus.external.qt import Qt, compat
-from taurus.qt.qtgui.dialog import TaurusMessageBox, TaurusInputDialog
 
 from sardana.taurus.core.tango.sardana.macroserver import BaseInputHandler
 
@@ -67,103 +59,3 @@ class SpockInputHandler(BaseInputHandler):
 
     def input_timeout(self, input_data):
         print("SpockInputHandler input timeout")
-
-
-class MessageHandler(Qt.QObject):
-
-    messageArrived = Qt.pyqtSignal(compat.PY_OBJECT)
-
-    def __init__(self, conn, parent=None):
-        Qt.QObject.__init__(self, parent)
-        self._conn = conn
-        self._dialog = None
-        self.messageArrived.connect(self.on_message)
-
-    def handle_message(self, input_data):
-        self.messageArrived.emit(input_data)
-
-    def on_message(self, input_data):
-        msg_type = input_data['type']
-        if msg_type == 'input':
-            if 'macro_name' in input_data and 'title' not in input_data:
-                input_data['title'] = input_data['macro_name']
-            self._dialog = dialog = TaurusInputDialog(input_data=input_data)
-            dialog.activateWindow()
-            dialog.exec_()
-            ok = dialog.result()
-            value = dialog.value()
-            ret = dict(input=None, cancel=False)
-            if ok:
-                ret['input'] = value
-            else:
-                ret['cancel'] = True
-            self._conn.send(ret)
-        elif msg_type == 'timeout':
-            dialog = self._dialog
-            if dialog:
-                dialog.close()
-
-
-class InputHandler(Singleton, BaseInputHandler):
-
-    def __init__(self):
-        # don't call super __init__ on purpose
-        pass
-
-    def init(self, *args, **kwargs):
-        self._conn, child_conn = Pipe()
-        self._proc = proc = Process(target=self.safe_run,
-                                    name="SpockInputHandler", args=(child_conn,))
-        proc.daemon = True
-        proc.start()
-
-    def input(self, input_data=None):
-        # parent process
-        data_type = input_data.get('data_type', 'String')
-        if isinstance(data_type, str):
-            ms = genutils.get_macro_server()
-            interfaces = ms.getInterfaces()
-            if data_type in interfaces:
-                input_data['data_type'] = [
-                    elem.name for elem in list(interfaces[data_type].values())]
-        self._conn.send(input_data)
-        ret = self._conn.recv()
-        return ret
-
-    def input_timeout(self, input_data):
-        # parent process
-        self._conn.send(input_data)
-
-    def safe_run(self, conn):
-        # child process
-        try:
-            return self.run(conn)
-        except Exception as e:
-            msgbox = TaurusMessageBox(*sys.exc_info())
-            conn.send((e, False))
-            msgbox.exec_()
-
-    def run(self, conn):
-        # child process
-        self._conn = conn
-        app = Qt.QApplication.instance()
-        if app is None:
-            app = Qt.QApplication(['spock'])
-        app.setQuitOnLastWindowClosed(False)
-        self._msg_handler = MessageHandler(conn)
-        TaurusManager().addJob(self.run_forever, None)
-        app.exec_()
-        conn.close()
-        print("Quit input handler")
-
-    def run_forever(self):
-        # child process
-        message, conn = True, self._conn
-        while message:
-            message = conn.recv()
-            if not message:
-                continue
-            self._msg_handler.handle_message(message)
-        app = Qt.QApplication.instance()
-        if app:
-            app.quit()

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -1289,12 +1289,15 @@ def mainloop(app=None, user_ns=None):
 def prepare_input_handler():
     # initialize input handler as soon as possible
 
-    try:
-        import sardana.spock.qtinputhandler
-        _ = sardana.spock.inputhandler.InputHandler()
-    except ImportError:
-        import sardana.spock.inputhandler
-        _ = sardana.spock.inputhandler.SpockInputHandler()
+    from sardana import sardanacustomsettings
+
+    if sardanacustomsettings.SPOCK_INPUT_HANDLER == "Qt":
+
+        try:
+            import sardana.spock.qtinputhandler
+            _ = sardana.spock.qtinputhandler.InputHandler()
+        except ImportError:
+            raise Exception("Cannot use Spock Qt input handler!")
 
 
 def prepare_cmdline(argv=None):

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -82,7 +82,10 @@ from taurus.core.taurushelper import Factory
 from taurus.core.util.codecs import CodecFactory
 
 # make sure Qt is properly initialized
-from taurus.external.qt import Qt
+try:
+    from taurus.external.qt import Qt
+except ImportError:
+    pass
 
 from sardana.spock import exception
 from sardana.spock import colors
@@ -110,7 +113,11 @@ ENV_NAME = "_E"
 
 
 def get_gui_mode():
-    return 'qt'
+    try:
+        import taurus.external.qt.Qt
+        return 'qt'
+    except ImportError:
+        return None
 
 
 def get_pylab_mode():
@@ -1159,7 +1166,8 @@ object?   -> Details about 'object'. ?object also works, ?? prints more.
     term_app = config.TerminalIPythonApp
     term_app.display_banner = True
     term_app.gui = gui_mode
-    term_app.pylab = 'qt'
+    if gui_mode == 'qt':
+        term_app.pylab = 'qt'
     term_app.pylab_import_all = False
     #term_app.nosep = False
     #term_app.classic = True
@@ -1280,8 +1288,13 @@ def mainloop(app=None, user_ns=None):
 
 def prepare_input_handler():
     # initialize input handler as soon as possible
-    import sardana.spock.inputhandler
-    _ = sardana.spock.inputhandler.InputHandler()
+
+    try:
+        import sardana.spock.qtinputhandler
+        _ = sardana.spock.inputhandler.InputHandler()
+    except ImportError:
+        import sardana.spock.inputhandler
+        _ = sardana.spock.inputhandler.SpockInputHandler()
 
 
 def prepare_cmdline(argv=None):

--- a/src/sardana/spock/magic.py
+++ b/src/sardana/spock/magic.py
@@ -42,7 +42,7 @@ def expconf(self, parameter_s=''):
     for the experiments (scans)"""
 
     try:
-        from taurus.external.qt import qt
+        from taurus.external.qt import Qt
     except ImportError:
         print("Qt binding is not available. ExpConf cannot work without it."
               "(hint: maybe you want to use experiment configuration macros? "
@@ -92,7 +92,7 @@ def showscan(self, parameter_s=''):
     """
 
     try:
-        from taurus.external.qt import qt
+        from taurus.external.qt import Qt
     except ImportError:
         print("Qt binding is not available. Showscan cannot work without it.")
         return
@@ -138,7 +138,7 @@ def showscan(self, parameter_s=''):
 
 def spsplot(self, parameter_s=''):
     try:
-        from taurus.external.qt import qt
+        from taurus.external.qt import Qt
     except ImportError:
         print("Qt binding is not available. SPSplot cannot work without it.")
         return

--- a/src/sardana/spock/magic.py
+++ b/src/sardana/spock/magic.py
@@ -40,6 +40,15 @@ from .genutils import page, get_door, get_macro_server, ask_yes_no, arg_split
 def expconf(self, parameter_s=''):
     """Launches a GUI for configuring the environment variables
     for the experiments (scans)"""
+
+    try:
+        from taurus.external.qt import qt
+    except ImportError:
+        print("Qt binding is not available. ExpConf cannot work without it."
+              "(hint: maybe you want to use experiment configuration macros? "
+              "https://sardana-controls.org/users/standard_macro_catalog.html#experiment-configuration-macros)")
+        return
+
     try:
         from sardana.taurus.qt.qtgui.extra_sardana import ExpDescriptionEditor
     except:
@@ -81,6 +90,13 @@ def showscan(self, parameter_s=''):
     Where *online* means plot the scan as it runs and *offline* means -
     extract the scan data from the file - works only with HDF5 files.
     """
+
+    try:
+        from taurus.external.qt import qt
+    except ImportError:
+        print("Qt binding is not available. Showscan cannot work without it.")
+        return
+
     params = parameter_s.split()
     door = get_door()
     scan_nb = None
@@ -121,6 +137,12 @@ def showscan(self, parameter_s=''):
 
 
 def spsplot(self, parameter_s=''):
+    try:
+        from taurus.external.qt import qt
+    except ImportError:
+        print("Qt binding is not available. SPSplot cannot work without it.")
+        return
+
     get_door().plot()
 
 

--- a/src/sardana/spock/qtinputhandler.py
+++ b/src/sardana/spock/qtinputhandler.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+"""Spock submodule. It contains an input handler"""
+
+__all__ = ['InputHandler']
+
+__docformat__ = 'restructuredtext'
+
+import sys
+from multiprocessing import Process, Pipe
+
+from taurus.core import TaurusManager
+from taurus.core.util.singleton import Singleton
+from taurus.external.qt import Qt, compat
+from taurus.qt.qtgui.dialog import TaurusMessageBox, TaurusInputDialog
+
+from sardana.taurus.core.tango.sardana.macroserver import BaseInputHandler
+
+from sardana.spock import genutils
+
+
+class MessageHandler(Qt.QObject):
+
+    messageArrived = Qt.pyqtSignal(compat.PY_OBJECT)
+
+    def __init__(self, conn, parent=None):
+        Qt.QObject.__init__(self, parent)
+        self._conn = conn
+        self._dialog = None
+        self.messageArrived.connect(self.on_message)
+
+    def handle_message(self, input_data):
+        self.messageArrived.emit(input_data)
+
+    def on_message(self, input_data):
+        msg_type = input_data['type']
+        if msg_type == 'input':
+            if 'macro_name' in input_data and 'title' not in input_data:
+                input_data['title'] = input_data['macro_name']
+            self._dialog = dialog = TaurusInputDialog(input_data=input_data)
+            dialog.activateWindow()
+            dialog.exec_()
+            ok = dialog.result()
+            value = dialog.value()
+            ret = dict(input=None, cancel=False)
+            if ok:
+                ret['input'] = value
+            else:
+                ret['cancel'] = True
+            self._conn.send(ret)
+        elif msg_type == 'timeout':
+            dialog = self._dialog
+            if dialog:
+                dialog.close()
+
+
+class InputHandler(Singleton, BaseInputHandler):
+
+    def __init__(self):
+        # don't call super __init__ on purpose
+        pass
+
+    def init(self, *args, **kwargs):
+        self._conn, child_conn = Pipe()
+        self._proc = proc = Process(target=self.safe_run,
+                                    name="SpockInputHandler", args=(child_conn,))
+        proc.daemon = True
+        proc.start()
+
+    def input(self, input_data=None):
+        # parent process
+        data_type = input_data.get('data_type', 'String')
+        if isinstance(data_type, str):
+            ms = genutils.get_macro_server()
+            interfaces = ms.getInterfaces()
+            if data_type in interfaces:
+                input_data['data_type'] = [
+                    elem.name for elem in list(interfaces[data_type].values())]
+        self._conn.send(input_data)
+        ret = self._conn.recv()
+        return ret
+
+    def input_timeout(self, input_data):
+        # parent process
+        self._conn.send(input_data)
+
+    def safe_run(self, conn):
+        # child process
+        try:
+            return self.run(conn)
+        except Exception as e:
+            msgbox = TaurusMessageBox(*sys.exc_info())
+            conn.send((e, False))
+            msgbox.exec_()
+
+    def run(self, conn):
+        # child process
+        self._conn = conn
+        app = Qt.QApplication.instance()
+        if app is None:
+            app = Qt.QApplication(['spock'])
+        app.setQuitOnLastWindowClosed(False)
+        self._msg_handler = MessageHandler(conn)
+        TaurusManager().addJob(self.run_forever, None)
+        app.exec_()
+        conn.close()
+        print("Quit input handler")
+
+    def run_forever(self):
+        # child process
+        message, conn = True, self._conn
+        while message:
+            message = conn.recv()
+            if not message:
+                continue
+            self._msg_handler.handle_message(message)
+        app = Qt.QApplication.instance()
+        if app:
+            app.quit()

--- a/src/sardana/spock/spockms.py
+++ b/src/sardana/spock/spockms.py
@@ -44,7 +44,6 @@ CHANGE_EVTS = TaurusEventType.Change, TaurusEventType.Periodic
 
 
 if genutils.get_gui_mode() == 'qt':
-    from taurus.external.qt import Qt
     from sardana.taurus.qt.qtcore.tango.sardana.macroserver import QDoor, QMacroServer
     BaseDoor = QDoor
     BaseMacroServer = QMacroServer

--- a/src/sardana/spock/spockms.py
+++ b/src/sardana/spock/spockms.py
@@ -46,13 +46,11 @@ CHANGE_EVTS = TaurusEventType.Change, TaurusEventType.Periodic
 if genutils.get_gui_mode() == 'qt':
     from taurus.external.qt import Qt
     from sardana.taurus.qt.qtcore.tango.sardana.macroserver import QDoor, QMacroServer
-    from sardana.spock.qtinputhandler import InputHandler
     BaseDoor = QDoor
     BaseMacroServer = QMacroServer
     BaseGUIViewer = object
 else:
     from sardana.taurus.core.tango.sardana.macroserver import BaseDoor, BaseMacroServer
-    from sardana.spock.inputhandler import SpockInputHandler
     BaseGUIViewer = object
 
 
@@ -292,6 +290,8 @@ class SpockBaseDoor(BaseDoor):
         self.call__init__(BaseDoor, name, **kw)
 
     def create_input_handler(self):
+        from sardana.spock.inputhandler import SpockInputHandler
+
         return SpockInputHandler()
 
     def get_color_mode(self):
@@ -574,6 +574,9 @@ class QSpockDoor(SpockBaseDoor):
         return res
 
     def create_input_handler(self):
+        from sardana.spock.inputhandler import SpockInputHandler
+        from sardana.spock.qtinputhandler import InputHandler
+
         inputhandler = getattr(sardanacustomsettings, 'SPOCK_INPUT_HANDLER',
                                "CLI")
 

--- a/src/sardana/spock/spockms.py
+++ b/src/sardana/spock/spockms.py
@@ -38,19 +38,21 @@ from taurus.core import TaurusEventType, TaurusSWDevState, TaurusDevState
 from sardana.sardanautils import is_pure_str, is_non_str_seq
 from sardana.spock import genutils
 from sardana.util.parser import ParamParser
-from sardana.spock.inputhandler import SpockInputHandler, InputHandler
 from sardana import sardanacustomsettings
 
 CHANGE_EVTS = TaurusEventType.Change, TaurusEventType.Periodic
 
 
 if genutils.get_gui_mode() == 'qt':
+    from taurus.external.qt import Qt
     from sardana.taurus.qt.qtcore.tango.sardana.macroserver import QDoor, QMacroServer
+    from sardana.spock.qtinputhandler import InputHandler
     BaseDoor = QDoor
     BaseMacroServer = QMacroServer
     BaseGUIViewer = object
 else:
     from sardana.taurus.core.tango.sardana.macroserver import BaseDoor, BaseMacroServer
+    from sardana.spock.inputhandler import SpockInputHandler
     BaseGUIViewer = object
 
 
@@ -290,7 +292,7 @@ class SpockBaseDoor(BaseDoor):
         self.call__init__(BaseDoor, name, **kw)
 
     def create_input_handler(self):
-        return SpockInputHandler(self)
+        return SpockInputHandler()
 
     def get_color_mode(self):
         return genutils.get_color_mode()
@@ -552,9 +554,6 @@ class SpockBaseDoor(BaseDoor):
             self.logReceived(self.Info, ['Received long data record (%d Kb)' % sizekb,
                                          'It may take some time to process. Please wait...'])
         return BaseDoor._processRecordData(self, data)
-
-
-from taurus.external.qt import Qt
 
 
 class QSpockDoor(SpockBaseDoor):


### PR DESCRIPTION
Allow launching Spock from commandline without need to have Qt bindings installed.
The behaviour is like this:
 - try to detect if Qt bindings are installed (vi `import taurus.external.qt.Qt`)
 - if Qt bindings are installed, use them
 - if Qt bindings are not installed, use command-line only input handler.

closes #1462 

I'm not an expert in IPython or Spock hence I would appreciate testing from more advanced users.