### PR TITLE
Fix bug in string formatting

### DIFF
--- a/src/sardana/pool/poolpseudomotor.py
+++ b/src/sardana/pool/poolpseudomotor.py
@@ -135,7 +135,7 @@ class Position(SardanaAttribute):
                     # because of a cold start
                     pos_attr.update(propagate=0)
                 if pos_attr.in_error():
-                    raise PoolException("Cannot get '%' position" % pos_attr.obj.name,
+                    raise PoolException("Cannot get '%s' position" % pos_attr.obj.name,
                                         exc_info=pos_attr.exc_info)
                 value = pos_attr.value
             ret.append(value)
@@ -149,7 +149,7 @@ class Position(SardanaAttribute):
             if not pos_attr.has_value():
                 pos_attr.update(propagate=0)
             if pos_attr.in_error():
-                raise PoolException("Cannot get '%' position" % pos_attr.obj.name,
+                raise PoolException("Cannot get '%s' position" % pos_attr.obj.name,
                                     exc_info=pos_attr.exc_info)
             ret.append(pos_attr.value)
         return ret


### PR DESCRIPTION
Fix ValueError (unsupported format character ''') by properly formatting string.

For example:

```
In [1]: "foo '%'" % "bar"
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-1-8b2d6384ce5e> in <module>()
----> 1 "foo '%'" % "bar"

ValueError: unsupported format character ''' (0x27) at index 6
```

vs.

```
In [2]: "foo '%s'" % "bar"
Out[2]: "foo 'bar'"
```

This is a trivial PR. I will auto-merge.