### PR TITLE
Allow to start PoolElement only when it is in On or Alarm states

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -478,7 +478,7 @@ class PoolElement(BaseElement, TangoDevice):
         evt_wait = self._getEventWait()
         evt_wait.connect(self.getAttribute("state"))
         try:
-            if not evt_wait.waitForEvent((DevState.MOVING, ), equal=False,
+            if not evt_wait.waitForEvent((DevState.ON, DevState.ALARM),
                                          timeout=3, reactivity=.1):
                 raise RuntimeError(
                     "{} is Moving, can not proceed to start".format(self.name))


### PR DESCRIPTION
PoolElement can can try to start when its state is different than
Moving. This tries to start elements in Fault state as well
what can hang the server, for example, in the case of
the measurement group. See discussion in #1316. Allow to start
the PoolElement only if it is in On or Alarm state.