### PR TITLE
Execute post-scan also in case of an exception

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1066,10 +1066,9 @@ class GScan(Logger):
             self._env["endstatus"] = endstatus
             self.end()
             self.do_restore()
-            if endstatus == ScanEndStatus.Normal:
-                if hasattr(macro, 'getHooks'):
-                    for hook in macro.getHooks('post-scan'):
-                        hook()
+            if hasattr(macro, 'getHooks'):
+                for hook in macro.getHooks('post-scan'):
+                    hook()
 
     def scan_loop(self):
         raise NotImplementedError('Scan method cannot be called by '


### PR DESCRIPTION
post-scan hook is only executed in case of normal end of the scan.
In some case it will be convenient to execute it also in case the
scan failed or was stopped/aborted. The hook could identify
the scan endstatus from its environment.