### PR TITLE
Fix #1471: add pre-move & post-move hook places to mv-macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ This file follows the formats and conventions from [keepachangelog.com]
 * `sequencer` loading of plain text sequences in spock syntax with macro functions (#1422)
 * Recorders tests helpers (#1439)
 * Disable flake8 job in travis CI (#1455)
-* `createMacro()` and `prepareMacro()` docstring (#1460, #1444) 
+* `createMacro()` and `prepareMacro()` docstring (#1460, #1444)
+* Make write of MeasurementGroup (Taurus extension) integration time more robust (#1473)
 * String formatting when rising exceptions in pseudomotors (#1469)
 
 ## [3.0.3] 2020-09-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This file follows the formats and conventions from [keepachangelog.com]
   e.g. pseudo counter's value, in controllers (#1440, #1446)
 * Problems with macro id's when `sequencer` executes from _plain text_ files (#1215, #1216)
 * `sequencer` loading of plain text sequences in spock syntax with macro functions (#1422)
+* Allow running Spock without Qt bindings (#1462, #1463)
 * Recorders tests helpers (#1439)
 * Disable flake8 job in travis CI (#1455)
 * `createMacro()` and `prepareMacro()` docstring (#1460, #1444)

--- a/src/sardana/macroserver/macros/hkl.py
+++ b/src/sardana/macroserver/macros/hkl.py
@@ -48,7 +48,7 @@ import re
 import numpy as np
 
 from sardana.sardanautils import py2_round
-from sardana.macroserver.macro import Macro, iMacro, Type
+from sardana.macroserver.macro import Hookable, Macro, iMacro, Type
 from sardana.macroserver.macros.scan import aNscan
 from sardana.macroserver.msexception import UnknownEnv
 
@@ -218,6 +218,9 @@ class br(Macro, _diffrac, Hookable):
 
     def prepare(self, H, K, L, AnglesIndex, FlagNotBlocking, FlagPrinting):
         _diffrac.prepare(self)
+        self.motors = []
+        for name in self.angle_names:
+            self.motors.append(self.getMotor(name))
 
     def run(self, H, K, L, AnglesIndex, FlagNotBlocking, FlagPrinting):
         h_idx = 0
@@ -286,6 +289,9 @@ class ubr(Macro, _diffrac, Hookable):
 
     def prepare(self, hh, kk, ll, AnglesIndex):
         _diffrac.prepare(self)
+        self.motors = []
+        for name in self.angle_names:
+            self.motors.append(self.getMotor(name))
 
     def run(self, hh, kk, ll, AnglesIndex):
         if ll != "Not set":

--- a/src/sardana/macroserver/macros/hkl.py
+++ b/src/sardana/macroserver/macros/hkl.py
@@ -120,10 +120,9 @@ class _diffrac:
             self.type = v
 
         self.angle_device_names = {}
-        i = 0
-        for motor in motor_list:
+
+        for i, motor in enumerate(motor_list):
             self.angle_device_names[self.angle_names[i]] = motor.split(' ')[0]
-            i = i + 1
 
     # TODO: it should not be necessary to implement on_stop methods in the
     # macros in order to stop the moveables. Macro API should provide this kind
@@ -219,8 +218,8 @@ class br(Macro, _diffrac, Hookable):
     def prepare(self, H, K, L, AnglesIndex, FlagNotBlocking, FlagPrinting):
         _diffrac.prepare(self)
         self.motors = []
-        for name in self.angle_names:
-            self.motors.append(self.getMotor(name))
+        for motor_name in self.angle_device_names.values():
+            self.motors.append(self.getMotor(motor_name))     
 
     def run(self, H, K, L, AnglesIndex, FlagNotBlocking, FlagPrinting):
         h_idx = 0
@@ -290,8 +289,8 @@ class ubr(Macro, _diffrac, Hookable):
     def prepare(self, hh, kk, ll, AnglesIndex):
         _diffrac.prepare(self)
         self.motors = []
-        for name in self.angle_names:
-            self.motors.append(self.getMotor(name))
+        for motor_name in self.angle_device_names.values():
+            self.motors.append(self.getMotor(motor_name))            
 
     def run(self, hh, kk, ll, AnglesIndex):
         if ll != "Not set":

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -477,8 +477,8 @@ class mv(Macro, Hookable):
                                True)
 
         if enable_hooks:
-            for preAcqHook in self.getHooks('pre-move'):
-                preAcqHook()
+            for preMoveHook in self.getHooks('pre-move'):
+                preMoveHook()
 
         self.motors, positions = [], []
         for m, p in motor_pos_list:
@@ -495,8 +495,8 @@ class mv(Macro, Hookable):
             self.info("\n".join(msg))
 
         if enable_hooks:
-            for postAcqHook in self.getHooks('post-move'):
-                postAcqHook()
+            for postMoveHook in self.getHooks('post-move'):
+                postMoveHook()
 
 
 class mstate(Macro):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -576,9 +576,10 @@ class mvr(Macro, Hookable):
     ]
 
     def run(self, motor_disp_list):
-        motor_pos_list = []
+        self.motors, motor_pos_list = [], []
         for motor, disp in motor_disp_list:
             pos = motor.getPosition(force=True)
+            self.motors.append(motor)
             if pos is None:
                 self.error("Cannot get %s position" % motor.getName())
                 return
@@ -597,9 +598,10 @@ class umvr(Macro, Hookable):
     param_def = mvr.param_def
 
     def run(self, motor_disp_list):
-        motor_pos_list = []
+        self.motors, motor_pos_list = [], []
         for motor, disp in motor_disp_list:
             pos = motor.getPosition(force=True)
+            self.motors.append(motor)
             if pos is None:
                 self.error("Cannot get %s position" % motor.getName())
                 return

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -459,9 +459,10 @@ class pwm(Macro):
         self.execMacro('wm', motor_list, **Table.PrettyOpts)
 
 
-class mv(Macro):
+class mv(Macro, Hookable):
     """Move motor(s) to the specified position(s)"""
 
+    hints = {'allowsHooks': ('pre-move', 'post-move')}
     param_def = [
         ['motor_pos_list',
          [['motor', Type.Moveable, None, 'Motor to move'],
@@ -470,6 +471,9 @@ class mv(Macro):
     ]
 
     def run(self, motor_pos_list):
+        for preAcqHook in self.getHooks('pre-move'):
+            preAcqHook()
+
         motors, positions = [], []
         for m, p in motor_pos_list:
             motors.append(m)
@@ -483,6 +487,9 @@ class mv(Macro):
             for motor in motors:
                 msg.append(motor.information())
             self.info("\n".join(msg))
+
+        for postAcqHook in self.getHooks('post-move'):
+            postAcqHook()
 
 
 class mstate(Macro):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -45,6 +45,7 @@ from sardana.macroserver.macro import Macro, macro, Type, ViewOption, \
 from sardana.macroserver.msexception import StopException, UnknownEnv
 from sardana.macroserver.scan.scandata import Record
 from sardana.macroserver.macro import Optional
+from sardana import sardanacustomsettings
 
 ##########################################################################
 #
@@ -470,9 +471,15 @@ class mv(Macro, Hookable):
          None, 'List of motor/position pairs'],
     ]
 
+    def prepare(self):
+        selsardanacustomsettings
+
     def run(self, motor_pos_list):
-        for preAcqHook in self.getHooks('pre-move'):
-            preAcqHook()
+        enable_hooks = getattr(sardanacustomsettings, 'PRE_POST_MOVE_HOOK_IN_MV')
+
+        if enable_hooks:
+            for preAcqHook in self.getHooks('pre-move'):
+                preAcqHook()
 
         motors, positions = [], []
         for m, p in motor_pos_list:
@@ -488,8 +495,9 @@ class mv(Macro, Hookable):
                 msg.append(motor.information())
             self.info("\n".join(msg))
 
-        for postAcqHook in self.getHooks('post-move'):
-            postAcqHook()
+        if enable_hooks:
+            for postAcqHook in self.getHooks('post-move'):
+                postAcqHook()
 
 
 class mstate(Macro):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -471,9 +471,6 @@ class mv(Macro, Hookable):
          None, 'List of motor/position pairs'],
     ]
 
-    def prepare(self):
-        selsardanacustomsettings
-
     def run(self, motor_pos_list):
         enable_hooks = getattr(sardanacustomsettings, 'PRE_POST_MOVE_HOOK_IN_MV')
 

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -473,7 +473,8 @@ class mv(Macro, Hookable):
 
     def run(self, motor_pos_list):
         enable_hooks = getattr(sardanacustomsettings,
-                               'PRE_POST_MOVE_HOOK_IN_MV')
+                               'PRE_POST_MOVE_HOOK_IN_MV',
+                               True)
 
         if enable_hooks:
             for preAcqHook in self.getHooks('pre-move'):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -472,6 +472,11 @@ class mv(Macro, Hookable):
     ]
 
     def run(self, motor_pos_list):
+        self.motors, positions = [], []
+        for m, p in motor_pos_list:
+            self.motors.append(m)
+            positions.append(p)
+
         enable_hooks = getattr(sardanacustomsettings,
                                'PRE_POST_MOVE_HOOK_IN_MV',
                                True)
@@ -480,11 +485,9 @@ class mv(Macro, Hookable):
             for preMoveHook in self.getHooks('pre-move'):
                 preMoveHook()
 
-        self.motors, positions = [], []
-        for m, p in motor_pos_list:
-            self.motors.append(m)
-            positions.append(p)
+        for m, p in zip(self.motors, positions):
             self.debug("Starting %s movement to %s", m.getName(), p)
+
         motion = self.getMotion(self.motors)
         state, pos = motion.move(positions)
         if state != DevState.ON:

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -479,17 +479,17 @@ class mv(Macro, Hookable):
             for preAcqHook in self.getHooks('pre-move'):
                 preAcqHook()
 
-        motors, positions = [], []
+        self.motors, positions = [], []
         for m, p in motor_pos_list:
-            motors.append(m)
+            self.motors.append(m)
             positions.append(p)
             self.debug("Starting %s movement to %s", m.getName(), p)
-        motion = self.getMotion(motors)
+        motion = self.getMotion(self.motors)
         state, pos = motion.move(positions)
         if state != DevState.ON:
             self.warning("Motion ended in %s", state.name)
             msg = []
-            for motor in motors:
+            for motor in self.motors:
                 msg.append(motor.information())
             self.info("\n".join(msg))
 
@@ -521,6 +521,7 @@ class umv(Macro):
             pos, posObj = motor.getPosition(force=True), motor.getPositionObj()
             self.all_pos.append([pos])
             posObj.subscribeEvent(self.positionChanged, motor)
+        self.motors = self.all_names
 
     def run(self, motor_pos_list):
         self.print_pos = True

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -520,13 +520,14 @@ class umv(Macro, Hookable):
     def prepare(self, motor_pos_list, **opts):
         self.all_names = []
         self.all_pos = []
+        self.motors = []
         self.print_pos = False
         for motor, pos in motor_pos_list:
             self.all_names.append([motor.getName()])
+            self.motors.append(motor)
             pos, posObj = motor.getPosition(force=True), motor.getPositionObj()
             self.all_pos.append([pos])
             posObj.subscribeEvent(self.positionChanged, motor)
-        self.motors = self.all_names
 
     def run(self, motor_pos_list):
         self.print_pos = True

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -511,9 +511,10 @@ class mstate(Macro):
         self.info("Motor %s" % str(motor.stateObj.read().rvalue))
 
 
-class umv(Macro):
+class umv(Macro, Hookable):
     """Move motor(s) to the specified position(s) and update"""
 
+    hints = {'allowsHooks': ('pre-move', 'post-move')}
     param_def = mv.param_def
 
     def prepare(self, motor_pos_list, **opts):
@@ -530,7 +531,9 @@ class umv(Macro):
     def run(self, motor_pos_list):
         self.print_pos = True
         try:
-            self.execMacro('mv', motor_pos_list)
+            mv, _ = self.createMacro('mv', motor_pos_list)
+            mv.appendHook(self.hooks)
+            self.runMacro(mv)
         finally:
             self.finish()
 

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -472,7 +472,8 @@ class mv(Macro, Hookable):
     ]
 
     def run(self, motor_pos_list):
-        enable_hooks = getattr(sardanacustomsettings, 'PRE_POST_MOVE_HOOK_IN_MV')
+        enable_hooks = getattr(sardanacustomsettings,
+                               'PRE_POST_MOVE_HOOK_IN_MV')
 
         if enable_hooks:
             for preAcqHook in self.getHooks('pre-move'):

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -100,3 +100,12 @@ MS_ENV_SHELVE_BACKEND = None
 #: - 0 - history will not be filled
 #: - <int> - max number of macros stored in the history
 MACROEXECUTOR_MAX_HISTORY = 100
+
+#: pre-move and post-move hooks applied in simple mv-based macros 
+#: Available options:
+#:
+#: - False (or no setting) - macros which are hooked to the pre-move and post-move
+#:   hook places are not called in simple mv-based macros but only in scan-based macros
+#: - True - macros which are hooked to the pre-move and post-move
+#:   hook places are called before and/or after any move a motor
+PRE_POST_MOVE_HOOK_IN_MV = 100

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -104,9 +104,9 @@ MACROEXECUTOR_MAX_HISTORY = 100
 #: pre-move and post-move hooks applied in simple mv-based macros
 #: Available options:
 #:
-#: - False (or no setting) - macros which are hooked to the pre-move and
-#:   post-move hook places are not called in simple mv-based macros but
-#:   only in scan-based macros
-#: - True - macros which are hooked to the pre-move and post-move
-#:   hook places are called before and/or after any move a motor
+#: - True (or no setting) - macros which are hooked to the pre-move and
+#:   post-move hook places are called before and/or after any move of a motor
+#: - False - macros which are hooked to the pre-move and post-move hook
+#:   places are not called in simple mv-based macros but only in scan-based
+#:   macros
 PRE_POST_MOVE_HOOK_IN_MV = True

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -108,4 +108,4 @@ MACROEXECUTOR_MAX_HISTORY = 100
 #:   hook places are not called in simple mv-based macros but only in scan-based macros
 #: - True - macros which are hooked to the pre-move and post-move
 #:   hook places are called before and/or after any move a motor
-PRE_POST_MOVE_HOOK_IN_MV = 100
+PRE_POST_MOVE_HOOK_IN_MV = False

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -109,4 +109,4 @@ MACROEXECUTOR_MAX_HISTORY = 100
 #:   only in scan-based macros
 #: - True - macros which are hooked to the pre-move and post-move
 #:   hook places are called before and/or after any move a motor
-PRE_POST_MOVE_HOOK_IN_MV = False
+PRE_POST_MOVE_HOOK_IN_MV = True

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -92,7 +92,7 @@ VALUE_REF_BUFFER_CODEC = "pickle"
 #: - "dumb" - worst performance but directly available with Python 3.
 MS_ENV_SHELVE_BACKEND = None
 
-#: macroexecutor maximum number of macros stored in the history. 
+#: macroexecutor maximum number of macros stored in the history.
 #: Available options:
 #:
 #: - None (or no setting) - unlimited history (may slow down the GUI operation
@@ -101,11 +101,12 @@ MS_ENV_SHELVE_BACKEND = None
 #: - <int> - max number of macros stored in the history
 MACROEXECUTOR_MAX_HISTORY = 100
 
-#: pre-move and post-move hooks applied in simple mv-based macros 
+#: pre-move and post-move hooks applied in simple mv-based macros
 #: Available options:
 #:
-#: - False (or no setting) - macros which are hooked to the pre-move and post-move
-#:   hook places are not called in simple mv-based macros but only in scan-based macros
+#: - False (or no setting) - macros which are hooked to the pre-move and
+#:   post-move hook places are not called in simple mv-based macros but
+#:   only in scan-based macros
 #: - True - macros which are hooked to the pre-move and post-move
 #:   hook places are called before and/or after any move a motor
 PRE_POST_MOVE_HOOK_IN_MV = False


### PR DESCRIPTION
This PR adds the `pre-move` & `post-move` hook places to `mv` macro.
A new `sardanacustomsetting ` parameter named `PRE_POST_MOVE_HOOK_IN_MV` is introduced to disable the `pre-move` and `post-move` hook places in the `mv` macro by default.