### PR TITLE
(fix) make PMTV relative move combobox accept only positive numbers

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_pool/poolmotor.py
@@ -789,7 +789,9 @@ class PoolMotorTVWriteWidget(TaurusWidget):
         self.cb_step.setSizePolicy(Qt.QSizePolicy(
             Qt.QSizePolicy.Expanding, Qt.QSizePolicy.Fixed))
         self.cb_step.setEditable(True)
-        self.cb_step.lineEdit().setValidator(Qt.QDoubleValidator(self))
+        cb_step_le_validator = Qt.QDoubleValidator(self)
+        cb_step_le_validator.setBottom(0)
+        self.cb_step.lineEdit().setValidator(cb_step_le_validator)
         self.cb_step.lineEdit().setAlignment(Qt.Qt.AlignRight)
         self.cb_step.addItem('1')
         self.qw_write_relative.layout().addWidget(self.cb_step)


### PR DESCRIPTION
In the PMTV widget, one can introduce negative values in the relative move write
widget. It is ambiguous since the relative movement is commanded with a move negative
or move positive buttons - there is no need to add a sign to the delta displacement.

Set bottom limit to 0 for the validator. `sys.float_info.min` was also evaluated but it
still allows moving the motor with 0 delta.

Fixes #1571.