### PR TITLE
(fix) prompt in qtspock when used with new traitlets

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
@@ -180,6 +180,7 @@ class QtSpockWidget(RichJupyterWidget, TaurusBaseWidget):
         self._macro_server_alias = None
         self._door_name = None
         self._door_alias = None
+        self._config_passed_as_extra_arguments = False
 
         self.append_stream("Waiting for kernel to start")
 
@@ -207,6 +208,7 @@ class QtSpockWidget(RichJupyterWidget, TaurusBaseWidget):
 
         if not self.use_model_from_profile:
             if self._macro_server_name and self._door_name:
+                self._config_passed_as_extra_arguments = True
                 extra_arguments.append("--Spock.macro_server={}".format(
                     self._macro_server_name))
                 extra_arguments.append("--Spock.macro_server_alias={}".format(
@@ -273,7 +275,14 @@ class QtSpockWidget(RichJupyterWidget, TaurusBaseWidget):
             self._macro_server_alias = None
 
     def _set_prompts(self):
-        var = "get_ipython().config.Spock.door_alias"
+        # If traitlets >= 5.0.0 then DeferredConfigString is used for values
+        # that are not listed in the configurable classes. Get its value.
+        if self._config_passed_as_extra_arguments:
+            self.kernel_client.execute(
+                "from sardana.spock.config import Spock", silent=True)
+            var = "get_ipython().config.Spock.door_alias.get_value(Spock.door_alias)"  # noqa
+        else:
+            var = "get_ipython().config.Spock.door_alias"
         self._silent_exec_callback(
             var, self._set_prompts_callback)
 

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/qtspock.py
@@ -36,6 +36,7 @@ import sys
 import pickle
 import ast
 
+import traitlets
 from IPython.core.profiledir import ProfileDirError, ProfileDir
 
 from taurus.external.qt import Qt
@@ -277,7 +278,8 @@ class QtSpockWidget(RichJupyterWidget, TaurusBaseWidget):
     def _set_prompts(self):
         # If traitlets >= 5.0.0 then DeferredConfigString is used for values
         # that are not listed in the configurable classes. Get its value.
-        if self._config_passed_as_extra_arguments:
+        if (traitlets.version_info >= (5, 0, 0)
+                and self._config_passed_as_extra_arguments):
             self.kernel_client.execute(
                 "from sardana.spock.config import Spock", silent=True)
             var = "get_ipython().config.Spock.door_alias.get_value(Spock.door_alias)"  # noqa


### PR DESCRIPTION
Setting qtspock's prompt (door's alias) fails when traitlet >= 5.0.0 and Taurus models are used instead of configuration stored in the profile. This is because the traitlets library instead of returning a string door_alias now returns DeferredConfigString object.

Fix it by obtaining a string value stored in this trait.

@schooft, first many thanks for providing unit tests together with the qtspock. These made us realize that with the new versions of the traitlets package the qtspock prompt was not correctly set (currently our CI does not run the tests with the newest versions of the packages and I just run them manually as part of the Jan21 release process).
It looks like I fixed it (to be honest it was not an easy one for me) but it would be nice if you could comment.