### PR TITLE
Make write of integration time more robust

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -2460,8 +2460,8 @@ class MeasurementGroup(PoolElement):
     def putIntegrationTime(self, ctime):
         if self._last_integ_time == ctime:
             return
-        self._last_integ_time = ctime
         self.getIntegrationTimeObj().write(ctime)
+        self._last_integ_time = ctime
 
     def getAcquisitionModeObj(self):
         return self._getAttrEG('AcquisitionMode')


### PR DESCRIPTION
Write of the integration time may fail e.g. problems with reading latency_time of the controller, and we fill the cache anyway. This causes problems with not initialized synchronization description.

Fill integration time cache only if the write worked.