### PR TITLE
Add sardana_init_hook

### DIFF
--- a/src/sardana/tango/core/SardanaDevice.py
+++ b/src/sardana/tango/core/SardanaDevice.py
@@ -170,6 +170,14 @@ class SardanaDevice(LatestDeviceImpl, Logger):
         non_detect_evts = ()
         self.set_change_events(detect_evts, non_detect_evts)
 
+    def sardana_init_hook(self):
+        """Hook that is called before the server event loop.
+        
+        The idea behind this hook is to be equivalent to server_init_hook from
+        Tango. Similar behaviour can be archived using post_init_callback.
+        """
+        pass
+
     def _get_nodb_device_info(self):
         """Internal method. Returns the device info when tango database is not
         being used (example: in demos)"""

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -1218,12 +1218,20 @@ def prepare_rconsole(options, args, tango_args):
 
 
 def run_tango_server(tango_util=None, start_time=None):
+    # Import here to avoid circular import
+    from sardana.tango.core.SardanaDevice import SardanaDevice
+
     try:
         if tango_util is None:
             tango_util = Util(sys.argv)
         util = Util.instance()
         SardanaServer.server_state = State.Init
         util.server_init()
+
+        for device in util.get_device_list("*"):
+            if isinstance(device, SardanaDevice):
+                device.sardana_init_hook()
+
         SardanaServer.server_state = State.Running
         if start_time is not None:
             import datetime

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -120,7 +120,6 @@ class MacroServer(SardanaDevice):
 
         macro_server.set_recorder_path(self.RecorderPath)
         macro_server.set_macro_path(self.MacroPath)
-        macro_server.set_pool_names(self.PoolNames)
 
         if self.RConsolePort:
             try:

--- a/src/sardana/tango/macroserver/MacroServer.py
+++ b/src/sardana/tango/macroserver/MacroServer.py
@@ -131,6 +131,9 @@ class MacroServer(SardanaDevice):
                 self.debug("Details:", exc_info=1)
         self.set_state(DevState.ON)
 
+    def sardana_init_hook(self):
+        self.macro_server.set_pool_names(self.PoolNames)
+
     def _calculate_name(self, name):
         if name is None:
             return None


### PR DESCRIPTION
Add sardana_init_hook to SardanaDevice for allowing the subscribe to pool's elements attribute in the init of the MacroServer.

Based on the response of Michal to https://gitlab.com/tango-controls/pytango/-/merge_requests/419. Modify the run_tango_server to replicate the behavior of post_init_callback found in PyTango High-level API which is invoked before the server enters the event loop. Fixes #674.