### PR TITLE
Add allowed hooks to macro description in Spock

### DIFF
--- a/doc/source/devel/api/sardana/taurus/core/tango/sardana.rst
+++ b/doc/source/devel/api/sardana/taurus/core/tango/sardana.rst
@@ -22,6 +22,7 @@
     
     pool <sardana/pool>
     macroserver <sardana/macroserver>
+    macro <sardana/macro>
 
 .. autofunction:: registerExtensions
 .. autofunction:: unregisterExtensions

--- a/doc/source/devel/api/sardana/taurus/core/tango/sardana/macro.rst
+++ b/doc/source/devel/api/sardana/taurus/core/tango/sardana/macro.rst
@@ -1,0 +1,37 @@
+.. currentmodule:: sardana.taurus.core.tango.sardana.macro
+
+
+:mod:`~sardana.taurus.core.tango.sardana.macro`
+===============================================
+
+.. automodule:: sardana.taurus.core.tango.sardana.macro
+
+.. rubric:: Classes
+
+.. hlist::
+    :columns: 4
+
+    * :class:`Macro`
+    * :class:`MacroInfo`
+
+Macro
+-----
+
+.. inheritance-diagram:: Macro
+    :parts: 1
+
+.. autoclass:: Macro
+    :show-inheritance:
+    :members:
+    :undoc-members:
+
+MacroInfo
+---------
+
+.. inheritance-diagram:: MacroInfo
+    :parts: 1
+
+.. autoclass:: MacroInfo
+    :show-inheritance:
+    :members:
+    :undoc-members:

--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -89,6 +89,9 @@ class MacroInfo(object):
         if self.hasResult():
             doc += '\n\nResult:\n\t'
             doc += '\n\t'.join(self.getResultDescr())
+        if self.allowsHooks():
+            doc += '\n\nAllows hooks:\n\t'
+            doc += '\n\t'.join(self.getAllowedHooks())
         self.doc = doc
 
     def _hasParamComplex(self, parameters=None):
@@ -298,6 +301,31 @@ class MacroInfo(object):
             return res[0]
         else:
             return tuple(res)
+
+    def allowsHooks(self):
+        """Checks whether the macro allows hooks
+
+        :return: True or False depending if the macro allows hooks
+        :rtype: bool
+        """
+        try:
+            self.hints["allowsHooks"]
+        except KeyError:
+            return False
+        return True
+
+    def getAllowedHooks(self):
+        """Gets allowed hooks
+
+        :return: list with the allowed hooks or empty list if the macro
+            does not allow hooks
+        :rtype: list[str]
+        """
+        try:
+            allowed_hooks = self.hints["allowsHooks"]
+        except KeyError:
+            return []
+        return allowed_hooks
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
As mentioned in https://github.com/sardana-org/sardana/pull/1480#issuecomment-799800371 I added "Allowed hooks" to the macro description, e.g.:

```
Door_zreszela_1 [1]: ascan?
Docstring:
Syntax:
        ascan <motor> <start_pos> <final_pos> <nr_interv> <integ_time> -> 


    Do an absolute scan of the specified motor.
    ascan scans one motor, as specified by motor. The motor starts at the
    position given by start_pos and ends at the position given by final_pos.
    The step size is (start_pos-final_pos)/nr_interv. The number of data
    points collected will be nr_interv+1. Count time is given by time which
    if positive, specifies seconds and if negative, specifies monitor counts.
    

Parameters:
        motor : (Moveable) Moveable to move
        start_pos : (Float) Scan start position
        final_pos : (Float) Scan final position
        nr_interv : (Integer) Number of scan intervals
        integ_time : (Float) Integration time

Result:
        

Allows hooks:
        pre-scan
        pre-move
        post-move
        pre-acq
        post-acq
        post-step
        post-scan
WARNING: do not rely on the file path below
File:      ~/workspace/sardana/src/sardana/spock/spockms.py

```