### PR TITLE
(fix) sardana GUIs launchers on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,9 +72,6 @@ console_scripts = [
     "Sardana = sardana.tango:main",
     "sardanatestsuite = sardana.test.testsuite:main",
     "spock = sardana.spock:main",
-]
-
-gui_scripts = [
     "diffractometeralignment = sardana.taurus.qt.qtgui.extra_hkl.diffractometeralignment:main",
     "hklscan = sardana.taurus.qt.qtgui.extra_hkl.hklscan:main",
     "macroexecutor = sardana.taurus.qt.qtgui.extra_macroexecutor.macroexecutor:main",
@@ -89,7 +86,6 @@ form_factories = [
 
 entry_points = {
     'console_scripts': console_scripts,
-    'gui_scripts': gui_scripts,
     'taurus.form.item_factories': form_factories,
 }
 


### PR DESCRIPTION
During the Jan21 release it was observed that the Sardana GUIs launchers,
when sardana is installed on Windows with pip, does not launch
the applications at all.
In the previous releases Sardana was never tested on Windows when installing with
pip, but with MSI, and in this case the launchers were working correctly.
Since version Jan21, the recommendation is to use Sardana on Windows with pip.
In order to overcome this problem change the GUIs launchers from gui_script to
console_scripts entry points. Similar solution was already applied for Taurus
in taurus-org/taurus#541.