### PR TITLE
Complement and fix docs on setting ORBendPoint

### DIFF
--- a/doc/source/users/configuration/server.rst
+++ b/doc/source/users/configuration/server.rst
@@ -7,25 +7,30 @@ Sardana system can
 :ref:`run as one or many Tango device servers<sardana-getting-started-running-server>`.
 Tango device servers listens on a TCP port for the CORBA requests. Usually
 it is fine to use the randomly assigned port (default behavior) but sometimes
-it may be necessary to use a fixed port number. For example, when the server
-needs to be accessed from another isolated network and we want to open
-connections only for the given ports.
+it may be necessary to use a fixed port number or even IP address.
+For example, when the server needs to be accessed from another isolated
+network and we want to open connections only for the given ports or IPs.
 
-There are three possibilities to assign the port explicitly (the order
-indicates the precedence):
+There are three possibilities to assign the IP and/or port in format of the
+ORBendPoint explicitly (the order indicates the precedence):
+
+.. note::
+    The ORBendPoint is in the following format: ``giop:tcp:<IP>:<port>``
+    and both IP and port are optional, so you could only fix the IP,
+    only fix the port, fix both of them or none of them.
 
 - using OS environment variable ``ORBendPoint`` e.g.
 
 .. code-block:: bash
 
-    $ export ORBendPoint=28366
-    $ Pool demo1 -ORBendPoint 28366
+    $ export ORBendPoint=giop:tcp:192.168.0.100:28366
+    $ Pool demo1
 
 - using Tango device server command line argument ``-ORBendPoint``
 
 .. code-block:: bash
 
-    $ Pool demo1 -ORBendPoint 28366
+    $ Pool demo1 -ORBendPoint giop:tcp:192.168.0.100:28366
 
 - using Tango DB free property with object name: ``ORBendPoint`` and property
   name: ``<server_name>/<instance_name>``)
@@ -34,7 +39,7 @@ indicates the precedence):
 
     import tango
     db = tango.Database()
-    db.put_property("ORBendPoint", {"Pool/demo1": 28366})
+    db.put_property("ORBendPoint", {"Pool/demo1": "giop:tcp:192.168.0.100:28366"})
 
 .. note::
 


### PR DESCRIPTION
* document the possibility to fix IP address
* fix examples to use "giop:tcp:" prefix

This is a trivial PR to add some additional infos to the docs hence I will auto-merge.