### PR TITLE
(test) increase timeout for qtspock tests

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/test/test_qtspock.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/test/test_qtspock.py
@@ -151,21 +151,21 @@ class ProfileErrorOutputMixin(object):
             text = self.widget._control.toPlainText()
             matches = re.findall(r"^IPython \d\.\d", text, re.MULTILINE)
             return len(matches) == 1
-        self.assertTrue(waitFor(predicate, 5000))
+        self.assertTrue(waitFor(predicate, 10000))
 
     def test_ipython_prompt(self):
         def predicate():
             text = self.widget._control.toPlainText()
             matches = re.findall(r"^In.*\[(\d)\]", text, re.MULTILINE)
             return len(matches) == 1 and matches[0] == "1"
-        self.assertTrue(waitFor(predicate, 5000))
+        self.assertTrue(waitFor(predicate, 10000))
 
     def test_profile_error_info(self):
         def predicate():
             text = self.widget._control.toPlainText()
             matches = re.findall(r"^Spock profile error", text, re.MULTILINE)
             return len(matches) == 1
-        self.assertTrue(waitFor(predicate, 5000))
+        self.assertTrue(waitFor(predicate, 10000))
 
 
 class MissingProfileTestCase(QtSpockTestCase, ProfileErrorOutputMixin):
@@ -193,7 +193,7 @@ class CorrectProfileAfterRestartTestCase(
             text = cls.widget._control.toPlainText()
             matches = re.findall(r"\[1\]: $", text, re.MULTILINE)
             return len(matches) == 1
-        assert waitFor(predicate, 5000)
+        assert waitFor(predicate, 10000)
 
         cls._create_profile()
 
@@ -224,7 +224,7 @@ class ProfileErrorAfterRestartTestCase(
             text = cls.widget._control.toPlainText()
             matches = re.findall(r"\[1\]: $", text, re.MULTILINE)
             return len(matches) == 1
-        assert waitFor(predicate, 5000)
+        assert waitFor(predicate, 10000)
 
         # "Update" profile
         config_file = os.path.join(
@@ -261,7 +261,7 @@ class QtSpockNoModelTestCase(QtSpockBaseTestCase, ProfileErrorOutputMixin):
             text = self.widget._control.toPlainText()
             matches = re.findall(r"^No door selected", text, re.MULTILINE)
             return len(matches) == 1
-        self.assertTrue(waitFor(predicate, 5000))
+        self.assertTrue(waitFor(predicate, 10000))
 
 
 class QtSpockModelTestCase(QtSpockBaseTestCase, CorrectProfileOutputMixin):
@@ -296,7 +296,7 @@ class QtSpockModelAfterRestartTestCase(
             text = cls.widget._control.toPlainText()
             matches = re.findall(r"\[1\]: $", text, re.MULTILINE)
             return len(matches) == 1
-        assert waitFor(predicate, 5000)
+        assert waitFor(predicate, 10000)
 
         cls.widget.setModel(UNITTEST_DOOR_NAME)
 
@@ -318,7 +318,7 @@ class QtSpockNoModelAfterRestartTestCase(QtSpockNoModelTestCase):
             text = cls.widget._control.toPlainText()
             matches = re.findall(r"\[1\]: $", text, re.MULTILINE)
             return len(matches) == 1
-        assert waitFor(predicate, 5000)
+        assert waitFor(predicate, 10000)
 
         cls.widget.setModel("")
 


### PR DESCRIPTION
On Windows it was observed that the qtspock tests that
have timeout set to 5 s sporadically fail.
The ones with the timeout set to 10 s works well.
This happened only when executed within the testsuite,
when executed separately it was not observed.
As an immediate solution, unify all timeouts in all tests
to 10 s.

@schooft hope you don't mind this change. For me, it was easier like this to have a reliable testsuite on Windows. I will auto-merge whenever the CI on Linux turns green but feel free to leave comments here.