### PR TITLE
(test) avoid executing Pool's DeleteElement() cmd on Windows

### DIFF
--- a/src/sardana/tango/pool/test/base_sartest.py
+++ b/src/sardana/tango/pool/test/base_sartest.py
@@ -23,6 +23,8 @@
 ##
 ##############################################################################
 
+import os
+
 import PyTango
 import taurus
 
@@ -168,7 +170,8 @@ class SarTestTestCase(BasePoolTestCase):
             if elem_name in f.tango_alias_devs:
                 _cleanup_device(elem_name)
             try:
-                self.pool.DeleteElement(elem_name)
+                if os.name != "nt":
+                    self.pool.DeleteElement(elem_name)
             except Exception as e:
                 print(e)
                 dirty_elems.append(elem_name)
@@ -182,7 +185,8 @@ class SarTestTestCase(BasePoolTestCase):
             if ctrl_name in f.tango_alias_devs:
                 _cleanup_device(ctrl_name)
             try:
-                self.pool.DeleteElement(ctrl_name)
+                if os.name != "nt":
+                    self.pool.DeleteElement(ctrl_name)
             except:
                 dirty_ctrls.append(ctrl_name)
 

--- a/src/sardana/tango/pool/test/test_Motor.py
+++ b/src/sardana/tango/pool/test/test_Motor.py
@@ -24,6 +24,8 @@
 ##############################################################################
 
 """Tests Read Position from Sardana using PyTango"""
+import os
+
 import PyTango
 import unittest
 from sardana.tango.pool.test import BasePoolTestCase
@@ -70,6 +72,7 @@ class ReadMotorPositionOutsideLim(BasePoolTestCase, unittest.TestCase):
     def tearDown(self):
         """Remove motor element and motor controller
         """
-        self.pool.DeleteElement(self.elem_name)
-        self.pool.DeleteElement(self.ctrl_name)
+        if os.name != "nt":
+            self.pool.DeleteElement(self.elem_name)
+            self.pool.DeleteElement(self.ctrl_name)
         super(ReadMotorPositionOutsideLim, self).tearDown()

--- a/src/sardana/tango/pool/test/test_measurementgroup.py
+++ b/src/sardana/tango/pool/test/test_measurementgroup.py
@@ -282,7 +282,8 @@ class MeasSarTestTestCase(SarTestTestCase):
             channel.unsubscribe_event(event_id)
         try:
             # Delete the meas
-            self.pool.DeleteElement(self.mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(self.mg_name)
         except Exception as e:
             print('Impossible to delete MeasurementGroup: %s' %
                   self.mg_name)

--- a/src/sardana/tango/pool/test/test_persistence.py
+++ b/src/sardana/tango/pool/test/test_persistence.py
@@ -22,6 +22,7 @@
 # along with Sardana.  If not, see <http://www.gnu.org/licenses/>.
 ##
 ##############################################################################
+import os
 
 import PyTango
 import unittest
@@ -86,11 +87,13 @@ class PersistenceTestCase(BasePoolTestCase, unittest.TestCase):
         cleanup_success = True
         if self.do_element_cleanup:
             try:
-                self.pool.DeleteElement(self.elem_name)
+                if os.name != "nt":
+                    self.pool.DeleteElement(self.elem_name)
             except:
                 cleanup_success = False
         try:
-            self.pool.DeleteElement(self.ctrl_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(self.ctrl_name)
         except:
             cleanup_success = False
         BasePoolTestCase.tearDown(self)

--- a/src/sardana/taurus/core/tango/sardana/test/test_measgrpconf.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_measgrpconf.py
@@ -91,7 +91,8 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
             self._assertResult(resutl, full_names, True)
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_output(self, elements=["_test_ct_1_1", "_test_ct_1_2",
                                     "_test_2d_1_3",
@@ -146,7 +147,8 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
             self._assertResult(is_output, full_names, True)
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_PlotType(self, elements=["_test_ct_1_1", "_test_ct_1_2",
                                       "_test_ct_1_3", "_test_2d_1_3",
@@ -194,7 +196,8 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
 
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_PlotAxes(self, elements=["_test_ct_1_1", "_test_ct_1_2",
                                       "_test_ct_1_3", "_test_2d_1_3",
@@ -268,7 +271,8 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
             self._assertMultipleResults(result, full_names, expected_result)
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_Timer(self, elements=["_test_ct_1_1", "_test_ct_1_2",
                                    "_test_ct_1_3",
@@ -313,7 +317,8 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
             self._assertResult(result, full_names, "_test_ct_1_2")
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_Monitor(self, elements=["_test_ct_1_1", "_test_ct_1_2",
                                      "_test_ct_1_3", "_test_2d_1_1",
@@ -355,7 +360,8 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
             self._assertMultipleResults(result, full_names, expected)
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_Synchronizer(self, elements=["_test_ct_1_1", "_test_ct_1_2",
                                           "_test_ct_1_3", "_test_2d_1_1",
@@ -405,7 +411,8 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
 
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_Synchronization(self, elements=["_test_ct_1_1", "_test_ct_1_2",
                                              "_test_ct_1_3", "_test_2d_1_1",
@@ -457,7 +464,8 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
 
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_ValueRefEnabled(self, elements=["_test_2d_1_1", "_test_2d_1_2",
                                              "_test_ct_1_3",
@@ -517,7 +525,8 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
             self._assertResult(enabled, full_names, True)
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_ValueRefPattern(self, elements=["_test_2d_1_1", "_test_2d_1_2",
                                              "_test_ct_1_3",
@@ -570,4 +579,5 @@ class TestMeasurementGroupConfiguration(SarTestTestCase, unittest.TestCase):
 
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)

--- a/src/sardana/taurus/core/tango/sardana/test/test_measgrpstress.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_measgrpstress.py
@@ -90,7 +90,8 @@ class TestStressMeasurementGroup(SarTestTestCase, TestCase):
                     self.assertTrue(is_numerical(value), msg)
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def tearDown(self):
         SarTestTestCase.tearDown(self)

--- a/src/sardana/taurus/core/tango/sardana/test/test_pool.py
+++ b/src/sardana/taurus/core/tango/sardana/test/test_pool.py
@@ -23,7 +23,7 @@
 ##
 ##############################################################################
 
-
+import os
 import uuid
 import numpy
 
@@ -78,7 +78,8 @@ class TestMeasurementGroup(SarTestTestCase, TestCase):
                 self.assertTrue(is_numerical(value), msg)
         finally:
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def tearDown(self):
         SarTestTestCase.tearDown(self)
@@ -107,7 +108,8 @@ class TestMeasurementGroupValueRef(SarTestTestCase, TestCase):
         finally:
             channel.cleanUp()
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def test_value_ref_disabled(self):
         mg_name = str(uuid.uuid1())
@@ -126,7 +128,8 @@ class TestMeasurementGroupValueRef(SarTestTestCase, TestCase):
         finally:
             channel.cleanUp()
             mg.cleanUp()
-            self.pool.DeleteElement(mg_name)
+            if os.name != "nt":
+                self.pool.DeleteElement(mg_name)
 
     def tearDown(self):
         SarTestTestCase.tearDown(self)


### PR DESCRIPTION
Calling Pool's DeleteElement() command at the end of the tests very often crashes the server on Windows (it may have to do with pushing change event on the Elements attribute just before the server exit, note that this is not problematic on Linux).
This deletion is not necessary cause at the end the device server will be deleted anyway.
Skip execution of this command on Windows.

Fixes #540.