### PR TITLE
respect timer/monitor passed in measurement group configuration

### DIFF
--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -880,7 +880,8 @@ class MeasurementConfiguration(object):
         # timer & monitor are not used
         mnt_grp_timer = cfg.get('timer')
         if mnt_grp_timer:
-            timerable_channels = self.get_timerable_channels(enabled=True)
+            timerable_channels = _get_timerable_channels(timerable_ctrls,
+                                                         enabled=True)
             if mnt_grp_timer in [ch.full_name for ch in timerable_channels]:
                 user_config['timer'] = mnt_grp_timer
             else:
@@ -897,7 +898,8 @@ class MeasurementConfiguration(object):
 
         mnt_grp_monitor = cfg.get('monitor')
         if mnt_grp_monitor:
-            timerable_channels = self.get_timerable_channels(enabled=True)
+            timerable_channels = _get_timerable_channels(timerable_ctrls,
+                                                         enabled=True)
             if mnt_grp_monitor in [ch.full_name for ch in timerable_channels]:
                 user_config['monitor'] = mnt_grp_monitor
             else:

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -881,9 +881,9 @@ class MeasurementConfiguration(object):
         # timer & monitor are not used
         mnt_grp_timer = cfg.get('timer')
         if mnt_grp_timer:
-            timerable_channels = _get_timerable_channels(timerable_ctrls,
-                                                         enabled=True)
-            if mnt_grp_timer in [ch.full_name for ch in timerable_channels]:
+            timerable_chs = _get_timerable_channels(timerable_ctrls,
+                                                    enabled=True)
+            if mnt_grp_timer in [ch.full_name for ch in timerable_chs]:
                 user_config['timer'] = mnt_grp_timer
             else:
                 raise ValueError(
@@ -899,9 +899,9 @@ class MeasurementConfiguration(object):
 
         mnt_grp_monitor = cfg.get('monitor')
         if mnt_grp_monitor:
-            timerable_channels = _get_timerable_channels(timerable_ctrls,
-                                                         enabled=True)
-            if mnt_grp_monitor in [ch.full_name for ch in timerable_channels]:
+            timerable_chs = _get_timerable_channels(timerable_ctrls,
+                                                    enabled=True)
+            if mnt_grp_monitor in [ch.full_name for ch in timerable_chs]:
                 user_config['monitor'] = mnt_grp_monitor
             else:
                 raise ValueError(

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -637,8 +637,9 @@ class MeasurementConfiguration(object):
         """Set measurement configuration from serializable data structure.
 
         Setting of the configuration includes the validation process. Setting
-        of invalid configuration raises an exception hence it is not necessary
-        that the client application does the validation.
+        of invalid configuration raises an exception and leaves the object
+        as it was before the setting process. Thanks to that it is not
+        necessary that the client application does the validation.
 
         The configuration parameters for given channels/controllers may differ
         depending on their types e.g. 0D channel does not support timer

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -883,11 +883,13 @@ class MeasurementConfiguration(object):
         if mnt_grp_timer:
             timerable_chs = _get_timerable_channels(timerable_ctrls,
                                                     enabled=True)
-            if mnt_grp_timer in [ch.full_name for ch in timerable_chs]:
-                user_config['timer'] = mnt_grp_timer
-            else:
-                raise ValueError(
-                    'timer {} is not present/enabled'.format(mnt_grp_timer))
+            if len(timerable_chs) > 0:
+                if mnt_grp_timer in [ch.full_name for ch in timerable_chs]:
+                    user_config['timer'] = mnt_grp_timer
+                else:
+                    raise ValueError(
+                        'timer {} is not present/enabled'.format(mnt_grp_timer)
+                    )
         elif master_timer_sw is not None:
             user_config['timer'] = master_timer_sw.full_name
         elif master_timer_sw_start is not None:
@@ -901,12 +903,13 @@ class MeasurementConfiguration(object):
         if mnt_grp_monitor:
             timerable_chs = _get_timerable_channels(timerable_ctrls,
                                                     enabled=True)
-            if mnt_grp_monitor in [ch.full_name for ch in timerable_chs]:
-                user_config['monitor'] = mnt_grp_monitor
-            else:
-                raise ValueError(
-                    'monitor {} is not present/enabled'.format(
-                        mnt_grp_monitor))
+            if len(timerable_chs) > 0:
+                if mnt_grp_monitor in [ch.full_name for ch in timerable_chs]:
+                    user_config['monitor'] = mnt_grp_monitor
+                else:
+                    raise ValueError(
+                        'monitor {} is not present/enabled'.format(
+                            mnt_grp_monitor))
         elif master_monitor_sw is not None:
             user_config['monitor'] = master_monitor_sw.full_name
         elif master_monitor_sw_start is not None:

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -124,6 +124,17 @@ def _to_fqdn(name, logger=None):
     return full_name
 
 
+def _filter_ctrls(ctrls, enabled=None):
+    if enabled is None:
+        return ctrls
+
+    filtered_ctrls = []
+    for ctrl in ctrls:
+        if ctrl.enabled == enabled:
+            filtered_ctrls.append(ctrl)
+    return filtered_ctrls
+
+
 class ConfigurationItem(object):
     """Container of configuration attributes related to a given element.
 
@@ -482,16 +493,6 @@ class MeasurementConfiguration(object):
             controller = controller.element
         return self._ctrl_acq_synch[controller]
 
-    def _filter_ctrls(self, ctrls, enabled):
-        if enabled is None:
-            return ctrls
-
-        filtered_ctrls = []
-        for ctrl in ctrls:
-            if ctrl.enabled == enabled:
-                filtered_ctrls.append(ctrl)
-        return filtered_ctrls
-
     def get_timerable_ctrls(self, acq_synch=None, enabled=None):
         """Return timerable controllers.
 
@@ -523,7 +524,7 @@ class MeasurementConfiguration(object):
         else:
             timerable_ctrls = list(self._timerable_ctrls[acq_synch])
 
-        return self._filter_ctrls(timerable_ctrls, enabled)
+        return _filter_ctrls(timerable_ctrls, enabled)
 
     def get_timerable_channels(self, acq_synch=None, enabled=None):
         """Return timerable channels.
@@ -567,7 +568,7 @@ class MeasurementConfiguration(object):
         :return: 0D controllers that fulfils the filtering criteria
         :rtype: list<:class:`~sardana.pool.poolmeasurementgroup.ControllerConfiguration`>  # noqa
         """
-        return self._filter_ctrls(self._zerod_ctrls, enabled)
+        return _filter_ctrls(self._zerod_ctrls, enabled)
 
     def get_synch_ctrls(self, enabled=None):
         """Return synchronizer (currently only trigger/gate) controllers.
@@ -585,7 +586,7 @@ class MeasurementConfiguration(object):
         :return: synchronizer controllers that fulfils the filtering criteria
         :rtype: list<:class:`~sardana.pool.poolmeasurementgroup.ControllerConfiguration`>  # noqa
         """
-        return self._filter_ctrls(self._synch_ctrls, enabled)
+        return _filter_ctrls(self._synch_ctrls, enabled)
 
     def get_master_timer_software(self):
         """Return master timer in software acquisition.


### PR DESCRIPTION
timer/monitor configuration parameters are still kept in the measurement
group configuration for the backwards compatibility. Respect the user
configuration values (if present) otherwise fill it with the software
master timer/monitor or a random timerable channel (last fallback).