### PR TITLE
Fix getting macroserver from remote door

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -424,11 +424,10 @@ class BaseDoor(MacroServerDevice):
     def _get_macroserver_for_door(self):
         """Returns the MacroServer device object in the same DeviceServer as
         this door"""
-        db = self.factory().getDatabase()
+        db = self.getParentObj()
         door_name = self.dev_name()
         server_list = list(db.get_server_list('MacroServer/*'))
         server_list += list(db.get_server_list('Sardana/*'))
-        server_devs = None
         for server in server_list:
             server_devs = db.get_device_class_list(server)
             devs, klasses = server_devs[0::2], server_devs[1::2]
@@ -436,7 +435,8 @@ class BaseDoor(MacroServerDevice):
                 if dev.lower() == door_name:
                     for i, klass in enumerate(klasses):
                         if klass == 'MacroServer':
-                            return self.factory().getDevice(devs[i])
+                            full_name = db.getFullName() + "/" + devs[i]
+                            return self.factory().getDevice(full_name)
         else:
             return None
 


### PR DESCRIPTION
_get_macroserver_for_door() is assuming that the macroserver belongs to the default Tango database. In case the door is
a remote door (on different Tango database) the macroserver is never found. Fix it by interrogating the Tango database of the door and by creating a macroserver device from full name.

I found it using a similar macro to this one:

```python3

import taurus
from sardana.macroserver.macro import macro
from sardana.taurus.core.tango.sardana.macroserver import registerExtensions

registerExtensions()


@macro()
def foo(self):
    door = taurus.Device("tango://pt222.cells.es:10000/Door/test/1")
    door.runMacro("bar", synch=True)
```

@sardana-org/integrators could you please take a look?
@cpascual maybe you know a better way of creating full name than: `full_name = db.getFullName() + "/" + devs[i]`