### PR TITLE
Assert motor sign is -1 or 1

### DIFF
--- a/src/sardana/pool/poolmotor.py
+++ b/src/sardana/pool/poolmotor.py
@@ -417,6 +417,8 @@ class PoolMotor(PoolElement):
         return self._sign
 
     def set_sign(self, sign, propagate=1):
+        assert sign in (-1, 1), \
+            "sign must be either -1 or 1 (not {})".format(sign)
         old_sign = self._sign.value
         self._sign.set_value(sign, propagate=propagate)
         # invert lower with upper limit switches and send event in case of


### PR DESCRIPTION
Setting motor sign to 0 may lead to wrong position calculation.
Assert motor sign is -1 or 1. Fix #1345.

It works as following:

```
Door_zreszela_1 [1]: mot01.sign = 1

Door_zreszela_1 [2]: mot01.sign = -2
PyDs_PythonError: AssertionError: sign must be either -1 or 1 (not -2)

(For more detailed information type: tango_error)

Door_zreszela_1 [3]: mot01.sign = -1

Door_zreszela_1 [4]: mot01.sign = 0
PyDs_PythonError: AssertionError: sign must be either -1 or 1 (not 0)

(For more detailed information type: tango_error)
```

@sardana-org/integrators could you please review. Many thanks!