### PR TITLE
Add "What's new?" section to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the formats and conventions from [keepachangelog.com]
 
-## [3.1.0] 2021-03-30
+## [3.1.0] 2021-05-17
 
 ### Added
 
@@ -33,7 +33,7 @@ This file follows the formats and conventions from [keepachangelog.com]
 * Assert motor sign is -1 or 1 (#1345, #1507)
 * _last macro_ concept to the `MacroExecutor` (kernel) #1559
 * Documentation on how to write 1D and 2D controllers (#1494)
-* Machanism to call `SardanaDevice.sardana_init_hook()` before entering in the server event loop (#674, #1545)
+* Mechanism to call `SardanaDevice.sardana_init_hook()` before entering in the server event loop (#674, #1545)
 * Missing documentation of SEP18 concepts to how-to counter/timer controller (#995, #1492)
 * Document how to properly deal with exceptions in macros in order to not interfer 
   with macro stopping/aborting (#1461)
@@ -43,6 +43,18 @@ This file follows the formats and conventions from [keepachangelog.com]
 * More clear installation instructions (#727, #1580)
 * napoleon extension to the sphinx configuration (#1533)
 * LICENSE file to python source distribution (#1490)
+
+### Changed
+
+* Experimental channel shape is now considered as a result of the configuration
+  and not part of the measurement group configuration (#1296, #1466)
+* Use `LatestDeviceImpl` (currently `Device_5Impl`) for as a base class of the Sardana Tango
+  devices (#1214, #1301, #1531)
+* Read experimental channel's `value` in serial mode to avoid involvement of a worker thread (#1512)
+
+### Removed
+
+* `shape` from the measurement group configuration and `expconf` (#1296, #1466)
 
 ### Fixed
 
@@ -87,20 +99,8 @@ This file follows the formats and conventions from [keepachangelog.com]
 * Skip execution of Pool's `DeleteElement` Tango command in tests for Windows in order to
   avoid server crashes (#540, #1567)
 * Skip QtSpock `test_get_value` test if qtconsole >= 4.4.0 (#1564)
-* More clear installation instructions (#727, #1580)
 * Increase timeout for QtSpock tests (#1568)
 
-### Changed
-
-* Experimental channel shape is now considered as a result of the configuration
-  and not part of the measurement group configuration (#1296, #1466)
-* Use `LatestDeviceImpl` (currently `Device_5Impl`) for as a base class of the Sardana Tango
-  devices (#1214, #1301, #1531)
-* Read experimental channel's `value` in serial mode to avoid involvement of a worker thread (#1512)
-
-### Removed
-
-* `shape` from the measurement group configuration and `expconf` (#1296, #1466)
 
 ## [3.0.3] 2020-09-18
 

--- a/doc/source/devel/howto_controllers/howto_1dcontroller.rst
+++ b/doc/source/devel/howto_controllers/howto_1dcontroller.rst
@@ -1,13 +1,10 @@
 .. currentmodule:: sardana.pool.controller
 
-.. _sardana-1dcontroller-howto-basics:
+.. _sardana-1dcontroller-howto:
 
 ============================
 How to write a 1D controller
 ============================
-
-The basics
-----------
 
 This chapter provides the necessary information to write a one dimensional (1D)
 experimental channel controller in Sardana.

--- a/doc/source/docs.rst
+++ b/doc/source/docs.rst
@@ -17,6 +17,7 @@ scientific installations.
    users/index
    devel/index
    sep/index.rst
+   What's new? <news>
    Glossary <glossary>
    other_versions
    

--- a/doc/source/news.rst
+++ b/doc/source/news.rst
@@ -1,0 +1,99 @@
+###########
+What's new?
+###########
+
+Below you will find the most relevant news that brings the Sardana releases.
+For a complete list of changes consult the Sardana `CHANGELOG.md \
+<https://github.com/sardana-org/sardana/blob/develop/CHANGELOG.md>`_ file.
+
+**************************
+What's new in Sardana 3.1?
+**************************
+
+Date: 2021-05-17 (*Jan21* milestone)
+
+Type: biannual stable release
+
+It is backwards compatible and comes with new features, changes and bug fixes.
+
+.. note::
+
+    This release, in comparison to the previous ones, brings significant
+    user experience improvements when used on Windows.
+
+Added
+=====
+
+- *HDF5 write session*, in order to avoid the file locking problems and to introduce
+  the SWMR mode support. It enables safe introspection e.g.: using data
+  analysis tools like PyMCA or silx, custom scripts, etc. of the scan data files
+  written in the `HDF5 data format <https://www.hdfgroup.org/solutions/hdf5/>`_
+  while scanning.
+  You can control the session using e.g.:
+  `~sardana.macroserver.macros.h5storage.h5_start_session` and
+  `~sardana.macroserver.macros.h5storage.h5_end_session` macros
+  or the `~sardana.macroserver.macros.h5storage.h5_write_session`
+  context manager.
+  More information in the :ref:`NXscanH5_FileRecorder documentation \
+  <sardana-users-scan-data-storage-nxscanh5_filerecorder>`
+- *scan information* and *scan point* forms to the *showscan online* widget.
+  See example in the :ref:`showscan online screenshot \
+  <showscan-online-infopanels-figure>`.
+- Handle `pre-move` and `post-move` hooks by: `mv`, `mvr`, `umv`, `umvr`,
+  `br` and `ubr` macros.
+  You may use `~sardana.sardanacustomsettings.PRE_POST_MOVE_HOOK_IN_MV`
+  for disabling these hooks.
+- Include trigger/gate (synchronizer) elements in the per-measurement preparation.
+  This enables possible dead time optimization in hardware synchronized step scans.
+  More information in the :ref:`How to write a trigger/gate controller documentation \
+  <sardana-TriggerGateController-howto-prepare>`.
+- :ref:`scanuser` environment variable.
+- Support to `PosFormat` :ref:`ViewOption <sardana-spock-viewoptions>` in `umv` macro.
+- Avoid double printing of user units in :ref:`pmtv`: read widget and
+  units widget.
+- Print of allowed :ref:`sardana-macros-hooks` when :ref:`sardana-spock-gettinghelp`
+  on macros in Spock.
+- Documentation:
+
+    - :ref:`sardana-1dcontroller-howto` and :ref:`sardana-2dcontroller-howto`
+    - :ref:`sardana-countertimercontroller` now contains the `SEP18 \
+      <http://www.sardana-controls.org/sep/?SEP18.md>`_ concepts.
+    - Properly :ref:`sardana-macro-exception-handling` in macros in order
+      to not interfere with macro stopping/aborting
+    - :ref:`faq_how_to_access_tango_from_macros_and_controllers`
+    - Update :ref:`Installation instructions <sardana-installing>`
+
+Changed
+=======
+
+- Experimental channel's shape is now considered as a result of the configuration
+  e.g. RoI, binning, etc. and not part of the measurement group configuration:
+
+  - Added :ref:`shape controller axis parameter (plugin) <sardana-2dcontroller-general-guide-shape>`,
+    `shape` experimental channel attribute (kernel)
+    and `Shape` Tango attribute to the experimental channels
+  - **Removed** the *shape* column from the measurement group's configuration panel
+    in :ref:`expconf_ui`.
+
+Fixed
+=====
+
+- Sardana server (standalone) startup is more robust.
+- Storing string values in *datasets*, *pre-scan snapshot* and *custom data*
+  in :ref:`sardana-users-scan-data-storage-nxscanh5_filerecorder`.
+- Stopping/aborting grouped movement when backlash correction would be applied.
+- Randomly swapping target positions in grouped motion when moveables proceed
+  from various Device Pool's.
+- Enables possible dead time optimization in `mesh` scan macro by executing
+  :ref:`per measurement preparation <sardana-macros-scanframework-determscan>`.
+- Continuously read experimental channel's value references in hardware
+  synchronized acquisition instead of reading only once at the end.
+- Problems when :ref:`sardana-controller-howto-change-default-interface` of standard attributes
+  in controllers e.g. shape of the pseudo counter's Value attribute.
+- :ref:`sequencer_ui` related bugs:
+
+    * Fill Macro's `parent_macro` in case of executing XML hooks in sequencer
+    * Problems with macro id's when executing sequences loaded from *plain text* files with spock syntax
+    * Loading of sequences using macro functions from *plain text* files with spock syntax
+- Apply position formatting (configured with `PosFormat`
+  :ref:`ViewOption <sardana-spock-viewoptions>`) to the limits in the `wm` macro.

--- a/doc/source/users/faq.rst
+++ b/doc/source/users/faq.rst
@@ -92,6 +92,8 @@ write Sardana controllers and pseudo controllers can be found
 This documentation also includes the :term:`API` which can be used to interface
 to the specific hardware item.
 
+.. _faq_how_to_access_tango_from_macros_and_controllers:
+
 How to access Tango from within macros or controllers
 --------------------------------------------------------------------------------
 In your macros and controllers almost certainly you will need to access Tango

--- a/doc/source/users/spock.rst
+++ b/doc/source/users/spock.rst
@@ -231,6 +231,8 @@ Exiting spock
 
 To exit spock type :kbd:`Control+d` or :samp:`exit()` inside a spock console.
 
+.. _sardana-spock-gettinghelp:
+
 Getting help
 ------------
 
@@ -478,6 +480,8 @@ Example accesing scan data:
 .. |br| raw:: html
 
     <br>
+
+.. _sardana-spock-viewoptions:
 
 Changing appearance with View Options
 -------------------------------------

--- a/doc/source/users/taurus/poolchanneltv.rst
+++ b/doc/source/users/taurus/poolchanneltv.rst
@@ -1,3 +1,5 @@
+.. _pctv:
+
 PoolChannelTV User’s Interface
 ------------------------------
 

--- a/doc/source/users/taurus/poolmotortv.rst
+++ b/doc/source/users/taurus/poolmotortv.rst
@@ -1,3 +1,5 @@
+.. _pmtv:
+
 PoolMotorTV User’s Interface
 -----------------------------
 

--- a/doc/source/users/taurus/showscan.rst
+++ b/doc/source/users/taurus/showscan.rst
@@ -53,6 +53,8 @@ and offer online updates on the channel values of the current scan point
 and some general scan information e.g. scan file, start and end time, etc.
 respectively.
 
+.. _showscan-online-infopanels-figure:
+
 .. figure:: /_static/showscan-online-infopanels.png
 
     Showscan online plotting with separate plots and information panels.


### PR DESCRIPTION
The need for this section was identified in https://github.com/sardana-org/sardana-followup/issues/32.
The format was not decided at that time. The last release provided it in the [GitHub release description](https://github.com/sardana-org/sardana/releases/tag/3.0.3). This time I tried another approach and add it to the docs directly.
IMHO it is better cause it unifies the news with the docs making them easier to discover.

Here is how it looks:

![sardana_news](https://user-images.githubusercontent.com/6735649/118269005-708ce580-b4be-11eb-9191-d49867b613b2.png)
