### PR TITLE
(test) Avoid crashes of tests at process exit

### DIFF
--- a/src/sardana/tango/macroserver/test/macroexecutor.py
+++ b/src/sardana/tango/macroserver/test/macroexecutor.py
@@ -25,6 +25,7 @@
 
 import copy
 import time
+import atexit
 import threading
 import PyTango
 from sardana.macroserver.macros.test import BaseMacroExecutor
@@ -127,6 +128,8 @@ class TangoMacroExecutor(BaseMacroExecutor):
     Macro executor implemented using Tango communication with the Door device
     '''
 
+    _api_util_cleanup_registered = False
+
     def __init__(self, door_name=None):
         super(TangoMacroExecutor, self).__init__()
         if door_name is None:
@@ -134,6 +137,10 @@ class TangoMacroExecutor(BaseMacroExecutor):
         self._door = PyTango.DeviceProxy(door_name)
         self._done_event = None
         self._started_event = None
+        if not TangoMacroExecutor._api_util_cleanup_registered:
+            # remove whenever PyTango#390 gets fixed
+            atexit.register(PyTango.ApiUtil.cleanup)
+            TangoMacroExecutor._api_util_cleanup_registered = True
 
     def _clean(self):
         '''Recreates threading Events in case the macro executor is reused.'''

--- a/src/sardana/tango/pool/test/test_measurementgroup.py
+++ b/src/sardana/tango/pool/test/test_measurementgroup.py
@@ -27,6 +27,7 @@ import copy
 import json
 import os
 import time
+import atexit
 import threading
 
 # TODO: decide what to use: taurus or PyTango
@@ -108,10 +109,17 @@ class TangoAttributeListener(AttributeListener):
 class MeasSarTestTestCase(SarTestTestCase):
     """ Helper class to setup the need environmet for execute """
 
+    _api_util_cleanup_registered = False
+
     def setUp(self, pool_properties=None):
         SarTestTestCase.setUp(self, pool_properties)
         self.event_ids = {}
         self.mg_name = '_test_mg_1'
+        if not MeasSarTestTestCase._api_util_cleanup_registered:
+            # remove whenever PyTango#390 gets fixed
+            atexit.register(PyTango.ApiUtil.cleanup)
+            MeasSarTestTestCase._api_util_cleanup_registered = True
+
 
     def create_meas(self, config):
         """ Create a meas with the given configuration


### PR DESCRIPTION
Some combination of tests (when not executed with other tests
using Taurus >= 4.7.1) crash at exit due to [PyTango#390](https://gitlab.com/tango-controls/pytango/-/issues/390).

Register (at class level) atexit hook to call `tango.ApiUtil.cleanup()` in:
- `MacroExecutor` (tango implementation) - used when testing
  macro execution
- MeasurementGroup (tango) tests

Multiple executions of `ApiUtil.cleanup()` does not harm.