### PR TITLE
fix: do not reserve instruments in GScan

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -720,8 +720,8 @@ class GScan(Logger):
                 except Exception:
                     instrument = ''
             try:
-                instrumentFullName = self.macro.findObjs(
-                    instrument, type_class=Type.Instrument)[0].getFullName()
+                instrumentFullName = \
+                    self.macro.getInstrument(instrument).getFullName()
             except InterruptException:
                 raise
             except Exception:
@@ -822,7 +822,7 @@ class GScan(Logger):
             env['ScanDir'] = None
         env['estimatedtime'], env['total_scan_intervals'] = self._estimate()
         env['instrumentlist'] = self.macro.findObjs(
-            '.*', type_class=Type.Instrument)
+            '.*', type_class=Type.Instrument, reserve=False)
 
         # env.update(self._getExperimentConfiguration) #add all the info from
         # the experiment configuration to the environment


### PR DESCRIPTION
Today @tiagocoutinho reported that scans, when get stopped, stop all the instruments present in the Pool. Then in the Spock we could see something like this:

```
Stopping /monitor reserved by dscanc
Stopping /mirror reserved by dscanc
Stopping /slit reserved by dscanc
```

GScan reserve instruments for the scanning macro when it simply
looks for the instruments information e.g. full names. This makes
the MacroExecutor to stop the instruments when the macro is
being stopped as it would do with any other reserved object.

Do not reserve instruments cause it does not make sense to stop
them when stopping the macro.