### PR TITLE
Open msenvironment shelve file always with 'c' flag

### DIFF
--- a/src/sardana/macroserver/msenvmanager.py
+++ b/src/sardana/macroserver/msenvmanager.py
@@ -145,7 +145,7 @@ class EnvironmentManager(MacroServerManager):
                 raise ose
         if os.path.exists(f_name) or os.path.exists(f_name + ".dat"):
             try:
-                self._env = shelve.open(f_name, flag='w', writeback=False)
+                self._env = shelve.open(f_name, flag='c', writeback=False)
             except Exception:
                 self.error("Failed to access environment in %s", f_name)
                 self.debug("Details:", exc_info=1)


### PR DESCRIPTION
Empty environment files used with dumb backend fails to
open with 'w' flag. This does not happen for gdbm backend.

Avoid this problem by always using 'c' flag, which according to
docs [1]: "Open database for reading and writing, creating it if it doesn’t exist".

Tested and it does not harm when the environment shelve files is not empty - its
content is preserved.

Fixes #1425.

[1] https://docs.python.org/3/library/dbm.html#dbm.open