### PR TITLE
Fix NXscanH5_FileRecorder.addCustomData() with strings

### DIFF
--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -578,7 +578,7 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
             if numpy.isscalar(value):
                 dtype = numpy.dtype(type(value)).name
                 if numpy.issubdtype(dtype, str):
-                    dtype = 'char'
+                    dtype = NXscanH5_FileRecorder.str_dt
                 if dtype == 'bool':
                     value, dtype = int(value), 'int8'
             else:

--- a/src/sardana/macroserver/recorders/test/test_h5storage.py
+++ b/src/sardana/macroserver/recorders/test/test_h5storage.py
@@ -193,3 +193,17 @@ class TestNXscanH5_FileRecorder(TestCase):
             os.remove(self.path)
         except OSError:
             pass
+
+
+@pytest.fixture
+def recorder(tmpdir):
+    path = str(tmpdir / "file.h5")
+    return NXscanH5_FileRecorder(filename=path)
+
+
+@pytest.mark.parametrize("custom_data", ["str_custom_data", 8, True])
+def test_addCustomData(recorder, custom_data):
+    name = "custom_data_name"
+    recorder.addCustomData(custom_data, name)
+    with h5py.File(recorder.filename) as fd:
+        assert fd["entry"]["custom_data"][name].value == custom_data

--- a/src/sardana/macroserver/recorders/test/test_h5storage.py
+++ b/src/sardana/macroserver/recorders/test/test_h5storage.py
@@ -31,6 +31,7 @@ from datetime import datetime
 
 import h5py
 import numpy
+import pytest
 from unittest import TestCase
 
 from sardana.macroserver.scan import ColumnDesc


### PR DESCRIPTION
https://github.com/sardana-org/sardana/issues/771#issuecomment-734743646 reports a bug with saving string _custom data_. This PR fixes it. @dschick, the workaround from https://github.com/sardana-org/sardana/issues/771#issuecomment-736360038 is not necessary anymore. @sardana-org/integrators could you please take a look on this one?

Note that in h5py 3.x they changed some recommendations for storing string data, but this PR still uses the recommendations from h5py 2.x that we used in the past.
