### PR TITLE
Revert "Open msenvironment shelve file always with 'c' flag"

### DIFF
--- a/src/sardana/macroserver/msenvmanager.py
+++ b/src/sardana/macroserver/msenvmanager.py
@@ -145,7 +145,7 @@ class EnvironmentManager(MacroServerManager):
                 raise ose
         if os.path.exists(f_name) or os.path.exists(f_name + ".dat"):
             try:
-                self._env = shelve.open(f_name, flag='c', writeback=False)
+                self._env = shelve.open(f_name, flag='w', writeback=False)
             except Exception:
                 self.error("Failed to access environment in %s", f_name)
                 self.debug("Details:", exc_info=1)


### PR DESCRIPTION
Reverts sardana-org/sardana#1514

This PR leads to wrong creation of new environment file with `ndbm` backend on top of already existing, empty, `dumb` backend.
This was reported by @teresanunez in https://github.com/sardana-org/sardana/pull/1514#issuecomment-794113215.