### PR TITLE
Refractor hooks for move macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ This file follows the formats and conventions from [keepachangelog.com]
 * `sequencer` loading of plain text sequences in spock syntax with macro functions (#1422)
 * Recorders tests helpers (#1439)
 * Disable flake8 job in travis CI (#1455)
-* `createMacro()` and `prepareMacro()` docstring (#1460, #1444) 
+* `createMacro()` and `prepareMacro()` docstring (#1460, #1444)
+* Make write of MeasurementGroup (Taurus extension) integration time more robust (#1473)
 * String formatting when rising exceptions in pseudomotors (#1469)
 
 ## [3.0.3] 2020-09-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This file follows the formats and conventions from [keepachangelog.com]
   e.g. pseudo counter's value, in controllers (#1440, #1446)
 * Problems with macro id's when `sequencer` executes from _plain text_ files (#1215, #1216)
 * `sequencer` loading of plain text sequences in spock syntax with macro functions (#1422)
+* Allow running Spock without Qt bindings (#1462, #1463)
 * Recorders tests helpers (#1439)
 * Disable flake8 job in travis CI (#1455)
 * `createMacro()` and `prepareMacro()` docstring (#1460, #1444)

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -32,6 +32,7 @@ import numbers
 
 __all__ = ["OverloadPrint", "PauseEvent", "Hookable", "ExecMacroHook",
            "MacroFinder", "Macro", "macro", "iMacro", "imacro",
+           "MoveMacro", "movemacro",
            "MacroFunc", "Type", "Table", "List", "ViewOption",
            "LibraryError", "Optional", "StopException", "AbortException",
            "InterruptException"]
@@ -2525,3 +2526,7 @@ class MacroFunc(Macro):
 
     def run(self, *args):
         return self._function(self, *args)
+
+
+class MoveMacro(Macro, Hookable):
+    pass

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -66,6 +66,7 @@ from sardana.macroserver.msexception import StopException, AbortException, \
 from sardana.macroserver.msoptions import ViewOption
 
 from sardana.taurus.core.tango.sardana.pool import PoolElement
+from sardana import sardanacustomsettings
 
 
 class OverloadPrint(object):
@@ -2529,4 +2530,9 @@ class MacroFunc(Macro):
 
 
 class MoveMacro(Macro, Hookable):
-    pass
+
+    hints = {'allowsHooks': ('pre-move', 'post-move')}
+
+    enable_hooks = getattr(sardanacustomsettings,
+                           'PRE_POST_MOVE_HOOK_IN_MV',
+                           True)

--- a/src/sardana/macroserver/macros/hkl.py
+++ b/src/sardana/macroserver/macros/hkl.py
@@ -48,7 +48,7 @@ import re
 import numpy as np
 
 from sardana.sardanautils import py2_round
-from sardana.macroserver.macro import Macro, iMacro, Type
+from sardana.macroserver.macro import Hookable, Macro, iMacro, Type
 from sardana.macroserver.macros.scan import aNscan
 from sardana.macroserver.msexception import UnknownEnv
 
@@ -218,6 +218,9 @@ class br(Macro, _diffrac, Hookable):
 
     def prepare(self, H, K, L, AnglesIndex, FlagNotBlocking, FlagPrinting):
         _diffrac.prepare(self)
+        self.motors = []
+        for name in self.angle_names:
+            self.motors.append(self.getMotor(name))
 
     def run(self, H, K, L, AnglesIndex, FlagNotBlocking, FlagPrinting):
         h_idx = 0
@@ -286,6 +289,9 @@ class ubr(Macro, _diffrac, Hookable):
 
     def prepare(self, hh, kk, ll, AnglesIndex):
         _diffrac.prepare(self)
+        self.motors = []
+        for name in self.angle_names:
+            self.motors.append(self.getMotor(name))
 
     def run(self, hh, kk, ll, AnglesIndex):
         if ll != "Not set":

--- a/src/sardana/macroserver/macros/hkl.py
+++ b/src/sardana/macroserver/macros/hkl.py
@@ -203,7 +203,6 @@ class br(MoveMacro, _diffrac):
     the correspondig to the given index. The index of the
     angles combinations are then changed."""
 
-    hints = {'allowsHooks': ('pre-move', 'post-move')}
     param_def = [
         ['H', Type.String, None, "H value"],
         ['K', Type.String, None, "K value"],
@@ -278,7 +277,6 @@ class ubr(MoveMacro, _diffrac):
     """Move the diffractometer to the reciprocal space coordinates given by
     H, K and L und update.
     """
-    hints = {'allowsHooks': ('pre-move', 'post-move')}
     param_def = [
         ["hh", Type.String, "Not set", "H position"],
         ["kk", Type.String, "Not set", "K position"],

--- a/src/sardana/macroserver/macros/hkl.py
+++ b/src/sardana/macroserver/macros/hkl.py
@@ -120,10 +120,9 @@ class _diffrac:
             self.type = v
 
         self.angle_device_names = {}
-        i = 0
-        for motor in motor_list:
+
+        for i, motor in enumerate(motor_list):
             self.angle_device_names[self.angle_names[i]] = motor.split(' ')[0]
-            i = i + 1
 
     # TODO: it should not be necessary to implement on_stop methods in the
     # macros in order to stop the moveables. Macro API should provide this kind
@@ -219,8 +218,8 @@ class br(Macro, _diffrac, Hookable):
     def prepare(self, H, K, L, AnglesIndex, FlagNotBlocking, FlagPrinting):
         _diffrac.prepare(self)
         self.motors = []
-        for name in self.angle_names:
-            self.motors.append(self.getMotor(name))
+        for motor_name in self.angle_device_names.values():
+            self.motors.append(self.getMotor(motor_name))     
 
     def run(self, H, K, L, AnglesIndex, FlagNotBlocking, FlagPrinting):
         h_idx = 0
@@ -290,8 +289,8 @@ class ubr(Macro, _diffrac, Hookable):
     def prepare(self, hh, kk, ll, AnglesIndex):
         _diffrac.prepare(self)
         self.motors = []
-        for name in self.angle_names:
-            self.motors.append(self.getMotor(name))
+        for motor_name in self.angle_device_names.values():
+            self.motors.append(self.getMotor(motor_name))            
 
     def run(self, hh, kk, ll, AnglesIndex):
         if ll != "Not set":

--- a/src/sardana/macroserver/macros/hkl.py
+++ b/src/sardana/macroserver/macros/hkl.py
@@ -48,7 +48,7 @@ import re
 import numpy as np
 
 from sardana.sardanautils import py2_round
-from sardana.macroserver.macro import Hookable, Macro, iMacro, Type
+from sardana.macroserver.macro import Hookable, Macro, iMacro, Type, MoveMacro
 from sardana.macroserver.macros.scan import aNscan
 from sardana.macroserver.msexception import UnknownEnv
 
@@ -196,7 +196,7 @@ class _diffrac:
         if mat:
             return regx.sub(repl, ch)
 
-class br(Macro, _diffrac, Hookable):
+class br(MoveMacro, _diffrac):
     """Move the diffractometer to the reciprocal space coordinates given by
     H, K and L.
     If a fourth parameter is given, the combination of angles to be set is
@@ -274,7 +274,7 @@ class br(Macro, _diffrac, Hookable):
                           hkl_values[l_idx], self.diffrac.WaveLength])
 
 
-class ubr(Macro, _diffrac, Hookable):
+class ubr(MoveMacro, _diffrac):
     """Move the diffractometer to the reciprocal space coordinates given by
     H, K and L und update.
     """

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -477,8 +477,8 @@ class mv(Macro, Hookable):
                                True)
 
         if enable_hooks:
-            for preAcqHook in self.getHooks('pre-move'):
-                preAcqHook()
+            for preMoveHook in self.getHooks('pre-move'):
+                preMoveHook()
 
         self.motors, positions = [], []
         for m, p in motor_pos_list:
@@ -495,8 +495,8 @@ class mv(Macro, Hookable):
             self.info("\n".join(msg))
 
         if enable_hooks:
-            for postAcqHook in self.getHooks('post-move'):
-                postAcqHook()
+            for postMoveHook in self.getHooks('post-move'):
+                postMoveHook()
 
 
 class mstate(Macro):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -576,9 +576,10 @@ class mvr(Macro, Hookable):
     ]
 
     def run(self, motor_disp_list):
-        motor_pos_list = []
+        self.motors, motor_pos_list = [], []
         for motor, disp in motor_disp_list:
             pos = motor.getPosition(force=True)
+            self.motors.append(motor)
             if pos is None:
                 self.error("Cannot get %s position" % motor.getName())
                 return
@@ -597,9 +598,10 @@ class umvr(Macro, Hookable):
     param_def = mvr.param_def
 
     def run(self, motor_disp_list):
-        motor_pos_list = []
+        self.motors, motor_pos_list = [], []
         for motor, disp in motor_disp_list:
             pos = motor.getPosition(force=True)
+            self.motors.append(motor)
             if pos is None:
                 self.error("Cannot get %s position" % motor.getName())
                 return

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -459,9 +459,10 @@ class pwm(Macro):
         self.execMacro('wm', motor_list, **Table.PrettyOpts)
 
 
-class mv(Macro):
+class mv(Macro, Hookable):
     """Move motor(s) to the specified position(s)"""
 
+    hints = {'allowsHooks': ('pre-move', 'post-move')}
     param_def = [
         ['motor_pos_list',
          [['motor', Type.Moveable, None, 'Motor to move'],
@@ -470,6 +471,9 @@ class mv(Macro):
     ]
 
     def run(self, motor_pos_list):
+        for preAcqHook in self.getHooks('pre-move'):
+            preAcqHook()
+
         motors, positions = [], []
         for m, p in motor_pos_list:
             motors.append(m)
@@ -483,6 +487,9 @@ class mv(Macro):
             for motor in motors:
                 msg.append(motor.information())
             self.info("\n".join(msg))
+
+        for postAcqHook in self.getHooks('post-move'):
+            postAcqHook()
 
 
 class mstate(Macro):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -45,6 +45,7 @@ from sardana.macroserver.macro import Macro, macro, Type, ViewOption, \
 from sardana.macroserver.msexception import StopException, UnknownEnv
 from sardana.macroserver.scan.scandata import Record
 from sardana.macroserver.macro import Optional
+from sardana import sardanacustomsettings
 
 ##########################################################################
 #
@@ -470,9 +471,15 @@ class mv(Macro, Hookable):
          None, 'List of motor/position pairs'],
     ]
 
+    def prepare(self):
+        selsardanacustomsettings
+
     def run(self, motor_pos_list):
-        for preAcqHook in self.getHooks('pre-move'):
-            preAcqHook()
+        enable_hooks = getattr(sardanacustomsettings, 'PRE_POST_MOVE_HOOK_IN_MV')
+
+        if enable_hooks:
+            for preAcqHook in self.getHooks('pre-move'):
+                preAcqHook()
 
         motors, positions = [], []
         for m, p in motor_pos_list:
@@ -488,8 +495,9 @@ class mv(Macro, Hookable):
                 msg.append(motor.information())
             self.info("\n".join(msg))
 
-        for postAcqHook in self.getHooks('post-move'):
-            postAcqHook()
+        if enable_hooks:
+            for postAcqHook in self.getHooks('post-move'):
+                postAcqHook()
 
 
 class mstate(Macro):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -471,9 +471,6 @@ class mv(Macro, Hookable):
          None, 'List of motor/position pairs'],
     ]
 
-    def prepare(self):
-        selsardanacustomsettings
-
     def run(self, motor_pos_list):
         enable_hooks = getattr(sardanacustomsettings, 'PRE_POST_MOVE_HOOK_IN_MV')
 

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -473,7 +473,8 @@ class mv(Macro, Hookable):
 
     def run(self, motor_pos_list):
         enable_hooks = getattr(sardanacustomsettings,
-                               'PRE_POST_MOVE_HOOK_IN_MV')
+                               'PRE_POST_MOVE_HOOK_IN_MV',
+                               True)
 
         if enable_hooks:
             for preAcqHook in self.getHooks('pre-move'):

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -472,6 +472,11 @@ class mv(Macro, Hookable):
     ]
 
     def run(self, motor_pos_list):
+        self.motors, positions = [], []
+        for m, p in motor_pos_list:
+            self.motors.append(m)
+            positions.append(p)
+
         enable_hooks = getattr(sardanacustomsettings,
                                'PRE_POST_MOVE_HOOK_IN_MV',
                                True)
@@ -480,11 +485,9 @@ class mv(Macro, Hookable):
             for preMoveHook in self.getHooks('pre-move'):
                 preMoveHook()
 
-        self.motors, positions = [], []
-        for m, p in motor_pos_list:
-            self.motors.append(m)
-            positions.append(p)
+        for m, p in zip(self.motors, positions):
             self.debug("Starting %s movement to %s", m.getName(), p)
+
         motion = self.getMotion(self.motors)
         state, pos = motion.move(positions)
         if state != DevState.ON:

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -479,17 +479,17 @@ class mv(Macro, Hookable):
             for preAcqHook in self.getHooks('pre-move'):
                 preAcqHook()
 
-        motors, positions = [], []
+        self.motors, positions = [], []
         for m, p in motor_pos_list:
-            motors.append(m)
+            self.motors.append(m)
             positions.append(p)
             self.debug("Starting %s movement to %s", m.getName(), p)
-        motion = self.getMotion(motors)
+        motion = self.getMotion(self.motors)
         state, pos = motion.move(positions)
         if state != DevState.ON:
             self.warning("Motion ended in %s", state.name)
             msg = []
-            for motor in motors:
+            for motor in self.motors:
                 msg.append(motor.information())
             self.info("\n".join(msg))
 
@@ -521,6 +521,7 @@ class umv(Macro):
             pos, posObj = motor.getPosition(force=True), motor.getPositionObj()
             self.all_pos.append([pos])
             posObj.subscribeEvent(self.positionChanged, motor)
+        self.motors = self.all_names
 
     def run(self, motor_pos_list):
         self.print_pos = True

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -520,13 +520,14 @@ class umv(Macro, Hookable):
     def prepare(self, motor_pos_list, **opts):
         self.all_names = []
         self.all_pos = []
+        self.motors = []
         self.print_pos = False
         for motor, pos in motor_pos_list:
             self.all_names.append([motor.getName()])
+            self.motors.append(motor)
             pos, posObj = motor.getPosition(force=True), motor.getPositionObj()
             self.all_pos.append([pos])
             posObj.subscribeEvent(self.positionChanged, motor)
-        self.motors = self.all_names
 
     def run(self, motor_pos_list):
         self.print_pos = True

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -511,9 +511,10 @@ class mstate(Macro):
         self.info("Motor %s" % str(motor.stateObj.read().rvalue))
 
 
-class umv(Macro):
+class umv(Macro, Hookable):
     """Move motor(s) to the specified position(s) and update"""
 
+    hints = {'allowsHooks': ('pre-move', 'post-move')}
     param_def = mv.param_def
 
     def prepare(self, motor_pos_list, **opts):
@@ -530,7 +531,9 @@ class umv(Macro):
     def run(self, motor_pos_list):
         self.print_pos = True
         try:
-            self.execMacro('mv', motor_pos_list)
+            mv, _ = self.createMacro('mv', motor_pos_list)
+            mv.appendHook(self.hooks)
+            self.runMacro(mv)
         finally:
             self.finish()
 

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -518,7 +518,7 @@ class umv(MoveMacro):
         self.print_pos = False
         for motor, pos in motor_pos_list:
             self.all_names.append([motor.getName()])
-            #self.motors.append(motor)
+            #self.motors.append(motor) # here?
             pos, posObj = motor.getPosition(force=True), motor.getPositionObj()
             self.all_pos.append([pos])
             posObj.subscribeEvent(self.positionChanged, motor)
@@ -527,9 +527,9 @@ class umv(MoveMacro):
         self.print_pos = True
         try:
             mv, _ = self.createMacro('mv', motor_pos_list)
+            self.motors = mv.motors  # or here?
             mv._setHooks(self.hooks)
             self.runMacro(mv)
-            self.motors = mv.motors
         finally:
             self.finish()
 

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -41,7 +41,7 @@ import PyTango
 from PyTango import DevState
 
 from sardana.macroserver.macro import Macro, macro, Type, ViewOption, \
-    iMacro, Hookable
+    iMacro, Hookable, MoveMacro
 from sardana.macroserver.msexception import StopException, UnknownEnv
 from sardana.macroserver.scan.scandata import Record
 from sardana.macroserver.macro import Optional
@@ -460,7 +460,7 @@ class pwm(Macro):
         self.execMacro('wm', motor_list, **Table.PrettyOpts)
 
 
-class mv(Macro, Hookable):
+class mv(MoveMacro):
     """Move motor(s) to the specified position(s)"""
 
     hints = {'allowsHooks': ('pre-move', 'post-move')}
@@ -511,7 +511,7 @@ class mstate(Macro):
         self.info("Motor %s" % str(motor.stateObj.read().rvalue))
 
 
-class umv(Macro, Hookable):
+class umv(MoveMacro):
     """Move motor(s) to the specified position(s) and update"""
 
     hints = {'allowsHooks': ('pre-move', 'post-move')}
@@ -564,7 +564,7 @@ class umv(Macro, Hookable):
         self.flushOutput()
 
 
-class mvr(Macro, Hookable):
+class mvr(MoveMacro):
     """Move motor(s) relative to the current position(s)"""
 
     hints = {'allowsHooks': ('pre-move', 'post-move')}
@@ -591,7 +591,7 @@ class mvr(Macro, Hookable):
         self.runMacro(mv)
 
 
-class umvr(Macro, Hookable):
+class umvr(MoveMacro):
     """Move motor(s) relative to the current position(s) and update"""
 
     hints = {'allowsHooks': ('pre-move', 'post-move')}

--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -472,7 +472,8 @@ class mv(Macro, Hookable):
     ]
 
     def run(self, motor_pos_list):
-        enable_hooks = getattr(sardanacustomsettings, 'PRE_POST_MOVE_HOOK_IN_MV')
+        enable_hooks = getattr(sardanacustomsettings,
+                               'PRE_POST_MOVE_HOOK_IN_MV')
 
         if enable_hooks:
             for preAcqHook in self.getHooks('pre-move'):

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -100,3 +100,12 @@ MS_ENV_SHELVE_BACKEND = None
 #: - 0 - history will not be filled
 #: - <int> - max number of macros stored in the history
 MACROEXECUTOR_MAX_HISTORY = 100
+
+#: pre-move and post-move hooks applied in simple mv-based macros 
+#: Available options:
+#:
+#: - False (or no setting) - macros which are hooked to the pre-move and post-move
+#:   hook places are not called in simple mv-based macros but only in scan-based macros
+#: - True - macros which are hooked to the pre-move and post-move
+#:   hook places are called before and/or after any move a motor
+PRE_POST_MOVE_HOOK_IN_MV = 100

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -104,9 +104,9 @@ MACROEXECUTOR_MAX_HISTORY = 100
 #: pre-move and post-move hooks applied in simple mv-based macros
 #: Available options:
 #:
-#: - False (or no setting) - macros which are hooked to the pre-move and
-#:   post-move hook places are not called in simple mv-based macros but
-#:   only in scan-based macros
-#: - True - macros which are hooked to the pre-move and post-move
-#:   hook places are called before and/or after any move a motor
+#: - True (or no setting) - macros which are hooked to the pre-move and
+#:   post-move hook places are called before and/or after any move of a motor
+#: - False - macros which are hooked to the pre-move and post-move hook
+#:   places are not called in simple mv-based macros but only in scan-based
+#:   macros
 PRE_POST_MOVE_HOOK_IN_MV = True

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -108,4 +108,4 @@ MACROEXECUTOR_MAX_HISTORY = 100
 #:   hook places are not called in simple mv-based macros but only in scan-based macros
 #: - True - macros which are hooked to the pre-move and post-move
 #:   hook places are called before and/or after any move a motor
-PRE_POST_MOVE_HOOK_IN_MV = 100
+PRE_POST_MOVE_HOOK_IN_MV = False

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -109,4 +109,4 @@ MACROEXECUTOR_MAX_HISTORY = 100
 #:   only in scan-based macros
 #: - True - macros which are hooked to the pre-move and post-move
 #:   hook places are called before and/or after any move a motor
-PRE_POST_MOVE_HOOK_IN_MV = False
+PRE_POST_MOVE_HOOK_IN_MV = True

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -92,7 +92,7 @@ VALUE_REF_BUFFER_CODEC = "pickle"
 #: - "dumb" - worst performance but directly available with Python 3.
 MS_ENV_SHELVE_BACKEND = None
 
-#: macroexecutor maximum number of macros stored in the history. 
+#: macroexecutor maximum number of macros stored in the history.
 #: Available options:
 #:
 #: - None (or no setting) - unlimited history (may slow down the GUI operation
@@ -101,11 +101,12 @@ MS_ENV_SHELVE_BACKEND = None
 #: - <int> - max number of macros stored in the history
 MACROEXECUTOR_MAX_HISTORY = 100
 
-#: pre-move and post-move hooks applied in simple mv-based macros 
+#: pre-move and post-move hooks applied in simple mv-based macros
 #: Available options:
 #:
-#: - False (or no setting) - macros which are hooked to the pre-move and post-move
-#:   hook places are not called in simple mv-based macros but only in scan-based macros
+#: - False (or no setting) - macros which are hooked to the pre-move and
+#:   post-move hook places are not called in simple mv-based macros but
+#:   only in scan-based macros
 #: - True - macros which are hooked to the pre-move and post-move
 #:   hook places are called before and/or after any move a motor
 PRE_POST_MOVE_HOOK_IN_MV = False


### PR DESCRIPTION
as discussed yesterday in the follow-up meeting, I am already trying to refector parts of the macros for movements based on #1480 

However, I just noticed that besides moving the `hints` to the new base class `MoveMacro` which then inherits from `Macro` and `Hookable` there is not much to refractor, since we do not define what actually happens in the move-macros, e.g. which underlying macro is called.
So `umv` calls `mv` but `umvr` calls `umv` and so on. And we can also not define that for any new Macros which developers/users will come up.

As I see it, it is most "effort" to hand the `hooks` to the final `mv` macro, which currenlty requires
```
mv, _ = self.createMacro('umv', motor_pos_list)
mv._setHooks(self.hooks)
self.runMacro(mv)
```
instead of
`self.executeMacro('umv', motor_pos_list)`

Regarding the `self.motors` one could ask about that from the called macro, right?
So refering to the line above, one could add at the end:
`self.motors = mv.motors`

As @reszelaz mentioned in his [comment](https://github.com/sardana-org/sardana/pull/1480#issuecomment-806226740) `self.motors` will be provided by the `mv` macro in the `pre-move` and `post-move` hooks.
We agreed to stil implement this property for all move macros for consistency.
But should it be available already in the `prepare` or in the `run` method?
I have move the filling of `self.motors` in the `mv` macro already into its `prepare` method.

So any ideas how to simplify this further?