### PR TITLE
Change shape to read only axis parameter

### DIFF
--- a/doc/source/devel/howto_controllers/howto_1dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_1dcontroller.rst
@@ -30,6 +30,31 @@ To write a 1D controller class you can follow
 the :ref:`sardana-countertimercontroller` guide keeping in mind
 differences explained in continuation.
 
+.. _sardana-1dcontroller-general-guide-shape:
+
+Get 1D shape
+~~~~~~~~~~~~
+
+1D controller must provide a shape of the spectrum which will be produced by
+acquisition. The shape can be either static e.g. defined by the detector's
+sensor size or dynamic e.g. depending on the detector's (or an intermediate
+control software layer e.g. `LImA`_) configuration like :term:`RoI` or binning.
+
+In any case you must provide the shape in the format of a one-element sequence
+with the length of the spectrum using
+the :meth:`~sardana.pool.controller.Controller.GetAxisPar` method.
+
+Here is an example of the possible implementation of
+:meth:`~sardana.pool.controller.Controller.GetAxisPar`:
+
+.. code-block:: python
+
+    class SpringfieldOneDController(TwoDController):
+
+        def GetAxisPar(self, axis, par):
+            if par == "shape":
+                return self.springfield.getShape(axis)
+
 .. _sardana-1dcontroller-differences-countertimer:
 
 Differences with counter/timer controller

--- a/doc/source/devel/howto_controllers/howto_1dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_1dcontroller.rst
@@ -35,12 +35,12 @@ differences explained in continuation.
 Get 1D shape
 ~~~~~~~~~~~~
 
-1D controller must provide a shape of the spectrum which will be produced by
+1D controller should provide a shape of the spectrum which will be produced by
 acquisition. The shape can be either static e.g. defined by the detector's
 sensor size or dynamic e.g. depending on the detector's (or an intermediate
 control software layer e.g. `LImA`_) configuration like :term:`RoI` or binning.
 
-In any case you must provide the shape in the format of a one-element sequence
+In any case you should provide the shape in the format of a one-element sequence
 with the length of the spectrum using
 the :meth:`~sardana.pool.controller.Controller.GetAxisPar` method.
 
@@ -54,6 +54,10 @@ Here is an example of the possible implementation of
         def GetAxisPar(self, axis, par):
             if par == "shape":
                 return self.springfield.getShape(axis)
+
+For backwards compatibility, in case of not implementing the ``shape`` axis
+parameter, shape will be determined from the ``MaxDimSize`` of the ``Value``
+attribute, currently (4096,).
 
 .. _sardana-1dcontroller-differences-countertimer:
 

--- a/doc/source/devel/howto_controllers/howto_1dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_1dcontroller.rst
@@ -121,7 +121,7 @@ leaving the data storage at the responsibility of the detector
 just deals with the reference to the data.
 
 Please refer to :ref:`sardana-2dcontroller-valuereferencing` chapter from
-:ref:`sardana-2dcontroller-howto` in order to implement this feature for 1D
+:ref:`sardana-2dcontroller-howto` guide in order to implement this feature for 1D
 controller.
 
 .. _ALBA: http://www.cells.es/

--- a/doc/source/devel/howto_controllers/howto_2dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_2dcontroller.rst
@@ -173,7 +173,7 @@ Configure 2D value reference
 Two axis parameters: ``value_ref_pattern`` (`str`)
 and ``value_ref_enabled`` (`bool`) are foreseen for configuring where to store
 the values and whether to use the value referencing. Here you need to implement
-the :meth:`~sardana.pool.controller.Controller.SetAxiPar` method.
+the :meth:`~sardana.pool.controller.Controller.SetAxisPar` method.
 
 Here is an example of the possible implementation of
 :meth:`~sardana.pool.controller.Controller.SetAxisPar`:

--- a/doc/source/devel/howto_controllers/howto_2dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_2dcontroller.rst
@@ -27,6 +27,31 @@ To write a 2D controller class you can follow
 the :ref:`sardana-countertimercontroller` guide keeping in mind
 differences explained in continuation.
 
+.. _sardana-2dcontroller-general-guide-shape:
+
+Get 2D shape
+~~~~~~~~~~~~
+
+2D controller must provide a shape of the image which will be produced by
+acquisition. The shape can be either static e.g. defined by the detector's
+sensor size or dynamic e.g. depending on the detector's (or an intermediate
+control software layer e.g. `LImA`_) configuration like :term:`RoI` or binning.
+
+In any case you must provide the shape in the format of a two-element sequence
+with horizonatal and vertical dimensions using
+the :meth:`~sardana.pool.controller.Controller.GetAxisPar` method.
+
+Here is an example of the possible implementation of
+:meth:`~sardana.pool.controller.Controller.GetAxisPar`:
+
+.. code-block:: python
+
+    class SpringfieldTwoDController(TwoDController):
+
+        def GetAxisPar(self, axis, par):
+            if par == "shape":
+                return self.springfield.getShape(axis)
+
 .. _sardana-2dcontroller-differences-countertimer:
 
 Differences with counter/timer controller

--- a/doc/source/devel/howto_controllers/howto_2dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_2dcontroller.rst
@@ -32,12 +32,12 @@ differences explained in continuation.
 Get 2D shape
 ~~~~~~~~~~~~
 
-2D controller must provide a shape of the image which will be produced by
+2D controller should provide a shape of the image which will be produced by
 acquisition. The shape can be either static e.g. defined by the detector's
 sensor size or dynamic e.g. depending on the detector's (or an intermediate
 control software layer e.g. `LImA`_) configuration like :term:`RoI` or binning.
 
-In any case you must provide the shape in the format of a two-element sequence
+In any case you should provide the shape in the format of a two-element sequence
 with horizontal and vertical dimensions using
 the :meth:`~sardana.pool.controller.Controller.GetAxisPar` method.
 
@@ -51,6 +51,10 @@ Here is an example of the possible implementation of
         def GetAxisPar(self, axis, par):
             if par == "shape":
                 return self.springfield.getShape(axis)
+
+For backwards compatibility, in case of not implementing the ``shape`` axis
+parameter, shape will be determined frm the ``MaxDimSize`` of the ``Value``
+attribute, currently (4096, 4096).
 
 .. _sardana-2dcontroller-differences-countertimer:
 

--- a/doc/source/devel/howto_controllers/howto_2dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_2dcontroller.rst
@@ -38,7 +38,7 @@ sensor size or dynamic e.g. depending on the detector's (or an intermediate
 control software layer e.g. `LImA`_) configuration like :term:`RoI` or binning.
 
 In any case you must provide the shape in the format of a two-element sequence
-with horizonatal and vertical dimensions using
+with horizontal and vertical dimensions using
 the :meth:`~sardana.pool.controller.Controller.GetAxisPar` method.
 
 Here is an example of the possible implementation of

--- a/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
@@ -73,6 +73,8 @@ negative. The value close to the zero indicates the beam centered in the middle.
 Similarly behaves the horizontal pseudo counter. The total pseudo counter is
 the mean value of all the four sensors and indicates the beam intensity.
 
+.. _sardana-pseudocountercontroller-howto-changing-interface:
+
 Changing default interface
 --------------------------
 
@@ -101,7 +103,7 @@ Get pseudo counter shape
 ------------------------
 
 If you change the pseudo counter format to spectrum or image then you
-controller must provide the shape of the calculation result in either
+controller should provide the shape of the calculation result in either
 of the formats:
 
 - one-element sequence with the length of the spectrum
@@ -117,6 +119,11 @@ Here is an example of the possible implementation of
     def GetAxisPar(self, axis, par):
         if par == "shape":
             return [1024, 1024]
+
+
+For backwards compatibility, in case of not implementing the ``shape`` axis
+parameter, shape will be determined from the ``MaxDimSize`` of the ``Value``
+attribute as defined in :ref:`sardana-pseudocountercontroller-howto-changing-interface`.
 
 Including external variables in the calculation
 -----------------------------------------------

--- a/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
@@ -80,12 +80,12 @@ Pseudo counters instantiated from your controller will have a default
 interface, which among others, comprises the *value* attribute. This attribute
 is feed with the result of the
 :meth:`~sardana.pool.controller.PseudoCounterController.calc` method and by
-default it expects values of ``float`` type and scalar shape. You can easily
+default it expects values of ``float`` type and scalar format. You can easily
 :ref:`change the default interface <sardana-controller-howto-change-default-interface>`.
-This way you could program a pseudo counter to obtain an image :term:`ROI`
+This way you could program a pseudo counter to obtain an image :term:`RoI`
 of a :ref:`2D experimental channel <sardana-2d-overview>`.
 
-Here is an example of how to change *value* attribute's shape to an image
+Here is an example of how to change *value* attribute's format to an image
 and specify its maximum dimension of 1024 x 1024 pixels:
 
 .. code-block:: python

--- a/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
@@ -97,6 +97,26 @@ and specify its maximum dimension of 1024 x 1024 pixels:
         axis_attrs['Value'][MaxDimSize] = (1024, 1024)
         return axis_attrs
 
+Get pseudo counter shape
+------------------------
+
+If you change the pseudo counter format to spectrum or image then you
+controller must provide the shape of the calculation result in either
+of the formats:
+
+- one-element sequence with the length of the spectrum
+- two-element sequence with the horizonatal and vertical dimensions of the image
+
+using the :meth:`~sardana.pool.controller.Controller.GetAxisPar` method.
+
+Here is an example of the possible implementation of
+:meth:`~sardana.pool.controller.Controller.GetAxisPar`:
+
+.. code-block:: python
+
+    def GetAxisPar(self, axis, par):
+        if par == "shape":
+            return [1024, 1024]
 
 Including external variables in the calculation
 -----------------------------------------------

--- a/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
@@ -90,7 +90,7 @@ and specify its maximum dimension of 1024 x 1024 pixels:
 
 .. code-block:: python
 
-        def GetAxisAttributes(self, axis):
+    def GetAxisAttributes(self, axis):
         axis_attrs = PseudoCounterController.GetAxisAttributes(self, axis)
         axis_attrs = dict(axis_attrs)
         axis_attrs['Value'][Type] = ((float, ), )

--- a/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_pseudocountercontroller.rst
@@ -105,7 +105,7 @@ controller must provide the shape of the calculation result in either
 of the formats:
 
 - one-element sequence with the length of the spectrum
-- two-element sequence with the horizonatal and vertical dimensions of the image
+- two-element sequence with the horizontal and vertical dimensions of the image
 
 using the :meth:`~sardana.pool.controller.Controller.GetAxisPar` method.
 

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -430,8 +430,8 @@ Glossary
     dial
         See :term:`dial position`
 
-    ROI
-        *Region of interest* are samples within a data set identified for a
+    RoI
+        *Region of Interest* are samples within a data set identified for a
         particular purpose.
         
 .. _plug-in: http://en.wikipedia.org/wiki/Plug-in_(computing)

--- a/doc/source/users/taurus/experimentconfiguration.rst
+++ b/doc/source/users/taurus/experimentconfiguration.rst
@@ -75,7 +75,6 @@ a given channel or its controller:
   process.
 * output - whether the channel acquisition results should be printed, for example,
   by the output recorder during the scan. Can be either True or False.
-* shape - shape of the data 
 * data type - type of the data
 * plot type - select the online scan plot type for the channel. Can have one
   of the following values:

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -88,7 +88,7 @@ def _get_shape(channel):
     if isinstance(channel, PyTango.DeviceProxy):
         try:
             shape = channel.shape
-        except:
+        except Exception:
             return None
         if shape is None:  # in PyTango empty spectrum is None
             return []
@@ -97,13 +97,13 @@ def _get_shape(channel):
     elif isinstance(channel, PyTango.AttributeProxy):
         try:
             attr_conf = channel.get_config()
-        except:
+        except Exception:
             return None
         if attr_conf.data_format == PyTango.AttrDataFormat.SCALAR:
             return []
         try:
             value = channel.read().value
-        except:
+        except Exception:
             return [n for n in (attr_conf.max_dim_x,
                                 attr_conf.max_dim_y) if n > 0]
         return list(np.shape(value))
@@ -708,16 +708,16 @@ class GScan(Logger):
                 # See: tango-controls/pytango#292
                 # channel = taurus.Device(full_name)
                 channel = PyTango.DeviceProxy(full_name)
-            except:
+            except Exception:
                 try:
                     channel = PyTango.AttributeProxy(full_name)
-                except:
+                except Exception:
                     channel = None
             if channel:
                 shape = _get_shape(channel)
                 try:
                     instrument = channel.instrument
-                except:
+                except Exception:
                     instrument = ''
             try:
                 instrumentFullName = self.macro.findObjs(

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -83,6 +83,32 @@ class ScanException(MacroServerException):
     pass
 
 
+def _get_shape(channel):
+    # internal Sardana channel
+    if isinstance(channel, PyTango.DeviceProxy):
+        try:
+            shape = channel.shape
+        except:
+            return None
+        if shape is None:  # in PyTango empty spectrum is None
+            return []
+        return shape
+    # external channel (Tango attribute)
+    elif isinstance(channel, PyTango.AttributeProxy):
+        try:
+            attr_conf = channel.get_config()
+        except:
+            return None
+        if attr_conf.data_format == PyTango.AttrDataFormat.SCALAR:
+            return []
+        try:
+            value = channel.read().value
+        except:
+            return [n for n in (attr_conf.max_dim_x,
+                                attr_conf.max_dim_y) if n > 0]
+        return list(np.shape(value))
+
+
 class ExtraData(object):
 
     def __init__(self, **kwargs):
@@ -675,16 +701,24 @@ class GScan(Logger):
         counters = []
         for ci in channels_info:
             full_name = ci.full_name
+            shape = None
+            instrument = ''
             try:
                 # Use DeviceProxy instead of taurus to avoid crashes in Py3
                 # See: tango-controls/pytango#292
                 # channel = taurus.Device(full_name)
                 channel = PyTango.DeviceProxy(full_name)
-                instrument = channel.instrument
-            except Exception:
-                # full_name of external channels is the name of the attribute
-                # external channels are not assigned to instruments
-                instrument = ''
+            except:
+                try:
+                    channel = PyTango.AttributeProxy(full_name)
+                except:
+                    channel = None
+            if channel:
+                shape = _get_shape(channel)
+                try:
+                    instrument = channel.instrument
+                except:
+                    instrument = ''
             try:
                 instrumentFullName = self.macro.findObjs(
                     instrument, type_class=Type.Instrument)[0].getFullName()
@@ -692,6 +726,10 @@ class GScan(Logger):
                 raise
             except Exception:
                 instrumentFullName = ''
+            if shape is None:
+                self.warning("unknown shape of {}, assuming scalar".format(
+                    ci.name))
+                shape = []
             # substitute the axis placeholder by the corresponding moveable.
             plotAxes = []
             i = 0
@@ -713,7 +751,7 @@ class GScan(Logger):
             column = ColumnDesc(name=ci.full_name,
                                 label=ci.label,
                                 dtype=ci.data_type,
-                                shape=ci.shape,
+                                shape=shape,
                                 instrument=instrumentFullName,
                                 source=ci.source,
                                 output=ci.output,

--- a/src/sardana/pool/controller.py
+++ b/src/sardana/pool/controller.py
@@ -878,6 +878,8 @@ class CounterTimerController(Controller, Readable, Startable, Stopable,
         # TODO: in case of Tango ValueBuffer type is overridden by DevEncoded
         'ValueBuffer': {'type': str,
                         'description': 'Value buffer', },
+        'Shape': {'type': (int,),
+                  'description': 'Shape of the value, it is an empty array'}
     }
     standard_axis_attributes.update(Controller.standard_axis_attributes)
 
@@ -940,6 +942,8 @@ class ZeroDController(Controller, Readable, Stopable):
         # TODO: in case of Tango ValueBuffer type is overridden by DevEncoded
         'ValueBuffer': {'type': str,
                         'description': 'Value buffer', },
+        'Shape': {'type': (int,),
+                  'description': 'Shape of the value, it is an empty array'}
     }
     standard_axis_attributes.update(Controller.standard_axis_attributes)
 
@@ -972,6 +976,9 @@ class OneDController(Controller, Readable, Startable, Stopable, Loadable):
         # TODO: in case of Tango ValueBuffer type is overridden by DevEncoded
         'ValueBuffer': {'type': str,
                         'description': 'Value buffer', },
+        'Shape': {'type': (int,),
+                  'description': 'Shape of the value, it is an array with '
+                                 '1 element - X dimension'}
     }
     standard_axis_attributes.update(Controller.standard_axis_attributes)
 
@@ -1017,6 +1024,9 @@ class TwoDController(Controller, Readable, Startable, Stopable, Loadable):
         # TODO: in case of Tango ValueBuffer type is overridden by DevEncoded
         'ValueBuffer': {'type': str,
                         'description': 'Value buffer', },
+        'Shape': {'type': (int,),
+                  'description': 'Shape of the value, it is an array with '
+                                 '2 elements: X and Y dimensions'}
     }
     standard_axis_attributes.update(Controller.standard_axis_attributes)
 
@@ -1263,6 +1273,8 @@ class PseudoCounterController(Controller):
         # TODO: in case of Tango ValueBuffer type is overridden by DevEncoded
         'ValueBuffer': {'type': str,
                         'description': 'Data', },
+        'Shape': {'type': (int,),
+                  'description': 'Shape of the value, it is an empty array'}
     }
 
     #: A :obj:`str` representing the controller gender

--- a/src/sardana/pool/poolbasechannel.py
+++ b/src/sardana/pool/poolbasechannel.py
@@ -666,7 +666,7 @@ class PoolBaseChannel(PoolElement):
     def read_shape(self):
         try:
             shape = self.controller.get_axis_par(self.axis, "shape")
-        except:
+        except Exception:
             shape = None
         if shape is None:
             # backwards compatibility for controllers not implementing

--- a/src/sardana/pool/poolbasechannel.py
+++ b/src/sardana/pool/poolbasechannel.py
@@ -30,7 +30,7 @@ __all__ = ["Value", "PoolBaseChannel"]
 
 __docformat__ = 'restructuredtext'
 
-from sardana.sardanadefs import AttrQuality
+from sardana.sardanadefs import AttrQuality, ElementType
 from sardana.sardanaattribute import SardanaAttribute
 from sardana.sardanabuffer import SardanaBuffer
 from sardana.pool.poolelement import PoolElement
@@ -120,6 +120,7 @@ class PoolBaseChannel(PoolElement):
             acq_name = "%s.Acquisition" % self._name
             self.set_action_cache(self.AcquisitionClass(self, name=acq_name))
         self._integration_time = 0
+        self._shape = None
 
     def has_pseudo_elements(self):
         """Informs whether this channel forms part of any pseudo element
@@ -644,6 +645,51 @@ class PoolBaseChannel(PoolElement):
 
     integration_time = property(get_integration_time, set_integration_time,
                                 doc="channel integration time")
+
+    # -------------------------------------------------------------------------
+    # shape
+    # -------------------------------------------------------------------------
+
+    def get_shape(self, cache=True, propagate=1):
+        if not cache or self._shape is None:
+            shape = self.read_shape()
+            self._set_shape(shape, propagate=propagate)
+        return self._shape
+
+    def _set_shape(self, shape, propagate=1):
+        self._shape = shape
+        if not propagate:
+            return
+        self.fire_event(
+            EventType("shape", priority=propagate), shape)
+
+    def read_shape(self):
+        try:
+            shape = self.controller.get_axis_par(self.axis, "shape")
+        except:
+            shape = None
+        if shape is None:
+            # backwards compatibility for controllers not implementing
+            # shape axis par
+            if self.get_type() in (ElementType.OneDExpChannel,
+                                   ElementType.TwoDExpChannel):
+                self.warning(
+                    "not implementing shape axis parameter in 1D and 2D "
+                    "controllers is deprecated since Jan21")
+                value = self.value.value
+                import numpy
+                try:
+                    shape = numpy.shape(value)
+                except Exception as e:
+                    raise RuntimeError(
+                        "can not provide backwards compatibility, you must"
+                        "implement shape axis parameter") from e
+            # scalar channel
+            else:
+                shape = []
+        return shape
+
+    shape = property(get_shape, doc="channel value shape")
 
     def _prepare(self):
         # TODO: think of implementing the preparation in the software

--- a/src/sardana/pool/poolcontrollers/DummyOneDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyOneDController.py
@@ -44,6 +44,7 @@ class Channel:
         self.active = True
         self.amplitude = BaseValue('1.0')
         self._counter = 0
+        self.roi = [0, 0]
 
 
 class BaseValue(object):
@@ -89,7 +90,15 @@ class DummyOneDController(OneDController):
             FGet: 'getAmplitude',
             FSet: 'setAmplitude',
             Description: 'Amplitude. Maybe a number or a tango attribute(must start with tango://)',
-            DefaultValue: '1.0'},
+            DefaultValue: '1.0'
+        },
+        'RoI': {
+            Type: (int,),
+            FGet: 'getRoI',
+            FSet: 'setRoI',
+            Description: "Region of Interest of spectrum (begin, end)",
+            DefaultValue: [0, 0]
+        }
     }
 
     def __init__(self, inst, props, *args, **kwargs):
@@ -170,7 +179,11 @@ class DummyOneDController(OneDController):
                 t = self.integ_time
             x = numpy.linspace(-10, 10, self.BufferSize[0])
             amplitude = axis * t * channel.amplitude.get()
-            channel.value = gauss(x, 0, amplitude, 4)
+            spectrum = gauss(x, 0, amplitude, 4)
+            roi = channel.roi
+            if roi != [0, 0]:
+                spectrum = spectrum[roi[0]:roi[1]]
+            channel.value = spectrum
         elif self._synchronization in (AcqSynch.HardwareTrigger,
                                        AcqSynch.HardwareGate):
             if self.integ_time is not None:
@@ -277,3 +290,30 @@ class DummyOneDController(OneDController):
         if value.startswith("tango://"):
             klass = TangoValue
         channel.amplitude = klass(value)
+
+    def getRoI(self, axis):
+        idx = axis - 1
+        channel = self.channels[idx]
+        return channel.roi
+
+    def setRoI(self, axis, value):
+        idx = axis - 1
+        channel = self.channels[idx]
+        try:
+            value = value.tolist()
+        except AttributeError:
+            pass
+        if len(value) != 2:
+            raise ValueError("RoI is not a list of two elements")
+        if any(not isinstance(v, int) for v in value):
+            raise ValueError("RoI is not a list of integers")
+        if value[1] <= value[0]:
+            raise ValueError("RoI[1] is lower or equal than RoI[0]")
+        dim = self.BufferSize[0]
+        if value[0] > (dim - 1):
+            raise ValueError(
+                "RoI[0] exceeds detector dimension - 1 ({})".format(dim - 1))
+        if value[1] > dim:
+            raise ValueError(
+                "RoI[1] exceeds detector dimension ({})".format(dim))
+        channel.roi = value

--- a/src/sardana/pool/poolcontrollers/DummyOneDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyOneDController.py
@@ -317,3 +317,12 @@ class DummyOneDController(OneDController):
             raise ValueError(
                 "RoI[1] exceeds detector dimension ({})".format(dim))
         channel.roi = value
+
+    def GetAxisPar(self, axis, par):
+        idx = axis - 1
+        channel = self.channels[idx]
+        if par == "shape":
+            roi = channel.roi
+            if roi == [0, 0]:
+                return self.BufferSize
+            return [roi[1] - roi[0]]

--- a/src/sardana/pool/poolcontrollers/DummyOneDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyOneDController.py
@@ -307,7 +307,7 @@ class DummyOneDController(OneDController):
             raise ValueError("RoI is not a list of two elements")
         if any(not isinstance(v, int) for v in value):
             raise ValueError("RoI is not a list of integers")
-        if value[1] <= value[0]:
+        if value != [0, 0] and value[1] <= value[0]:
             raise ValueError("RoI[1] is lower or equal than RoI[0]")
         dim = self.BufferSize[0]
         if value[0] > (dim - 1):

--- a/src/sardana/pool/poolcontrollers/DummyTwoDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyTwoDController.py
@@ -397,10 +397,11 @@ class BasicDummyTwoDController(TwoDController):
             raise ValueError("RoI is not a list of four elements")
         if any(not isinstance(v, int) for v in value):
             raise ValueError("RoI is not a list of integers")
-        if value[1] <= value[0]:
-            raise ValueError("RoI[1] is lower or equal than RoI[0]")
-        if value[3] <= value[2]:
-            raise ValueError("RoI[3] is lower or equal than RoI[2]")
+        if value != [0, 0, 0, 0]:
+            if value[1] <= value[0]:
+                raise ValueError("RoI[1] is lower or equal than RoI[0]")
+            if value[3] <= value[2]:
+                raise ValueError("RoI[3] is lower or equal than RoI[2]")
         x_dim = self.BufferSize[0]
         if value[0] > (x_dim - 1):
             raise ValueError(

--- a/src/sardana/pool/poolcontrollers/DummyTwoDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyTwoDController.py
@@ -107,6 +107,7 @@ class Channel:
         self.saving_enabled = False
         self.value_ref_pattern = "h5file:///tmp/dummy2d_default_{index}.h5"
         self.value_ref_enabled = False
+        self.roi = [0, 0, 0, 0]
 
 
 class BaseValue(object):
@@ -164,7 +165,16 @@ class BasicDummyTwoDController(TwoDController):
             FSet: 'setAmplitude',
             Description: ("Amplitude. Maybe a number or a tango attribute "
                           "(must start with tango://)"),
-            DefaultValue: '1.0'}
+            DefaultValue: '1.0'
+        },
+        'RoI': {
+            Type: (int,),
+            FGet: 'getRoI',
+            FSet: 'setRoI',
+            Description: ("Region of Interest of image "
+                          "(begin_x, end_x, begin_y, end_y)"),
+            DefaultValue: [0, 0, 0, 0]
+        }
     }
 
     def __init__(self, inst, props, *args, **kwargs):
@@ -284,6 +294,9 @@ class BasicDummyTwoDController(TwoDController):
         y_size = self.BufferSize[1]
         amplitude = axis * self.integ_time * channel.amplitude.get()
         img = generate_img(x_size, y_size, amplitude)
+        roi = channel.roi
+        if roi != [0, 0, 0, 0]:
+            img = img[roi[0]:roi[1], roi[2]:roi[3]]
         if self._synchronization == AcqSynch.SoftwareTrigger:
             channel.value = img
             channel.acq_idx += 1
@@ -367,6 +380,44 @@ class BasicDummyTwoDController(TwoDController):
         if value.startswith("tango://"):
             klass = TangoValue
         channel.amplitude = klass(value)
+
+    def getRoI(self, axis):
+        idx = axis - 1
+        channel = self.channels[idx]
+        return channel.roi
+
+    def setRoI(self, axis, value):
+        idx = axis - 1
+        channel = self.channels[idx]
+        try:
+            value = value.tolist()
+        except AttributeError:
+            pass
+        if len(value) != 4:
+            raise ValueError("RoI is not a list of four elements")
+        if any(not isinstance(v, int) for v in value):
+            raise ValueError("RoI is not a list of integers")
+        if value[1] <= value[0]:
+            raise ValueError("RoI[1] is lower or equal than RoI[0]")
+        if value[3] <= value[2]:
+            raise ValueError("RoI[3] is lower or equal than RoI[2]")
+        x_dim = self.BufferSize[0]
+        if value[0] > (x_dim - 1):
+            raise ValueError(
+                "RoI[0] exceeds detector X dimension - 1 ({})".format(
+                    x_dim - 1))
+        if value[1] > x_dim:
+            raise ValueError(
+                "RoI[1] exceeds detector X dimension ({})".format(x_dim))
+        y_dim = self.BufferSize[1]
+        if value[2] > (y_dim - 1):
+            raise ValueError(
+                "RoI[2] exceeds detector Y dimension - 1 ({})".format(
+                    y_dim - 1))
+        if value[3] > y_dim:
+            raise ValueError(
+                "RoI[3] exceeds detector Y dimension ({})".format(y_dim))
+        channel.roi = value
 
     def GetCtrlPar(self, par):
         if par == "synchronization":
@@ -488,6 +539,9 @@ class DummyTwoDController(BasicDummyTwoDController, Referable):
         y_size = self.BufferSize[1]
         amplitude = axis * self.integ_time * channel.amplitude.get()
         img = generate_img(x_size, y_size, amplitude)
+        roi = channel.roi
+        if roi != [0, 0, 0, 0]:
+            img = img[roi[0]:roi[1], roi[2]:roi[3]]
         if self._synchronization == AcqSynch.SoftwareTrigger:
             channel.value = img
             if channel.value_ref_enabled:

--- a/src/sardana/pool/poolcontrollers/DummyTwoDController.py
+++ b/src/sardana/pool/poolcontrollers/DummyTwoDController.py
@@ -430,6 +430,15 @@ class BasicDummyTwoDController(TwoDController):
         if par == "synchronization":
             self._synchronization = value
 
+    def GetAxisPar(self, axis, par):
+        idx = axis - 1
+        channel = self.channels[idx]
+        if par == "shape":
+            roi = channel.roi
+            if roi == [0, 0, 0, 0]:
+                return self.BufferSize
+            return [roi[1] - roi[0], roi[3] - roi[2]]
+
     def getSynchronizer(self):
         if self._synchronizer is None:
             return "None"

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -953,7 +953,7 @@ class MeasurementConfiguration(object):
         channel_data['normalization'] = channel_data.get('normalization',
                                                          Normalization.No)
         # TODO: think of filling other keys: data_type, data_units, nexus_path
-        # shape here instead of feeling them on the Taurus extension level
+        #  here instead of feeling them on the Taurus extension level
 
         if ctype != ElementType.External:
             ctrl_name = channel.controller.full_name

--- a/src/sardana/tango/pool/PoolDevice.py
+++ b/src/sardana/tango/pool/PoolDevice.py
@@ -902,7 +902,7 @@ class PoolExpChannelDevice(PoolElementDevice):
     def initialize_dynamic_attributes(self):
         attrs = PoolElementDevice.initialize_dynamic_attributes(self)
 
-        non_detect_evts = "integrationtime",
+        non_detect_evts = "integrationtime", "shape"
 
         for attr_name in non_detect_evts:
             if attr_name in attrs:
@@ -941,6 +941,13 @@ class PoolExpChannelDevice(PoolElementDevice):
         :type attr: :class:`~PyTango.Attribute`"""
         self.element.integration_time = attr.get_write_value()
 
+    def read_Shape(self, attr):
+        """Reads the shape.
+
+        :param attr: tango attribute
+        :type attr: :class:`~PyTango.Attribute`"""
+        attr.set_value(self.element.shape)
+
 
 class PoolExpChannelDeviceClass(PoolElementDeviceClass):
 
@@ -955,7 +962,14 @@ class PoolExpChannelDeviceClass(PoolElementDeviceClass):
     attr_list.update(PoolElementDeviceClass.attr_list)
 
     standard_attr_list = {
-        'ValueBuffer': [[DevEncoded, SCALAR, READ]]
+        'ValueBuffer': [[DevEncoded, SCALAR, READ]],
+        'Shape': [[DevLong64, SPECTRUM, READ, 2],
+                  {'label': "Shape (X,Y)",
+                   'description': "Shape of the value. It is an array with \n"
+                                  "at most 2 elements: X and Y dimensions. \n"
+                                  "0-element array - scalar\n"
+                                  "1-element array (X) - spectrum\n"
+                                  "2-element array (X, Y) - image"}],
     }
     standard_attr_list.update(PoolElementDeviceClass.standard_attr_list)
 

--- a/src/sardana/tango/pool/PoolDevice.py
+++ b/src/sardana/tango/pool/PoolDevice.py
@@ -946,7 +946,7 @@ class PoolExpChannelDevice(PoolElementDevice):
 
         :param attr: tango attribute
         :type attr: :class:`~PyTango.Attribute`"""
-        attr.set_value(self.element.shape)
+        attr.set_value(self.element.get_shape(cache=False))
 
 
 class PoolExpChannelDeviceClass(PoolElementDeviceClass):

--- a/src/sardana/tango/pool/PseudoCounter.py
+++ b/src/sardana/tango/pool/PseudoCounter.py
@@ -152,6 +152,8 @@ class PseudoCounter(PoolExpChannelDevice):
                 else:
                     value = event_value.value
                 timestamp = event_value.timestamp
+            else:
+                value = event_value
 
         self.set_attribute(attr, value=value, w_value=w_value,
                            timestamp=timestamp, quality=quality,

--- a/src/sardana/taurus/core/tango/sardana/sardana.py
+++ b/src/sardana/taurus/core/tango/sardana/sardana.py
@@ -56,7 +56,7 @@ ChannelView = Enumeration("ChannelView",
                            "PlotAxes", "Timer", "Monitor", "Synchronization",
                            "ValueRefPattern", "ValueRefEnabled",
                            "Conditioning", "Normalization", "NXPath",
-                           "Shape", "DataType", "Unknown", "Synchronizer"))
+                           "DataType", "Unknown", "Synchronizer"))
 
 PlotType = Enumeration("PlotType", ("No", "Spectrum", "Image"))
 


### PR DESCRIPTION
This PR changes the experimental channel's shape: from the measurement group configuration parameter to the read only controller's axis parameter - see #1296. The main benefit of this is that it is not necessary to modify the measurement group configuration everytime the shape changes e.g. RoI or binning change. The drawbacks is that the shape is consulted on every scan start (for external channels one extra read may be necessary).

@dschick, I have published it even if it is still WIP so you could comment if it goes in the right direction. It should be pretty operable - the scan already takes into account the shape reported by the controller and ignores the shape from the measurement group configuration. If you already go for testing it please follow the example of dummies from e01ce34.

Roadmap:
- [x] remove the shape from the measurement group configuration (server side and expconf)
- [ ] verify if the backwards compatibily asked by @teresanunez in https://github.com/sardana-org/sardana/issues/1296#issuecomment-596383364 works as expected
- [x] add documentation

