### PR TITLE
Add LICENSE to python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ exclude .ropeproject
 exclude build_*
 
 include CHANGELOG.md
+include LICENSE


### PR DESCRIPTION
The LICENSE was missing from the Python package