### PR TITLE
Fix: completely clean client side after removing a measurement group

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -3519,6 +3519,13 @@ class Pool(TangoDevice, MoveableSource):
                                   _pool_data=data)
         return obj
 
+    def _delObject(self, element):
+        elem_type = element.getType()
+        if elem_type in ('ControllerClass', 'ControllerLibrary', 'Instrument'):
+            return
+        obj = element.getObj()
+        obj.factory().removeExistingDevice(obj)
+
     def on_elements_changed(self, evt_src, evt_type, evt_value):
         if evt_type == TaurusEventType.Error:
             msg = evt_value
@@ -3553,6 +3560,15 @@ class Pool(TangoDevice, MoveableSource):
             element = self.getElementInfo(element_data['full_name'])
             try:
                 elements.removeElement(element)
+                # Ideally this object should disappear without the need to
+                # call _delObject() - there should be no references to it.
+                # Most probably due to the complex circular references
+                # between the element and its attributes, as it is in the case
+                # of the measurement group, we need to explicitly remove the
+                # object so it does not remain on the client side (Taurus
+                # factory)
+                # See more details in #145, #1528.
+                self._delObject(element)
             except:
                 self.warning("Failed to remove %s", element_data)
         for element_data in elems.get('change', ()):


### PR DESCRIPTION
As said on the last follow-up meeting I recovered on old work (still done together with @amilan many years ago) and tried it again. Indeed with Tango 9 it works like a charm and looks like fixes the said bug. Details below:

MeasurementGroup _proxy_ object resides on the client side after removing it on the server. This leads to inconsistency when one recreates the measurement group using the same name e.g. its list of the channels corresponds to the list of the channels of the previously deleted measurement group.

Explicitly remove the Taurus objects (device and its attributes) from the factory so they do not interfere with the future attempts to recreate objects with the same name.

These are the circular references that I tracked and are explained in the inline comment:

![measurement_group_circular_refs](https://user-images.githubusercontent.com/6735649/121509761-41976000-c9e7-11eb-9145-6b70cfa5a060.jpg)


Fixes #145, #1528.