### PR TITLE
Fixes for string datasets with h5py >= 3

### DIFF
--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -397,7 +397,9 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
                         continue
                     uri_groups = group.groupdict()
                     filename = uri_groups["filepath"]
-                    dataset = uri_groups.get("dataset", "dataset")
+                    dataset = uri_groups["dataset"]
+                    if dataset is None:
+                        dataset = "dataset"
                     vsource = h5py.VirtualSource(filename, dataset,
                                                  shape=(dim_1, dim_2))
                     layout[i] = vsource

--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -66,7 +66,11 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
     """
     formats = {'h5': '.h5'}
     # from http://docs.h5py.org/en/latest/strings.html
-    str_dt = h5py.special_dtype(vlen=str)  # Variable-length UTF-8
+    try:
+        str_dt = h5py.string_dtype()
+    except AttributeError:
+        # h5py < 3
+        str_dt = h5py.special_dtype(vlen=str)  # Variable-length UTF-8
     byte_dt = h5py.special_dtype(vlen=bytes)  # Variable-length UTF-8
     supported_dtypes = ('float32', 'float64', 'int8',
                         'int16', 'int32', 'int64', 'uint8',

--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -363,7 +363,9 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
             if dd.value_ref_enabled:
                 measurement = nxentry['measurement']
                 first_reference = measurement[label][0]
-
+                # in some versions of h5py we get bytes
+                if isinstance(first_reference, bytes):
+                    first_reference = first_reference.decode()
                 group = re.match(self.pattern, first_reference)
                 if group is None:
                     msg = 'Unsupported reference %s' % first_reference
@@ -390,6 +392,9 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
 
                 for i in range(nb_points):
                     reference = measurement[label][i]
+                    # in some versions of h5py we get bytes
+                    if isinstance(reference, bytes):
+                        reference = reference.decode()
                     group = re.match(self.pattern, reference)
                     if group is None:
                         msg = 'Unsupported reference %s' % first_reference

--- a/src/sardana/macroserver/recorders/test/test_h5storage.py
+++ b/src/sardana/macroserver/recorders/test/test_h5storage.py
@@ -130,7 +130,12 @@ class TestNXscanH5_FileRecorder(TestCase):
         file_ = h5py.File(self.path)
         for i in range(nb_records):
             expected_data = "file:///tmp/test.edf"
-            data = file_["entry0"]["measurement"][COL1_NAME][i]
+            try:
+                dataset = file_["entry0"]["measurement"][COL1_NAME].asstr()
+            except AttributeError:
+                # h5py < 3
+                dataset = file_["entry0"]["measurement"][COL1_NAME]
+            data = dataset[i]
             msg = "data does not match"
             self.assertEqual(data, expected_data, msg)
 
@@ -202,9 +207,21 @@ def recorder(tmpdir):
     return NXscanH5_FileRecorder(filename=path)
 
 
-@pytest.mark.parametrize("custom_data", ["str_custom_data", 8, True])
+@pytest.mark.parametrize("custom_data", [8, True])
 def test_addCustomData(recorder, custom_data):
     name = "custom_data_name"
     recorder.addCustomData(custom_data, name)
     with h5py.File(recorder.filename) as fd:
-        assert fd["entry"]["custom_data"][name].value == custom_data
+        assert fd["entry"]["custom_data"][name][()] == custom_data
+
+
+def test_addCustomData_str(recorder):
+    name = "custom_data_name"
+    custom_data = "str_custom_data"
+    recorder.addCustomData(custom_data, name)
+    with h5py.File(recorder.filename) as fd:
+        try:
+            dset = fd["entry"]["custom_data"][name].asstr()
+        except AttributeError:
+            dset = fd["entry"]["custom_data"][name]
+        assert dset[()] == custom_data


### PR DESCRIPTION
Some fixes required for having hdf5 with VDS feature working.
Identified so far:
* if no vds name is given in ValueRefPattern it should default to "dataset" but instead is defaulting to None which raises error
* in some versions of h5py (example: 3.1) you get "bytes" instead of "str" as value for a key which raises an error

A more serious error is that when vds is active for a specific channel, the vds shape is taken from the channel (which gets it from the controller) but the dtype is the same of the original even which is "str" since the channel provides the data source in form of a URI. hdf5 raises an error saying that it cannot create a vds for type "<U" as seen below:
```
spock --profile=myth2
Spock 3.0.3 -- An interactive laboratory application.

help      -> Spock's help system.
object?   -> Details about 'object'. ?object also works, ?? prints more.

IPython profile: myth2

Connected to Door_myth2_1

Door_myth2_1 [1]: _myth2ct 0.1 2   # this is basically a timescan
Operation will be saved in /tmp/mythen2/scan.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #25 started at Wed Feb 24 18:50:55 2021. It will take at least 0:00:00.200000
 #Pt No   test_myth2     dt   
   0      h5file:///tmp/mythen2/myth2_024.h5  0.0392895
   1      h5file:///tmp/mythen2/myth2_025.h5  0.211432
Operation saved in /tmp/mythen2/scan.h5 (HDF5::NXscan)
Scan #25 ended at Wed Feb 24 18:50:55 2021, taking 0:00:00.375989. Dead time 100.0% (motion dead time 0.0%)
```
In spock we get no error or warning but the hdf5 has wrong data. Specifically instead of the channel key we get "_" + channel name and the data is the original list of paths instead of the expected VDS.
Here is the sardana log:

```
SardanaTP.W001 WARNING  2021-02-24 18:50:55,949 NXscanH5_FileRecorder: Could not create a Virtual Dataset. Reason: TypeError("No conversion path for dtype: dtype('<U')")
```