### PR TITLE
Use AttributeEventWait.waitForEvent() instead of deprecated AttributeEventWait.waitEvent()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,15 +53,14 @@ provides = [
 requires = [
     'PyTango (>=9.2.5)',
     'itango (>=0.1.6)',
-    'taurus (>= 4.7.0)',
+    'taurus (>= 4.9.0dev0)',
     'lxml (>=2.3)',
 ]
 
 install_requires = [
     'PyTango>=9.2.5',
     'itango>=0.1.6',
-    'taurus>=4.7.0',
-    'taurus>=4.7.1.1 ; platform_system=="Windows"',
+    'taurus >=4.9.0dev0',
     'lxml>=2.3',
     'click',
 ]

--- a/setup.py
+++ b/setup.py
@@ -53,14 +53,14 @@ provides = [
 requires = [
     'PyTango (>=9.2.5)',
     'itango (>=0.1.6)',
-    'taurus (>= 4.9.0dev0)',
+    'taurus (> 4.8.0)',
     'lxml (>=2.3)',
 ]
 
 install_requires = [
     'PyTango>=9.2.5',
     'itango>=0.1.6',
-    'taurus >=4.9.0dev0',
+    'taurus > 4.8.0',
     'lxml>=2.3',
     'click',
 ]

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -474,8 +474,9 @@ class BaseDoor(MacroServerDevice):
         try:
             time_stamp = time.time()
             self.command_inout("AbortMacro")
-            evt_wait.waitEvent(self.Running, equal=False, after=time_stamp,
-                               timeout=self.InteractiveTimeout)
+            evt_wait.waitForEvent((self.Running, ), equal=False,
+                                  after=time_stamp,
+                                  reactivity=self.InteractiveTimeout)
         finally:
             evt_wait.unlock()
             evt_wait.disconnect()
@@ -500,9 +501,9 @@ class BaseDoor(MacroServerDevice):
                 # Macro already finished - no need to release
                 if df.args[0].reason == "API_CommandNotAllowed":
                     return
-            evt_wait.waitEvent(self.Running, equal=False,
-                               after=time_stamp,
-                               timeout=self.InteractiveTimeout)
+            evt_wait.waitForEvent((self.Running, ), equal=False,
+                                  after=time_stamp,
+                                  reactivity=self.InteractiveTimeout)
         finally:
             evt_wait.unlock()
             evt_wait.disconnect()
@@ -517,8 +518,9 @@ class BaseDoor(MacroServerDevice):
         try:
             time_stamp = time.time()
             self.command_inout("StopMacro")
-            evt_wait.waitEvent(self.Running, equal=False, after=time_stamp,
-                               timeout=self.InteractiveTimeout)
+            evt_wait.waitForEvent((self.Running, ), equal=False,
+                                  after=time_stamp,
+                                  reactivity=self.InteractiveTimeout)
         finally:
             evt_wait.unlock()
             evt_wait.disconnect()
@@ -598,7 +600,8 @@ class BaseDoor(MacroServerDevice):
         evt_wait.connect(self.getAttribute("state"))
         evt_wait.lock()
         try:
-            evt_wait.waitEvent(self.Running, equal=False, timeout=timeout)
+            evt_wait.waitForEvent((self.Running, ), equal=False,
+                                  reactivity=timeout)
             # Clear event set to not confuse the value coming from the
             # connection with the event of of end of the macro execution
             # in the next wait event. This was observed on Windows where
@@ -608,10 +611,11 @@ class BaseDoor(MacroServerDevice):
             result = self.command_inout("RunMacro",
                                         [etree.tostring(xml,
                                                         encoding='unicode')])
-            evt_wait.waitEvent(self.Running, after=ts, timeout=timeout)
+            evt_wait.waitForEvent((self.Running, ), after=ts,
+                                  reactivity=timeout)
             if synch:
-                evt_wait.waitEvent(self.Running, equal=False, after=ts,
-                                   timeout=timeout)
+                evt_wait.waitForEvent((self.Running, ), equal=False, after=ts,
+                                      reactivity=timeout)
         finally:
             self._clearRunMacro()
             evt_wait.unlock()

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -478,8 +478,8 @@ class PoolElement(BaseElement, TangoDevice):
         evt_wait = self._getEventWait()
         evt_wait.connect(self.getAttribute("state"))
         try:
-            if not evt_wait.waitEvent(DevState.MOVING, equal=False,
-                                      timeout=1.5, retries=1):
+            if not evt_wait.waitForEvent((DevState.MOVING, ), equal=False,
+                                         timeout=3, reactivity=.1):
                 raise RuntimeError(
                     "{} is Moving, can not proceed to start".format(self.name))
             # Clear event set to not confuse the value coming from the
@@ -491,7 +491,7 @@ class PoolElement(BaseElement, TangoDevice):
             self.__go_start_time = ts1 = time.time()
             self._start(*args, **kwargs)
             ts2 = time.time()
-            evt_wait.waitEvent(DevState.MOVING, after=ts1)
+            evt_wait.waitForEvent((DevState.MOVING, ), after=ts1)
         except:
             evt_wait.disconnect()
             raise
@@ -506,22 +506,12 @@ class PoolElement(BaseElement, TangoDevice):
         :param id: id of the opertation returned by start
         :type id: tuple(float)
         """
-        if timeout is None:
-            # 0.1 s of timeout with infinite retries facilitates aborting
-            # by raising exceptions from a different threads
-            timeout = 0.1
-            retries = -1
-        else:
-            # Due to taurus-org/taurus #573 we need to divide the timeout
-            # in two intervals
-            timeout = timeout / 2
-            retries = 1
         if id is not None:
             id = id[0]
         evt_wait = self._getEventWait()
         try:
-            evt_wait.waitEvent(DevState.MOVING, after=id, equal=False,
-                               timeout=timeout, retries=retries)
+            evt_wait.waitForEvent((DevState.MOVING, ), after=id, equal=False,
+                                  timeout=timeout, reactivity=0.1)
         finally:
             self.__go_end_time = time.time()
             self.__go_time = self.__go_end_time - self.__go_start_time
@@ -1045,7 +1035,7 @@ class Motor(PoolElement, Moveable):
         evt_wait.connect(state)
         evt_wait.lock()
         try:
-            # evt_wait.waitEvent(DevState.MOVING, equal=False)
+            # evt_wait.waitForEvent((DevState.MOVING, ), equal=False)
             time_stamp = time.time()
             try:
                 self.getPositionObj().write(new_pos)
@@ -1059,8 +1049,8 @@ class Motor(PoolElement, Moveable):
             # putting timeout=0.1 and retries=1 is a patch for the case when
             # the initial moving event doesn't arrive do to an unknown
             # tango/pytango error at the time
-            evt_wait.waitEvent(DevState.MOVING, time_stamp,
-                               timeout=0.1, retries=1)
+            evt_wait.waitForEvent((DevState.MOVING, ), time_stamp,
+                                  timeout=0.2, reactivity=0.1)
         finally:
             evt_wait.unlock()
             evt_wait.disconnect()


### PR DESCRIPTION
`AttributeEventWait.waitEvent()` use non-intuitive API and showed to be buggy - see [taurus-org/taurus#573](https://gitlab.com/taurus-org/taurus/-/issues/573) and
[taurus-org/taurus!1191](https://gitlab.com/taurus-org/taurus/-/merge_requests/1191).
Use an improved method `AttributeEventWait.waitForEvent()`.

Bump taurus version requirement.

Note, this PR is urgent to be reviewed and eventually merged since after the premature merge of https://github.com/sardana-org/sardana/pull/1592 currently the develop branch is in a broken state.