### PR TITLE
(test) use os.pathsep as recorder paths separator in test.

### DIFF
--- a/src/sardana/macroserver/test/test_msrecordermanager.py
+++ b/src/sardana/macroserver/test/test_msrecordermanager.py
@@ -48,7 +48,8 @@ _FAKE_RECORDER_DIR = os.path.join(_TEST_DIR, 'res')
             extra_recorders=1)
 @insertTest(helper_name='getRecorderPath',
             recorder_path=["/tmp/foo", "#/tmp/foo2"], expected_num_path=2)
-@insertTest(helper_name='getRecorderPath', recorder_path=["/tmp/foo:/tmp/foo2"],
+@insertTest(helper_name='getRecorderPath',
+            recorder_path=["/tmp/foo" + os.pathsep + "/tmp/foo2"],
             expected_num_path=3)
 @insertTest(helper_name='getRecorderPath', recorder_path=["/tmp/foo"],
             expected_num_path=2)


### PR DESCRIPTION
Fix test failing on Windows due to using wrong path separator.
Use os.pathsep instead of hardcoding ":" in recorder paths
(test input). For windows the separator must be ";".