### PR TITLE
Fix hookable set hooks to empty list

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -283,6 +283,8 @@ class Hookable(Logger):
         # delete _hookHintsDict to force its recreation on the next access
         if hasattr(self, '_hookHintsDict'):
             del self._hookHintsDict
+        if len(self._hooks) == 0:
+            return
         # create _hookHintsDict
         self._getHookHintsDict()['_ALL_'] = list(zip(*self._hooks))[0]
         nohints = self._hookHintsDict['_NOHINTS_']

--- a/src/sardana/macroserver/test/test_macro.py
+++ b/src/sardana/macroserver/test/test_macro.py
@@ -1,3 +1,28 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
 from sardana.macroserver.macro import Hookable
 
 

--- a/src/sardana/macroserver/test/test_macro.py
+++ b/src/sardana/macroserver/test/test_macro.py
@@ -34,3 +34,4 @@ def test_Hookable():
     hookable.hooks = []
     assert len(hookable.hooks) == 0
     hooks = hookable.getHooks("unexisting-hook-place")
+    assert len(hooks) == 0

--- a/src/sardana/macroserver/test/test_macro.py
+++ b/src/sardana/macroserver/test/test_macro.py
@@ -4,5 +4,8 @@ from sardana.macroserver.macro import Hookable
 def test_Hookable():
     hookable = Hookable()
     assert len(hookable.hooks) == 0
+    hooks = hookable.getHooks("unexisting-hook-place")
+    assert len(hooks) == 0
     hookable.hooks = []
     assert len(hookable.hooks) == 0
+    hooks = hookable.getHooks("unexisting-hook-place")

--- a/src/sardana/macroserver/test/test_macro.py
+++ b/src/sardana/macroserver/test/test_macro.py
@@ -1,0 +1,8 @@
+from sardana.macroserver.macro import Hookable
+
+
+def test_Hookable():
+    hookable = Hookable()
+    assert len(hookable.hooks) == 0
+    hookable.hooks = []
+    assert len(hookable.hooks) == 0

--- a/src/sardana/macroserver/test/test_msparameter.py
+++ b/src/sardana/macroserver/test/test_msparameter.py
@@ -1,3 +1,28 @@
+#!/usr/bin/env python
+
+##############################################################################
+##
+# This file is part of Sardana
+##
+# http://www.sardana-controls.org/
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Sardana is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Sardana is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
 import unittest
 from taurus.test import insertTest
 


### PR DESCRIPTION
When working on #1480 we discovered that `Hookable.hooks` property could not be set to empty list. Fix it and add automatic tests.

Not related to this, in a6b55a6, I add a missing header with the license.

@sardana-org/integrators, whenever CI allows me, I will auto-merge since this is a trivial bug-fix and it will speed-up work on #1480. Feel free to comment anyway and I will apply corrections afterwards.