### PR TITLE
Stop motion only once in scans

### DIFF
--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1068,11 +1068,6 @@ class MacroExecutor(Logger):
         self._door = door
         self._macro_counter = 0
 
-        # dict<PoolElement, set<Macro>>
-        # key PoolElement - reserved object
-        # value set<Macro> macros that reserved the object
-        self._reserved_objs = {}
-
         # dict<Macro, seq<PoolElement>>
         # key Macro - macro object
         # value - sequence of reserverd objects by the macro
@@ -1551,11 +1546,6 @@ class MacroExecutor(Logger):
                        macro script
         :return: (lxml.etree.Element) the xml representation of the running macro
         """
-        # dict<PoolElement, set<Macro>>
-        # key PoolElement - reserved object
-        # value set<Macro> macros that reserved the object
-        self._reserved_objs = {}
-
         # dict<Macro, seq<PoolElement>>
         # key Macro - macro object
         # value - sequence of reserved objects by the macro
@@ -1823,10 +1813,6 @@ class MacroExecutor(Logger):
             else:
                 objs.append(obj)
 
-        # Fill _reserved_objs
-        macros = self._reserved_objs[obj] = self._reserved_objs.get(obj, set())
-        macros.add(macro_obj)
-
         # Tell the object that it is reserved by a new macro
         if hasattr(obj, 'reserve'):
             obj.reserve(macro_obj)
@@ -1858,11 +1844,3 @@ class MacroExecutor(Logger):
         objs.remove(obj)
         if len(objs) == 0:
             del self._reserved_macro_objs[macro_obj]
-
-        try:
-            macros = self._reserved_objs[obj]
-            macros.remove(macro_obj)
-            if not len(macros):
-                del self._reserved_objs[obj]
-        except KeyError:
-            self.debug("Unexpected KeyError trying to remove reserved object")

--- a/src/sardana/taurus/core/tango/sardana/motion.py
+++ b/src/sardana/taurus/core/tango/sardana/motion.py
@@ -259,6 +259,13 @@ class Motion(BaseMotion):
     def __str__(self):
         return self.__class__.__name__ + "(" + str(self.names) + ")"
 
+    def __eq__(self, other):
+        if not hasattr(other, "_moveable_full_name_list"):
+            return False
+        else:
+            return set(self._moveable_full_name_list) \
+                   == set(other._moveable_full_name_list)
+
     def init_by_movables(self, elements, moveable_srcs, allow_repeat, allow_unknown):
         # TODO: Optimize this. Dont call init_by_names. It its possible to do it
         # manually with some performance gain
@@ -295,6 +302,7 @@ class Motion(BaseMotion):
 
         # list<Moveable>
         self.moveable_list = moveable_list
+        self._moveable_full_name_list = [m.full_name for m in moveable_list]
 
         # list<tuple(int moveable_index, int position_index)>
         # the list index itself is the position index for this motion


### PR DESCRIPTION
https://github.com/sardana-org/sardana/issues/1578#issue-876870113 explains a failed attempt to implement an equality check on the `Motion` class in order to avoid reserving different `Motion` objects pointing to the same moveables multiple times:

>  I tried to Implement the `__eq__()` method in the `Motion` class so we could discover _duplicates_ in https://github.com/sardana-org/sardana/blob/74f3e1ad46b19665c8d206782c19e02fdaf76ba9/src/sardana/macroserver/msmacromanager.py#L1820 but this does not help. This is because, in other places in the code, we assume that this class is hashable e.g. we use its objects as keys in the dictionaries.

It appeared that the said dict is not used anywhere in the code. In order to fix #1578 I propose to remove this dict in 9595940 and then implement the equality check in 339e051. 

Fixes #1578

```
Door/zreszela/1 [4]: dscanc mot01 -100 100 0.1 0.1
Operation will be saved in /tmp/foo.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #69 started at Thu May  6 11:41:47 2021. It will take at least 0:00:30.491421
 #Pt No    mot01      ct01      ct02      ct03      ct04       dt   
   0      -100.499    0.1       0.2       0.3       0.4     1.23456 
   1      -98.8527    0.1       0.2       0.3       0.4     1.37602 
   2      -97.7824    0.1       0.2       0.3       0.4     1.49142 
   3      -96.7154    0.1       0.2       0.3       0.4     1.60656 
   4      -95.6631    0.1       0.2       0.3       0.4      1.7296 
   5      -94.6033    0.1       0.2       0.3       0.4     1.84293 
   6      -93.5582    0.1       0.2       0.3       0.4     1.95627 
   7      -92.4955    0.1       0.2       0.3       0.4     2.06997 
   8      -91.4424    0.1       0.2       0.3       0.4     2.18491 
   9      -90.3777    0.1       0.2       0.3       0.4     2.29937 
   10     -88.2685    0.1       0.2       0.3       0.4     2.42388 
   11     -87.2058    0.1       0.2       0.3       0.4     2.53739 
   12     -86.1511    0.1       0.2       0.3       0.4     2.64982 
^C
Ctrl-C received: Stopping...
Stopping Motion(['mot01']) reserved by dscanc
Motion(['mot01']) stopped
Stopping mntgrp01 reserved by dscanc
mntgrp01 stopped
Operation saved in /tmp/foo.h5 (HDF5::NXscan)
Scan #69 ended at Thu May  6 11:41:50 2021, taking 0:00:02.877715. Dead time 100.0% (motion dead time 0.0%)
Returning to start positions...
Executing dscanc.on_stop method...
Stopping done!

```

If this solution does not work or you see it problematic, we could explore other options e.g. the ones listed in https://github.com/sardana-org/sardana/issues/1578#issue-876870113.