### PR TITLE
Set stop flags for each element in multiple elements movement

### DIFF
--- a/src/sardana/pool/poolbasegroup.py
+++ b/src/sardana/pool/poolbasegroup.py
@@ -358,7 +358,7 @@ class PoolBaseGroup(PoolContainer):
             self.debug("Stopping %s %s", ctrl.name,
                        [e.name for e in elements])
             for el in elements:
-                el.stop()
+                el._stopped = True
             try:
                 error_elements = ctrl.stop_elements(elements=elements)
                 if len(error_elements) > 0:

--- a/src/sardana/pool/poolbasegroup.py
+++ b/src/sardana/pool/poolbasegroup.py
@@ -357,9 +357,9 @@ class PoolBaseGroup(PoolContainer):
         for ctrl, elements in list(self.get_physical_elements().items()):
             self.debug("Stopping %s %s", ctrl.name,
                        [e.name for e in elements])
+            for el in elements:
+                el.stop()
             try:
-                for el in elements:
-                    el.stop()
                 error_elements = ctrl.stop_elements(elements=elements)
                 if len(error_elements) > 0:
                     element_names = [elem.name for elem in error_elements]

--- a/src/sardana/pool/poolbasegroup.py
+++ b/src/sardana/pool/poolbasegroup.py
@@ -358,6 +358,8 @@ class PoolBaseGroup(PoolContainer):
             self.debug("Stopping %s %s", ctrl.name,
                        [e.name for e in elements])
             try:
+                for el in elements:
+                    el.stop()
                 error_elements = ctrl.stop_elements(elements=elements)
                 if len(error_elements) > 0:
                     element_names = [elem.name for elem in error_elements]


### PR DESCRIPTION
As proposed in https://github.com/sardana-org/sardana/pull/1474#issuecomment-805937733 this PR cherry-picks from #1474 the commits which fix #1421. The rest of the commits, the ones which provide the automatic tests, stay in #1474.

