### PR TITLE
Set stop flags for each element in multiple elements movement

### DIFF
--- a/src/sardana/pool/poolbasegroup.py
+++ b/src/sardana/pool/poolbasegroup.py
@@ -358,6 +358,8 @@ class PoolBaseGroup(PoolContainer):
             self.debug("Stopping %s %s", ctrl.name,
                        [e.name for e in elements])
             try:
+                for el in elements:
+                    el.stop()
                 error_elements = ctrl.stop_elements(elements=elements)
                 if len(error_elements) > 0:
                     element_names = [elem.name for elem in error_elements]


### PR DESCRIPTION
Related to #1421 

Sets `stop` flag for each element in multiple elements movement. It results in correct (`interrupted`) state of the moveables and does not allow to apply backlash.

