### PR TITLE
bump taurus requirement to >= 4.7.1.1 on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ install_requires = [
     'PyTango>=9.2.5',
     'itango>=0.1.6',
     'taurus>=4.7.0',
+    'taurus>=4.7.1.1 ; platform_system=="Windows"',
     'lxml>=2.3',
     'click',
 ]


### PR DESCRIPTION
#724, #540 requires taurus >= 4.7.1
#1077, #540 requires taurus >= 4.7.1.1

Tested:
- on Linux, installing with pip (in a conda environment) where taurus 4.7.0 was available and pip considered this version as satisfactory
- on Windows, installing with pip (on Python installed with the exe installer from python.org) where taurus 4.7.0 was available and pip considered this version as **not satisfactory** and performed the upgrade