### PR TITLE
perf: remove redundant print of positions at the end of umv

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -518,7 +518,6 @@ class umv(Macro):
 
     def finish(self):
         self._clean()
-        self.printAllPos()
 
     def _clean(self):
         for motor, pos in self.getParameters()[0]:


### PR DESCRIPTION
PoolMotion action at the very end emits first the position event
and then the state event. If the mv macro, which is internally
executed by the umv macro, finished, then we can assume that no
more position events will arrive corresponding to the requested
move. This is because the mv macro finishes only after the state
transition which is based on the event and we are executing
the events callback sequentially. The event emission order is
preserved on the client side according to:
https://www.tango-controls.org/community/forum/c/general/development/is-events-order-maintained

Removing of this extra print also improves the behaviour when
post-move hooks use macro logging as described in #1480.