### PR TITLE
Fix example in docstring of QtSpockWidget

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
@@ -181,6 +181,8 @@ class QtSpockWidget(RichJupyterWidget, TaurusBaseWidget):
         self._door_name = None
         self._door_alias = None
 
+        self.append_stream("Waiting for kernel to start")
+
         self.kernel_manager = SpockKernelManager(kernel_name=kernel)
         self.kernel_manager.kernel_about_to_launch.connect(
             self._handle_kernel_lauched)

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
@@ -145,7 +145,7 @@ class QtSpockWidget(RichJupyterWidget, TaurusBaseWidget):
 
         from taurus.external.qt import Qt
         from sardana.taurus.qt.qtgui.extra_sardana.qtspock import QtSpockWidget
-        app = Qt.QApplication([])
+        app = Qt.QApplication(["qtspock"])
         widget = QtSpockWidget(use_model_from_profile=True)
         widget.show()
         widget.start_kernel()

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
@@ -146,8 +146,9 @@ class QtSpockWidget(RichJupyterWidget, TaurusBaseWidget):
         from taurus.external.qt import Qt
         from sardana.taurus.qt.qtgui.extra_sardana.qtspock import QtSpockWidget
         app = Qt.QApplication([])
-        widget = QtSpockWidget()
+        widget = QtSpockWidget(use_model_from_profile=True)
         widget.show()
+        widget.start_kernel()
         app.aboutToQuit.connect(widget.shutdown_kernel)
         app.exec_()
     """


### PR DESCRIPTION
I forgot to update the example to reflect the changes in ba692bc9c1c2273da6c2d56b08bb2c9890f870d9.

It would be nice to have a better error message when no kernel is started. Currently, only `...` is shown after pressing enter in a widget without a running kernel.