### PR TITLE
(fix) Avoid already finished macro being aborted at MS exit

### DIFF
--- a/src/sardana/macroserver/msdoor.py
+++ b/src/sardana/macroserver/msdoor.py
@@ -129,8 +129,15 @@ class MSDoor(MSObject):
 
     running_macro = property(get_running_macro)
 
+    def get_last_macro(self):
+        return self.macro_executor.getLastMacro()
+
+    last_macro = property(get_last_macro)
+
     def get_macro_data(self):
         macro = self.running_macro
+        if macro is None:
+            macro = self.last_macro
         if macro is None:
             raise MacroServerException("No macro has run so far " +
                                        "or the macro data was not preserved.")

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1089,6 +1089,7 @@ class MacroExecutor(Logger):
         self._macro_stack = []
         self._xml_stack = []
         self._macro_pointer = None
+        self._last_macro = None
         self._abort_thread = None
         self._aborted = False
         self._stop_thread = None
@@ -1398,6 +1399,9 @@ class MacroExecutor(Logger):
 
     def getRunningMacro(self):
         return self._macro_pointer
+
+    def getLastMacro(self):
+        return self._last_macro
 
     def clearRunningMacro(self):
         """Clear pointer to the running macro.
@@ -1726,11 +1730,13 @@ class MacroExecutor(Logger):
             preserve_macro_data = macro_obj.getEnv(env_var_name)
         except UnknownEnv:
             preserve_macro_data = True
-        if not preserve_macro_data:
+        if preserve_macro_data:
+            self._last_macro = self._macro_pointer
+        else:
             self.debug('Macro data will not be preserved. ' +
                        'Set "%s" environment variable ' % env_var_name +
                        'to True in order to change it.')
-            self._macro_pointer = None
+        self._macro_pointer = None
 
         log_macro_manager.disable()
 


### PR DESCRIPTION
Macro which was already finished is considered as _running
macro_ and at the MacroServer (MS) exit the running macro gets
aborted. This abort is unnecessary and causes the MS to crash
on Windows.

- Introduce the concept of _last macro_.
- When the macro finishes, update the _last macro_ information
and at the same time clear the _running macro_ - this avoids
the macro aborting.
- Maintain the backwards compatibility when reading the macro
data from the door: if it is read during the macro execution
it reports the data of the macro currently being run and as
soon as the macro finished it returns the data of the macro
which just finished execution.