### PR TITLE
Ensure order of moveables is preserved in Motion object

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/motion.py
+++ b/src/sardana/taurus/core/tango/sardana/motion.py
@@ -30,6 +30,7 @@ __all__ = ["Moveable", "MoveableSource", "Motion", "MotionGroup"]
 __docformat__ = 'restructuredtext'
 
 import time
+from collections import OrderedDict
 
 from taurus.core.util.containers import CaselessDict
 
@@ -270,7 +271,7 @@ class Motion(BaseMotion):
                                                           allow_repeat=allow_repeat, allow_unknown=allow_unknown)
 
         # map<MoveableSource, Moveable>
-        ms_moveables = {}
+        ms_moveables = OrderedDict()
         for moveable_source, ms_names in list(ms_elem_names.items()):
             moveable = moveable_source.getMoveable(ms_names)
             ms_moveables[moveable_source] = moveable
@@ -330,7 +331,7 @@ class Motion(BaseMotion):
         belong to the that motion source.
         """
 
-        ms_elems = {}
+        ms_elems = OrderedDict()
 
         for name in names:
             moveable = None


### PR DESCRIPTION
Move of motion object sends motors to wrong positions. This happens when using moveables from different Pools and is not 100 % reproducible.

This is due to the fact that we rely on simple dictionaries (their order is not preserved in Python 3.5) when constructing the Motion object from the list of moveables requested by the user. Further move requests on that object assume that the positions correspond to the order of moveables requested at the Motion object creation time. Currently the order may be lost.

Use OrderedDict instead to avoid such problems.

We discovered this bug after migrating one of our beamlines to Python 3, while executing continuous scan (a2scanct). I looks like with Python 2 we were more lucky and we had not suffered it. Before reviewing it, let's wait until @jairomoldes confirms it fixes the issue for him.