### PR TITLE
fix: Macro.hasResult() and Macro.hasParams()

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macro.py
+++ b/src/sardana/taurus/core/tango/sardana/macro.py
@@ -137,7 +137,7 @@ class MacroInfo(object):
 
         :return: (bool) True if the macro has parameters or False otherwise
         """
-        return hasattr(self, 'parameters')
+        return hasattr(self, 'parameters') and len(self.parameters) > 0
 
     def getParamList(self):
         """Returs the list of parameters
@@ -223,7 +223,7 @@ class MacroInfo(object):
 
         :return: (bool) True if the macro has a result or False otherwise
         """
-        return hasattr(self, 'result')
+        return hasattr(self, 'result') and len(self.result) > 0
 
     def getResultList(self):
         """Returns the list of results


### PR DESCRIPTION
Macro.hasResult() and Macro.hasParams() wrongly returns True if the result
and params definition is an empty list. This leads to adding empty:
"Parameters" and "Result" sections in the macro's description in Spock.
Fix it and consider empty lists as no parameters and result.

This changes macro's description from:

```
Door_zreszela_1 [1]: ascan?
Docstring:
Syntax:
        ascan <motor> <start_pos> <final_pos> <nr_interv> <integ_time> -> 


    Do an absolute scan of the specified motor.
    ascan scans one motor, as specified by motor. The motor starts at the
    position given by start_pos and ends at the position given by final_pos.
    The step size is (start_pos-final_pos)/nr_interv. The number of data
    points collected will be nr_interv+1. Count time is given by time which
    if positive, specifies seconds and if negative, specifies monitor counts.
    

Parameters:
        motor : (Moveable) Moveable to move
        start_pos : (Float) Scan start position
        final_pos : (Float) Scan final position
        nr_interv : (Integer) Number of scan intervals
        integ_time : (Float) Integration time

Result:
        

WARNING: do not rely on the file path below
File:      ~/workspace/sardana/src/sardana/spock/spockms.py

```

to:

```
Door_zreszela_1 [1]: ascan?
Docstring:
Syntax:
        ascan <motor> <start_pos> <final_pos> <nr_interv> <integ_time>


    Do an absolute scan of the specified motor.
    ascan scans one motor, as specified by motor. The motor starts at the
    position given by start_pos and ends at the position given by final_pos.
    The step size is (start_pos-final_pos)/nr_interv. The number of data
    points collected will be nr_interv+1. Count time is given by time which
    if positive, specifies seconds and if negative, specifies monitor counts.
    

Parameters:
        motor : (Moveable) Moveable to move
        start_pos : (Float) Scan start position
        final_pos : (Float) Scan final position
        nr_interv : (Integer) Number of scan intervals
        integ_time : (Float) Integration time
WARNING: do not rely on the file path below
File:      ~/workspace/sardana/src/sardana/spock/spockms.py
```