### PR TITLE
Use equality instead of identity checks for numbers and strings

### DIFF
--- a/src/sardana/macroserver/macros/lists.py
+++ b/src/sardana/macroserver/macros/lists.py
@@ -143,7 +143,7 @@ class _lsobj(_ls):
     def run(self, filter):
         objs = self.objs(filter)
         nb = len(objs)
-        if nb is 0:
+        if nb == 0:
             if self.subtype is Macro.All:
                 if isinstance(self.type, str):
                     t = self.type.lower()

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -1206,7 +1206,7 @@ def prepare_logging(options, args, tango_args, start_time=None,
 
 def prepare_rconsole(options, args, tango_args):
     port = options.rconsole_port
-    if port is None or port is 0:
+    if port is None or port == 0:
         return
     taurus.debug("Setting up rconsole on port %d...", port)
     try:

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -665,7 +665,7 @@ class BaseDoor(MacroServerDevice):
         input_type = input_data['type']
         if input_type == 'input':
             result = self._input_handler.input(input_data)
-            if result['input'] is '' and 'default_value' in input_data:
+            if result['input'] == '' and 'default_value' in input_data:
                 result['input'] = input_data['default_value']
             result = CodecFactory().encode('json', ('', result))[1]
             self.write_attribute('Input', result)


### PR DESCRIPTION
Starting with Python 3.8 these are reported as warnings:

The compiler now produces a SyntaxWarning when identity checks (is and is not)
are used with certain types of literals (e.g. strings, numbers).
These can often work by accident in CPython, but are not guaranteed by the language spec.
The warning advises users to use equality tests (== and !=) instead.

This is a trivial PR I will auto-merge when CI shows green light.