### PR TITLE
Correctly evaluate MeasurementGroup state 

### DIFF
--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -665,6 +665,8 @@ class PoolAcquisition(PoolAction):
         ret.update(self._0d_acq.get_pool_controllers())
         return ret
 
+    pool_controllers = property(get_pool_controllers)
+
     def read_value(self, ret=None, serial=False):
         """Reads value information of all elements involved in this action
 


### PR DESCRIPTION
Make the measurement group state to be correctly evaluated based on the elements present in the measurement group's acquisition sub-actions. This correctly evaluates state of only the enabled elements.

Fixes #1316.