### PR TITLE
Read value in serial mode

### DIFF
--- a/src/sardana/pool/poolbasechannel.py
+++ b/src/sardana/pool/poolbasechannel.py
@@ -241,7 +241,7 @@ class PoolBaseChannel(PoolElement):
             value
         :rtype:
             :class:`~sardana.sardanavalue.SardanaValue`"""
-        return self.acquisition.read_value()[self]
+        return self.acquisition.read_value(serial=True)[self]
 
     def put_value(self, value, quality=AttrQuality.Valid, propagate=1):
         """Sets a value.


### PR DESCRIPTION
Value is read in a worker thread, however the read synchronizes with the worker
thread anyway in order to return the read value.

Read it in serial mode to avoid extra complexity of involving a thread.
It is also done the same way for the motor's dial position readout.