### PR TITLE
WIP: Add hook execution logging

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -231,24 +231,26 @@ class Hookable(Logger):
             and its optional parameters/arguments, the second one is the list
             of hints e.g. hook places
         """
-        self._getHooks().append(hook_info)
         hook = hook_info[0]
         hints = hook_info[1]
+        wrapped_hook = wrap_hook_with_logs(hook, self)
+        self._getHooks().append(wrapped_hook, hints)
         allowed_hookhints = self.getAllowedHookHints()
         if len(hints) == 0:
-            self._getHookHintsDict()['_ALL_'].append(hook)
-            self._hookHintsDict['_NOHINTS_'].append(hook)
+            self._getHookHintsDict()['_ALL_'].append(wrapped_hook)
+            self._hookHintsDict['_NOHINTS_'].append(wrapped_hook)
             return
         for hint in hints:
             if hint in allowed_hookhints:
-                self._getHookHintsDict()['_ALL_'].append(hook)
+                self._getHookHintsDict()['_ALL_'].append(wrapped_hook)
                 break
         for hint in hints:
             if hint in allowed_hookhints:
+                wrapped_hook_hint = wrap_hook_with_logs(hook, self, hint)
                 try:
-                    self._hookHintsDict[hint].append(hook)
+                    self._hookHintsDict[hint].append(wrapped_hook_hint)
                 except KeyError:
-                    self._hookHintsDict[hint] = [hook]
+                    self._hookHintsDict[hint] = [wrapped_hook_hint]
 
     @property
     def hooks(self):

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -48,6 +48,7 @@ import operator
 import io
 import threading
 import traceback
+import functools
 
 from taurus.core.util.log import Logger
 from taurus.core.util.prop import propertx
@@ -160,6 +161,26 @@ class PauseEvent(Logger):
 
     def isPaused(self):
         return not self._event.isSet()
+
+
+def wrap_hook_with_logs(hook, macro_obj, hook_place=None):
+    @functools.wraps(hook)
+    def wrapper_hook(*args, **kwargs):
+        try:
+            hook_exec_line = hook._exec_line
+        except AttributeError:
+            hook_description = hook.__name__
+        msg = "Start hook: {}".format(hook_exec_line)
+        if hook_place is not None:
+            msg += " at hook place {}".format(hook_place)
+        macro_obj.debug(msg)
+        ret = hook(*args, **kwargs)
+        msg = "End hook: {}".format(hook_exec_line)
+        if hook_place is not None:
+            msg += " at hook place {}".format(hook_place)
+        macro_obj.debug(msg)
+        return ret
+    return wrapper_hook
 
 
 class Hookable(Logger):

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -57,6 +57,7 @@ from taurus.console.list import List
 from sardana.sardanadefs import State
 from sardana.util.wrap import wraps
 from sardana.util.thread import _asyncexc
+from sardana.sardanautils import is_non_str_seq
 
 from sardana.macroserver.msparameter import Type, ParamType, Optional
 from sardana.macroserver.msexception import StopException, AbortException, \
@@ -315,6 +316,13 @@ class ExecMacroHook(object):
         self._macro_obj_wr = weakref.ref(parent_macro)
         self._pars = pars
         self._opts = kwargs
+        macro_and_params = pars
+        if is_non_str_seq(macro_and_params[0]):
+            macro_and_params = macro_and_params[0]
+        name = macro_and_params[0]
+        params = macro_and_params[1:]
+        self._exec_line = "{}({})".format(name, ", ".join(map(str,params)))
+
 
     @property
     def macro_obj(self):


### PR DESCRIPTION
#782 implements hooks execution logging in scans.

This PR introduces a more general solution to printing logs when executing hooks - it is not restricted to scans and work with any macro.

It is still WIP - for the moment works only with hooks added with `Hookable.appendHook()` and not the ones with the `Hookable.hooks` property setter. If you like this more general idea, I could also implement it for the property setter.

Here is how it looks like:

```
Door_zreszela_1 [28]: defgh "mv mot02 0" pre-acq
Defining general hook
mv mot02 0

Door_zreszela_1 [29]: debug on
debug mode is now on

Door_zreszela_1 [30]: ascan mot01 0 1 1 0.1
[START] runMacro Macro 'ascan(mot01, 0.0, 1.0, 1, 0.1) -> 39594a5e-67c9-11eb-b709-4ce17347e857'
Operation will be saved in /tmp/scan3.h5 (Spec from SPEC_FileRecorder)
Scan #21 started at Fri Feb  5 16:45:51 2021. It will take at least 0:00:00.765685
 #Pt No    mot01      ct01      ct02      ct03      ct04    zerod01      dt   
Start hook: mv([['mot02', '0']]) at hook place pre-acq
Executing macro: mv
[START] runMacro Macro 'mv([['mot02', '0.0']]) -> None'
Starting mot02 movement to 0.0
[ END ] runMacro Macro 'mv([['mot02', '0.0']]) -> None'
End hook: mv([['mot02', '0']]) at hook place pre-acq
   0         0        0.1       0.2       0.3       0.4     101.172   0.313357
Start hook: mv([['mot02', '0']]) at hook place pre-acq
Executing macro: mv
[START] runMacro Macro 'mv([['mot02', '0.0']]) -> None'
Starting mot02 movement to 0.0
[ END ] runMacro Macro 'mv([['mot02', '0.0']]) -> None'
End hook: mv([['mot02', '0']]) at hook place pre-acq
   1         1        0.1       0.2       0.3       0.4     100.659   0.791111
Operation saved in /tmp/scan3.h5 (Spec)
Scan #21 ended at Fri Feb  5 16:45:52 2021, taking 0:00:00.972370. Dead time 79.4% (motion dead time 63.6%)
[ END ] runMacro Macro 'ascan(mot01, 0.0, 1.0, 1, 0.1) -> 39594a5e-67c9-11eb-b709-4ce17347e857'

Job ended (stopped=False, aborted=False)
```

It should also already work for the simple callable hooks (not macros).

@AntoineDupre, @13bscsaamjad could you check if this also solves your need?



