### PR TITLE
Document how to write 1D and 2D controllers

### DIFF
--- a/doc/source/devel/api/sardana/pool/controller.rst
+++ b/doc/source/devel/api/sardana/pool/controller.rst
@@ -25,6 +25,7 @@
     :columns: 3
 
     * :class:`Readable`
+    * :class:`Referable`
     * :class:`Startable`
     * :class:`Stopable`
     * :class:`Loadable`
@@ -55,6 +56,17 @@ Readable interface
     :parts: 1
     
 .. autoclass:: Readable
+    :show-inheritance:
+    :members:
+    :undoc-members:
+
+Referable interface
+-------------------
+
+.. inheritance-diagram:: Referable
+    :parts: 1
+
+.. autoclass:: Referable
     :show-inheritance:
     :members:
     :undoc-members:

--- a/doc/source/devel/howto_controllers/howto_1dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_1dcontroller.rst
@@ -9,8 +9,96 @@ How to write a 1D controller
 The basics
 ----------
 
-.. todo:: document 1D controller howto
-        
+This chapter provides the necessary information to write a one dimensional (1D)
+experimental channel controller in Sardana.
+
+.. contents:: Table of contents
+    :depth: 3
+    :backlinks: entry
+
+.. _sardana-1dcontroller-general-guide:
+
+General guide
+-------------
+
+:ref:`1D experimental channels <sardana-1d-overview>`
+together with :ref:`2D experimental channels <sardana-2d-overview>`
+and :ref:`counter/timers <sardana-countertimer-overview>`
+belong to the same family of *timerable* experimental channels.
+
+To write a 1D controller class you can follow
+the :ref:`sardana-countertimercontroller` guide keeping in mind
+differences explained in continuation.
+
+.. _sardana-1dcontroller-differences-countertimer:
+
+Differences with counter/timer controller
+-----------------------------------------
+
+Class definition
+~~~~~~~~~~~~~~~~
+
+:ref:`The basics of the counter/timer controller <sardana-countertimercontroller-howto-basics>`
+chapter explains how to define the counter/timer controller class.
+Here you need to simply inherit from the
+`~sardana.pool.controller.OneDController` class:
+
+.. code-block:: python
+    :emphasize-lines: 3
+
+    from sardana.pool.controller import OneDController
+
+    class SpringfieldOneDController(OneDController):
+
+       def __init__(self, inst, props, *args, **kwargs):
+            super().__init__(inst, props, *args, **kwargs)
+
+.. _sardana-1dcontroller-getvalue:
+
+Get 1D value
+~~~~~~~~~~~~
+
+:ref:`Get counter value <sardana-countertimercontroller-howto-value>` chapter
+explains how to read a counter/timer value
+using the :meth:`~sardana.pool.controller.Readable.ReadOne` method.
+Here you need to implement the same method but its return value
+must be a one-dimensional `numpy.array` (or eventually
+a `~sardana.sardanavalue.SardanaValue` object) containing the spectrum instead
+of a scalar value.
+
+.. _sardana-1dcontroller-getvalues:
+
+Get 1D values
+~~~~~~~~~~~~~
+
+:ref:`Get counter values <sardana-countertimercontroller-howto-external-synchronization-get-values>`
+chapter explains how to read counter/timer values
+using the :meth:`~sardana.pool.controller.Readable.ReadOne` method while
+acquiring with external (hardware) synchronization.
+Here you need to implement the same method but its return value
+must be a sequence with one-dimensional `numpy.array` objects (or eventually
+with :obj:`~sardana.sardanavalue.SardanaValue` objects) containing spectrums
+instead of scalar values.
+
+Advanced topics
+---------------
+
+.. _sardana-1dcontroller-valuereferencing:
+
+Working with value referencing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1D experimental channels may produce significant arrays of data at high
+frame rate. Reading this data and storing it using sardana
+is not always optimal. `SEP2`_ introduced data saving duality, optionally,
+leaving the data storage at the responsibility of the detector
+(or an intermediate software layer e.g. `LImA`_). In this case sardana
+just deals with the reference to the data.
+
+Please refer to :ref:`sardana-2dcontroller-valuereferencing` chapter from
+:ref:`sardana-2dcontroller-howto` in order to implement this feature for 1D
+controller.
+
 .. _ALBA: http://www.cells.es/
 .. _ANKA: http://http://ankaweb.fzk.de/
 .. _ELETTRA: http://http://www.elettra.trieste.it/
@@ -35,3 +123,5 @@ The basics
 .. _numpy: http://numpy.scipy.org/
 .. _SPEC: http://www.certif.com/
 .. _EPICS: http://www.aps.anl.gov/epics/
+.. _SEP2: http://www.sardana-controls.org/sep/?SEP2.md
+.. _LImA: https://lima1.readthedocs.io/en/latest/

--- a/doc/source/devel/howto_controllers/howto_2dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_2dcontroller.rst
@@ -1,16 +1,192 @@
 .. currentmodule:: sardana.pool.controller
 
-.. _sardana-2dcontroller-howto-basics:
+.. _sardana-2dcontroller-howto:
 
 ============================
 How to write a 2D controller
 ============================
 
-The basics
-----------
+This chapter provides the necessary information to write a two dimensional (2D)
+experimental channel controller in Sardana.
 
-.. todo:: document 2D controller howto
-        
+.. contents:: Table of contents
+    :depth: 3
+    :backlinks: entry
+
+.. _sardana-2dcontroller-general-guide:
+
+General guide
+-------------
+
+:ref:`2D experimental channels <sardana-2d-overview>`
+together with :ref:`1D experimental channels <sardana-1d-overview>`
+and :ref:`counter/timers <sardana-countertimer-overview>`
+belong to the same family of *timerable* experimental channels.
+
+To write a 2D controller class you can follow
+the :ref:`sardana-countertimercontroller` guide keeping in mind
+differences explained in continuation.
+
+.. _sardana-2dcontroller-differences-countertimer:
+
+Differences with counter/timer controller
+-----------------------------------------
+
+Class definition
+~~~~~~~~~~~~~~~~
+
+:ref:`The basics of the counter/timer controller <sardana-countertimercontroller-howto-basics>`
+chapter explains how to define the counter/timer controller class.
+Here you need to simply inherit from the
+`~sardana.pool.controller.TwoDController` class:
+
+.. code-block:: python
+    :emphasize-lines: 3
+
+    from sardana.pool.controller import TwoDController
+
+    class SpringfieldTwoDController(TwoDController):
+
+       def __init__(self, inst, props, *args, **kwargs):
+            super().__init__(inst, props, *args, **kwargs)
+
+.. _sardana-2dcontroller-getvalue:
+
+Get 2D value
+~~~~~~~~~~~~
+
+:ref:`Get counter value <sardana-countertimercontroller-howto-value>` chapter
+explains how to read a counter/timer value
+using the :meth:`~sardana.pool.controller.Readable.ReadOne` method.
+Here you need to implement the same method but its return value
+must be a two-dimensional `numpy.array` (or eventually
+a `~sardana.sardanavalue.SardanaValue` object) containing an image instead
+of a scalar value.
+
+.. _sardana-2dcontroller-getvalues:
+
+Get 2D values
+~~~~~~~~~~~~~
+
+:ref:`Get counter values <sardana-countertimercontroller-howto-external-synchronization-get-values>`
+chapter explains how to read counter/timer values
+using the :meth:`~sardana.pool.controller.Readable.ReadOne` method while
+acquiring with external (hardware) synchronization.
+Here you need to implement the same method but its return value
+must be a sequence with two-dimensional `numpy.array` objects (or eventually
+with :obj:`~sardana.sardanavalue.SardanaValue` objects) containing the images
+instead of a scalar values.
+
+Advanced topics
+---------------
+
+.. _sardana-2dcontroller-valuereferencing:
+
+Working with value referencing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+2D experimental channels may produce big arrays of data at high
+frame rate. Reading this data and storing it using sardana
+is not always optimal. `SEP2`_ introduced data saving duality, optionally,
+leaving the data storage at the responsibility of the detector
+(or an intermediate software layer e.g. `LImA`_). In this case sardana
+just deals with the reference to the data.
+
+In order to announce the referencing capability the 2D controller must
+additionally inherit from the `~sardana.pool.controller.Referable` class:
+
+.. code-block:: python
+    :emphasize-lines: 3
+
+    from sardana.pool.controller import TwoDController, Referable
+
+    class SpringfieldTwoDController(TwoDController, Referable):
+
+        def __init__(self, inst, props, *args, **kwargs):
+            super().__init__(inst, props, *args, **kwargs)
+
+.. _sardana-2dcontroller-getvaluereference:
+
+Get 2D value reference
+""""""""""""""""""""""
+
+To get the 2D value reference, sardana calls the
+:meth:`~sardana.pool.controller.Referable.RefOne` method. This method
+receives an axis as parameter and should return a URI (`str`)
+pointing to the value.
+
+Here is an example of the possible implementation of
+:meth:`~sardana.pool.controller.Referable.RefOne`:
+
+.. code-block:: python
+    :emphasize-lines: 3
+
+    class SpringfieldTwoDController(TwoDController):
+
+        def RefOne(self, axis):
+            value_ref = self.springfield.getValueRef(axis)
+            return value_ref
+
+.. _sardana-2dcontroller-getvaluesreferences:
+
+Get 2D values references
+""""""""""""""""""""""""
+
+:ref:`Get counter values <sardana-countertimercontroller-howto-external-synchronization-get-values>`
+chapter explains how to read counter/timer values
+using the :meth:`~sardana.pool.controller.Readable.ReadOne` method while
+acquiring with external (hardware) synchronization.
+Here you need to implement the :meth:`~sardana.pool.controller.Referable.RefOne`
+method and its return value must be a sequence with URIs (`str`)
+pointing to the values.
+
+.. _sardana-2dcontroller-configvaluereference:
+
+Configure 2D value reference
+""""""""""""""""""""""""""""
+
+Two axis parameters: ``value_ref_pattern`` (`str`)
+and ``value_ref_enabled`` (`bool`) are foreseen for configuring where to store
+the values and whether to use the value referencing. Here you need to implement
+the :meth:`~sardana.pool.controller.Controller.SetAxiPar` method.
+
+Here is an example of the possible implementation of
+:meth:`~sardana.pool.controller.Controller.SetAxisPar`:
+
+.. code-block:: python
+
+    class SpringfieldTwoDController(TwoDController):
+
+        def SetAxisPar(self, axis, par, value):
+            if par == "value_ref_pattern":
+                self.springfield.setValueRefPattern(axis, value)
+            elif par == "value_ref_enabled":
+                self.springfield.setValueRefEnabled(axis, value)
+
+.. hint::
+    Use `Python Format String Syntax <https://docs.python.org/3/library/string.html#format-string-syntax>`_
+    e.g. ``file:///tmp/sample1_{index:02d}`` to configure a dynamic value
+    referencing using the acquisition index or any other parameter
+    (acquisition index can be reset in the
+    :ref:`per measurement preparation <sardana-countertimercontroller-per-measurement-preparation>`.
+    phase)
+
+When value referencing is used
+""""""""""""""""""""""""""""""
+
+Sardana will :ref:`sardana-2dcontroller-getvaluereference` when:
+
+    - channel has referencing capability and it is enabled
+
+Sardana will :ref:`sardana-2dcontroller-getvalue` when any of these
+conditions applies:
+
+    - channel does not have referencing capability
+    - channel has referencing capability but it is disabled
+    - there is a pseudo counter based on this channel
+
+Hence, in some configurations, both methods may be used simultaneously.
+
 .. _ALBA: http://www.cells.es/
 .. _ANKA: http://http://ankaweb.fzk.de/
 .. _ELETTRA: http://http://www.elettra.trieste.it/
@@ -35,3 +211,5 @@ The basics
 .. _numpy: http://numpy.scipy.org/
 .. _SPEC: http://www.certif.com/
 .. _EPICS: http://www.aps.anl.gov/epics/
+.. _SEP2: http://www.sardana-controls.org/sep/?SEP2.md
+.. _LImA: https://lima1.readthedocs.io/en/latest/

--- a/doc/source/devel/howto_controllers/howto_countertimercontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_countertimercontroller.rst
@@ -1,6 +1,6 @@
 .. currentmodule:: sardana.pool.controller
 
-.. _sardana-countertimercontroller-howto-basics:
+.. _sardana-countertimercontroller:
 
 =======================================
 How to write a counter/timer controller
@@ -12,6 +12,8 @@ controller in Sardana.
 .. contents:: Table of contents
     :depth: 3
     :backlinks: entry
+
+.. _sardana-countertimercontroller-howto-basics:
 
 The basics
 ----------
@@ -217,6 +219,7 @@ Here is an example of the possible implementation of
         def AbortOne(self, axis):
             self.springfield.AbortChannel(axis)
 
+.. _sardana-countertimercontroller-howto-advanced:
 
 Advanced topics
 ---------------
@@ -238,8 +241,6 @@ parameter ``acquisition_mode``.
 
 Controller may announce its default timer axis with the
 :obj:`~sardana.pool.controller.Loadable.default_timer` class attribute.
-
-.. _sardana-countertimercontroller-howto-advanced:
 
 .. _sardana-countertimercontroller-howto-timestamp-value:
 
@@ -410,6 +411,8 @@ We can modify our counter controller to take profit of this hardware feature:
         def StartAll(self):
             self.springfield.startCounters(self._counters_info)
 
+.. _sardana-countertimercontroller-howto-external-synchronization:
+
 External (hardware) synchronization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -537,6 +540,8 @@ of the :meth:`~sardana.pool.controller.Loadable.LoadOne` method:
             self.springfield.SetLatency(latency)
             return value
 
+.. _sardana-countertimercontroller-howto-external-synchronization-get-values:
+
 Get counter values
 """"""""""""""""""
 
@@ -567,6 +572,8 @@ can be:
 
 Sardana assumes that the counter values are returned in the order of acquisition
 and that there are no gaps in between them.
+
+.. _sardana-countertimercontroller-per-measurement-preparation:
 
 Per measurement preparation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR adds documentation on how to write 1D and 2D controllers.

Since at the end 1D and 2D are _timerable_ controllers as counter/timer controller, I decided to not duplicate the documentation and just reference to the counter/timer controller documentation and list the differences and additional features.

Similarly the 1D controller documentation does not duplicate the _value referencing_ documentation which is placed in the 2D controller documentation.

These documentation does not follow the entire narration of developing "Springfield" hypothetical hardware controller as it is done for the motor and counter/timer. This would require more time and this PR just adds the strictly necessary information. This way we could advance with the last missing point from #1466.

@sardana-org/integrators could you please take a look on this one? Many thanks!