### PR TITLE
Enable sphinx napoleon extension

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -77,6 +77,7 @@ extensions = ['sphinx.ext.imgmath',
               'sardanaextension',
               'ipython_console_highlighting',
               'spock_console_highlighting',
+              'sphinxcontrib.napoleon'
               ]
 
 try:

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -1787,12 +1787,12 @@ class Macro(Logger):
         """**Macro API**. Gets the local environment matching the given
         parameters:
 
-           - door_name and macro_name define the context where to look for
-             the environment. If both are None, the global environment is
-             used. If door name is None but macro name not, the given macro
-             environment is used and so on...
-           - If key is None it returns the complete environment, otherwise
-             key must be a string containing the environment variable name.
+        - door_name and macro_name define the context where to look for
+          the environment. If both are None, the global environment is
+          used. If door name is None but macro name not, the given macro
+          environment is used and so on...
+        - If key is None it returns the complete environment, otherwise
+          key must be a string containing the environment variable name.
 
         :raises: UnknownEnv
 

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -247,15 +247,17 @@ class MacroServer(SardanaDevice):
         is_TypeList_allowed = is_Elements_allowed
 
     def GetMacroInfo(self, macro_names):
-        """GetMacroInfo(list<string> macro_names):
+        """Get macro information
 
-           Returns a list of string containing macro information.
-           Each string is a JSON encoded.
+       Returns a list of strings containing macro information.
+       Each string is a JSON encoded.
 
-           Params:
-               - macro_name: a list of strings with the macro(s) name(s)
-           Returns:
-               - a list of string containing macro information.
+       Args:
+           macro_names (list(str)): macro(s) name(s)
+
+       Returns:
+           list(str): macro(s) information
+
         """
         macro_server = self.macro_server
         codec = CodecFactory().getCodec('json')


### PR DESCRIPTION
Docstring using the Numpy style, e.g. as proposed in 321b6a6, cause warning "Unexpected section title". Enable sphinx napoleon extension to avoid this warning and preprocess other styles in addition to a pure rst.

Also, fix two warnings that appeared after enabling this extension.

Soon, I will open an issue to discuss the preferred docsting style, if we actually need an alternative to a pure rst.

This also depends on installing sphinxcontrib-napoleon which should be already available in [sardana-test](https://github.com/reszelaz/sardana-test/commit/3480c875e91b3baf06bb54c432a15b963a3425f4)