### PR TITLE
Fill parent_macro in case of executing XML hooks (sequencer)

### DIFF
--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1613,8 +1613,9 @@ class MacroExecutor(Logger):
 
     def __runXMLMacro(self, xml):
         assert xml.tag == 'macro'
+        parent_macro = self.getRunningMacro()
         try:
-            macro_obj, _ = self._prepareXMLMacro(xml)
+            macro_obj, _ = self._prepareXMLMacro(xml, parent_macro)
         except AbortException as ae:
             raise ae
         except Exception as e:


### PR DESCRIPTION
XML hooks, usually composed by the sequencer, as other hooks (programmatic or
general), needs information about the parent macro. Fill it when preparing
the macro object. See #1472 for more details.