### PR TITLE
Add devcontainer for VS Code - Remote Containers

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,0 +1,3 @@
+DOCKER_REGISTRY_HOST=nexus.engageska-portugal.pt
+DOCKER_REGISTRY_USER=ska-docker
+CONTAINER_NAME_PREFIX=sardana_dev_

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,10 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [],
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance"
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,5 +39,5 @@
 	// "postCreateCommand": "apt-get update && apt-get install -y curl",
 
 	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/docker-existing-docker-compose
+// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+{
+	"name": "Existing Docker Compose (Extend)",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "sardana_dev",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspace",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": null
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     hostname: sardana
     environment:
       TANGO_HOST: databaseds:10000
+      DISPLAY: "unix:0"
     build:
       context: ./sardana_dev
       args: 
@@ -32,6 +33,7 @@ services:
       - sardana
     volumes:
       - ..:/workspace:cached
+      - /tmp/.X11-unix:/tmp/.X11-unix
     command: /bin/sh -c "while sleep 1000; do :; done"
   tangodb:
     image: ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/tango-db:latest

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       TANGO_HOST: databaseds:10000
     build:
       context: ./sardana_dev
+      args: 
+        INSTALL_NODE: false
     cap_add:
         - SYS_PTRACE
     security_opt:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,87 @@
+# 
+# Docker compose file for Sardana development with TANGO database and database device server
+#
+# Defines:
+#   - sardana_dev: A development sardana machine with all dependencies already installed
+#   - tangodb: MariaDB database with TANGO schema
+#   - databaseds: TANGO database device server
+#   - tangotest: A useful DeviceServer to do tests.
+
+version: '3'
+
+volumes:
+  tangodb: {}
+
+networks:
+  sardana:
+
+services:
+  sardana_dev:
+    hostname: sardana
+    environment:
+      TANGO_HOST: databaseds:10000
+    build:
+      context: ./sardana_dev
+    cap_add:
+        - SYS_PTRACE
+    security_opt:
+        - seccomp:unconfined
+    networks:
+      - sardana
+    volumes:
+      - ..:/workspace:cached
+    command: /bin/sh -c "while sleep 1000; do :; done"
+  tangodb:
+    image: ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/tango-db:latest
+    container_name: ${CONTAINER_NAME_PREFIX}tangodb
+    networks:
+      - sardana
+    environment:
+        - MYSQL_ROOT_PASSWORD=secret
+        - MYSQL_DATABASE=tango
+        - MYSQL_USER=tango
+        - MYSQL_PASSWORD=tango
+    volumes:
+        - tangodb:/var/lib/mysql
+    restart: on-failure
+
+  databaseds:
+    image: ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/tango-cpp:latest
+    container_name: ${CONTAINER_NAME_PREFIX}databaseds
+    networks:
+      - sardana
+    depends_on:
+        - tangodb
+    environment:
+        - MYSQL_HOST=tangodb:3306
+        - MYSQL_DATABASE=tango
+        - MYSQL_USER=tango
+        - MYSQL_PASSWORD=tango
+    entrypoint:
+        - /usr/local/bin/wait-for-it.sh
+        - tangodb:3306
+        - --timeout=30
+        - --strict
+        - --
+        - /usr/local/bin/DataBaseds
+        - "2"
+        - -ORBendPoint
+        - giop:tcp::10000
+    restart: on-failure
+  
+  tangotest:
+    image: ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/tango-java:latest
+    container_name: ${CONTAINER_NAME_PREFIX}tangotest
+    networks:
+      - sardana
+    environment:
+      - TANGO_HOST=databaseds:10000
+    entrypoint:
+      - /usr/local/bin/wait-for-it.sh
+      - databaseds:10000
+      - --timeout=30
+      - --strict
+      - --
+      - /usr/local/bin/TangoTest
+      - test
+    restart: on-failure

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     build:
       context: ./sardana_dev
       args: 
-        INSTALL_NODE: false
+        INSTALL_NODE: "false"
     cap_add:
         - SYS_PTRACE
     security_opt:

--- a/.devcontainer/sardana_dev/Dockerfile
+++ b/.devcontainer/sardana_dev/Dockerfile
@@ -17,6 +17,6 @@ RUN micromamba install -y -n base -f /root/environment.yml && micromamba clean -
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends pkg-config make build-essential \
-    iputils-ping git
+    iputils-ping git libgl1-mesa-glx
 
 # RUN sed -i 's/${gitbranch}//'  /root/.bashrc

--- a/.devcontainer/sardana_dev/Dockerfile
+++ b/.devcontainer/sardana_dev/Dockerfile
@@ -6,6 +6,12 @@ FROM mambaorg/micromamba:0.13.1
 
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends pkg-config make build-essential \
+    iputils-ping git libgl1-mesa-glx
+
 COPY environment.yml /root/environment.yml
 # RUN micromamba env update -n base -f /root/environment.yml && rm /root/environment.yml
 RUN micromamba install -y -n base -f /root/environment.yml && micromamba clean --all --yes
@@ -13,10 +19,5 @@ RUN micromamba install -y -n base -f /root/environment.yml && micromamba clean -
 # RUN conda install -y python=3.6 \
 #     && pip install --no-cache-dir pipx \
 #     && pipx reinstall-all
-
-# [Optional] Uncomment this section to install additional OS packages.
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends pkg-config make build-essential \
-    iputils-ping git libgl1-mesa-glx
 
 # RUN sed -i 's/${gitbranch}//'  /root/.bashrc

--- a/.devcontainer/sardana_dev/Dockerfile
+++ b/.devcontainer/sardana_dev/Dockerfile
@@ -1,13 +1,14 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.155.1/containers/python-3-miniconda/.devcontainer/base.Dockerfile
 
-FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
+FROM mambaorg/micromamba:0.13.1
+
+# RUN conda install mamba -n base -c conda-forge --yes
 
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
-COPY environment.yml /tmp/conda-tmp/
-RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
-    && rm -rf /tmp/conda-tmp
-
+COPY environment.yml /root/environment.yml
+# RUN micromamba env update -n base -f /root/environment.yml && rm /root/environment.yml
+RUN micromamba install -y -n base -f /root/environment.yml && micromamba clean --all --yes
 # [Optional] Uncomment to install a different version of Python than the default
 # RUN conda install -y python=3.6 \
 #     && pip install --no-cache-dir pipx \
@@ -15,7 +16,7 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env up
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends pkg-config make build-essential iputils-ping
+    && apt-get -y install --no-install-recommends pkg-config make build-essential \
+    iputils-ping git
 
-RUN conda init bash
-RUN sed -i 's/${gitbranch}//'  /root/.bashrc
+# RUN sed -i 's/${gitbranch}//'  /root/.bashrc

--- a/.devcontainer/sardana_dev/Dockerfile
+++ b/.devcontainer/sardana_dev/Dockerfile
@@ -2,11 +2,6 @@
 
 FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
-
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
 COPY environment.yml /tmp/conda-tmp/

--- a/.devcontainer/sardana_dev/Dockerfile
+++ b/.devcontainer/sardana_dev/Dockerfile
@@ -17,4 +17,5 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env up
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends pkg-config make build-essential iputils-ping
 
-RUN su vscode -c "conda init bash"
+RUN conda init bash
+RUN sed -i 's/${gitbranch}//'  /root/.bashrc

--- a/.devcontainer/sardana_dev/Dockerfile
+++ b/.devcontainer/sardana_dev/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends pkg-config make build-essential \
     iputils-ping git libgl1-mesa-glx
 
-COPY environment.yml /root/environment.yml
+ADD environment.yml /root/
 # RUN micromamba env update -n base -f /root/environment.yml && rm /root/environment.yml
 RUN micromamba install -y -n base -f /root/environment.yml && micromamba clean --all --yes
 # [Optional] Uncomment to install a different version of Python than the default

--- a/.devcontainer/sardana_dev/Dockerfile
+++ b/.devcontainer/sardana_dev/Dockerfile
@@ -1,0 +1,25 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.155.1/containers/python-3-miniconda/.devcontainer/base.Dockerfile
+
+FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# Copy environment.yml (if found) to a temp locaition so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+COPY environment.yml /tmp/conda-tmp/
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+    && rm -rf /tmp/conda-tmp
+
+# [Optional] Uncomment to install a different version of Python than the default
+# RUN conda install -y python=3.6 \
+#     && pip install --no-cache-dir pipx \
+#     && pipx reinstall-all
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends pkg-config make build-essential iputils-ping
+
+RUN su vscode -c "conda init bash"

--- a/.devcontainer/sardana_dev/environment.yml
+++ b/.devcontainer/sardana_dev/environment.yml
@@ -9,4 +9,7 @@ dependencies:
   - pip=21.1
   - taurus
   - itango
+  - pyqtgraph
+  - matplotlib
+  - h5py
 prefix: /opt/conda

--- a/.devcontainer/sardana_dev/environment.yml
+++ b/.devcontainer/sardana_dev/environment.yml
@@ -1,0 +1,11 @@
+name: base
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.8.5
+  - pytango=9.3.3
+  - boost
+  - boost-cpp
+  - pip=21.1
+prefix: /opt/conda

--- a/.devcontainer/sardana_dev/environment.yml
+++ b/.devcontainer/sardana_dev/environment.yml
@@ -7,9 +7,11 @@ dependencies:
   - boost
   - boost-cpp
   - pip=21.1
-  - taurus
   - itango
   - pyqtgraph
   - matplotlib
   - h5py
+  - pip:
+    # Temporarily install taurus from repo to include MR!1191
+    - git+https://gitlab.com/taurus-org/taurus.git@9a3043ad
 prefix: /opt/conda

--- a/.devcontainer/sardana_dev/environment.yml
+++ b/.devcontainer/sardana_dev/environment.yml
@@ -8,4 +8,6 @@ dependencies:
   - boost
   - boost-cpp
   - pip=21.1
+  - pip:
+    - pydevd=2.4.1
 prefix: /opt/conda

--- a/.devcontainer/sardana_dev/environment.yml
+++ b/.devcontainer/sardana_dev/environment.yml
@@ -1,6 +1,5 @@
 name: base
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.8.5
@@ -8,6 +7,6 @@ dependencies:
   - boost
   - boost-cpp
   - pip=21.1
-  - pip:
-    - pydevd=2.4.1
+  - taurus
+  - itango
 prefix: /opt/conda

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Users\\sunlo\\AppData\\Local\\Programs\\Python\\Python39\\python.exe"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "C:\\Users\\sunlo\\AppData\\Local\\Programs\\Python\\Python39\\python.exe"
-}


### PR DESCRIPTION
This adds a docker-compose with four containers, one for the Sardana development with a clean conda environment specified in the file environment.yml and the other 3 related to have a Tango CS (tangodb, databaseds and tangotest).

By default the TANGO_HOST is set to databaseds:10000 but an external Tango DB could be used.