### PR TITLE
Do not try to start operation when state is Moving

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -478,7 +478,10 @@ class PoolElement(BaseElement, TangoDevice):
         evt_wait = self._getEventWait()
         evt_wait.connect(self.getAttribute("state"))
         try:
-            evt_wait.waitEvent(DevState.MOVING, equal=False)
+            if not evt_wait.waitEvent(DevState.MOVING, equal=False,
+                                      timeout=1.5, retries=1):
+                raise RuntimeError(
+                    "{} is Moving, can not proceed to start".format(self.name))
             # Clear event set to not confuse the value coming from the
             # connection with the event of of end of the operation
             # in the next wait event. This was observed on Windows where


### PR DESCRIPTION
Operations, like for example motion or acquisition, are attempted to start
even if the element is already Moving. Early recognize this situation
on the client and raise an exception before requesting start to the server.

**Dependencies:**
- #1591
- [taurus-org/taurus!1191](https://gitlab.com/taurus-org/taurus/-/merge_requests/1191)

I have tested it with the following _buggy_ dummy counter/timer:

```diff
diff --git a/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py b/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
index eab5cf141..28b8e3284 100644
--- a/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
+++ b/src/sardana/pool/poolcontrollers/DummyCounterTimerController.py
@@ -79,6 +79,7 @@ class DummyCounterTimerController(CounterTimerController):
         self.__synchronizer_obj = None
         # flag whether the controller was armed for hardware synchronization
         self._armed = False
+        self._started = False
 
     def AddDevice(self, axis):
         idx = axis - 1
@@ -130,6 +131,7 @@ class DummyCounterTimerController(CounterTimerController):
             self._armed = True
         else:
             self.start_time = time.time()
+        self._started = True
 
     def StateOne(self, axis):
         self._log.debug('StateOne(%d): entering...' % axis)
@@ -147,6 +149,8 @@ class DummyCounterTimerController(CounterTimerController):
             if channel.is_counting:
                 sta = State.Moving
                 status = "Acquiring"
+        if self._started:
+            sta, status = State.Moving, 'Hardware hung in Moving state'
         ret = (sta, status)
         self._log.debug('StateOne(%d): returning %s' % (axis, repr(ret)))
         return sta, status
```

The results are as following:

```
Door/zreszela/1 [1]: ct 1
Wed May 19 21:58:10 2021

^C
Ctrl-C received: Stopping...
Stopping mntgrp01 reserved by ct
^C2nd Ctrl-C received: Aborting...
Unable to stop mntgrp01
Aborting mntgrp01 reserved by ct
^C3rd Ctrl-C received: Releasing...
Unable to abort mntgrp01
Executing ct.on_abort method...
Releasing done!

Door/zreszela/1 [2]: ct 1
Wed May 19 21:58:21 2021

Elements ended acquisition with:
ct01:
       State: Moving (21:58:24.664283)
      Status: ct01 is Moving
              Hardware hung in Moving state (21:58:24.665884)
An error occurred while running ct:
RuntimeError: mntgrp01 is Moving, can not proceed to start
Hint: in Spock execute `www` to get more details
```

Here we can see how the first count acquisition hangs forever. We try to stop the macro which tries to stop the measurement group without success. Then we try to abort, again, without success. Finally, we release the macro.
The next attempt to count, waits for 3 s, and raises RuntimeError: mntgrp01 is Moving, can not proceed to start.

Then, as described in #1581, the pool acquisition action keeps polling the state, what of course is not desired, but will be treated in #1582. 