### PR TITLE
Fix restoring velocity in software (ascanc) continuous scans

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1607,7 +1607,9 @@ class CScan(GScan):
         try:
             motor.setVelocity(v)
         except Exception:
-            pass
+            self.warning(
+                "failed setting max top velocity {} for {}".format(
+                    v, motor.name), exc_info=True)
 
     def get_min_pos(self, motor):
         '''Helper method to find the minimum position for a given motor.

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1551,9 +1551,8 @@ class CScan(GScan):
 
         top_vel_obj = motor.getVelocityObj()
         _, max_top_vel = top_vel_obj.getRange()
-        try:
-            max_top_vel = float(max_top_vel)
-        except ValueError:
+        # Taurus4 reports -inf or inf when no limits are defined (NotSpecified)
+        if np.isinf(max_top_vel):
             try:
                 # hack to avoid recursive velocity reduction
                 self._maxVelDict = getattr(self, '_maxVelDict', {})
@@ -1562,9 +1561,6 @@ class CScan(GScan):
                 max_top_vel = self._maxVelDict[motor]
             except AttributeError:
                 pass
-        # Taurus4 reports -inf or inf when no limits are defined (NotSpecified)
-        if np.isinf(max_top_vel):
-            max_top_vel = motor.getVelocity()
         return max_top_vel
 
     def get_min_acc_time(self, motor):

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1595,10 +1595,22 @@ class CScan(GScan):
             min_dec_time = motor.getAcceleration()
         return min_dec_time
 
-    def set_max_top_velocity(self, motor):
-        """Helper method to set the maximum top velocity for the motor to
-        its maximum allowed limit."""
+    def set_max_top_velocity(self, moveable):
+        """Helper method to set the maximum top velocity for the moveable to
+        its maximum allowed limit.
 
+        :param moveable: moveable (motor or pseudo motor) on which to set
+            the max top velocity
+        :type moveable: `sardana.taurus.core.tango.sardana.BaseSardanaElement`
+        """
+        if moveable.type == "PseudoMotor":
+            for name in moveable.physical_elements:
+                motor = self.macro.getMotor(name)
+                self._set_max_top_velocity(motor)
+        else:
+            self._set_max_top_velocity(moveable)
+
+    def _set_max_top_velocity(self, motor):
         v = self.get_max_top_velocity(motor)
         try:
             motor.setVelocity(v)


### PR DESCRIPTION
8815c91 introduced a hack to avoid recursive decrease of
velocity in continuous scans. Most probably this hack was needed
to avoid some synchronization problems between the software
continuous scan threads (motion and acquisition are done in
separate threads).
When using Taurus 4 this hack is not applied
cause the attribute's range returns -inf and inf floats
instead of "Not specified" string and we don't fall into the
except clause anymore.
Refactor the `CScan.get_max_top_velocity()` to consider only
Taurus 4 and above case (we don't support Taurus < 4 anymore)
and maintain the hack.

Also, log failed setting of maximum top velocity in continuous scans.

Fixes #1574.