### PR TITLE
Hotfix 3.1.1: allow to stop/abort macro executing another hooked macro

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 3.1.0
+current_version = 3.1.1-alpha
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 3.1.1-alpha
+current_version = 3.1.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the formats and conventions from [keepachangelog.com]
 
+## [3.1.1] 2021-06-11
+
+### Fixed
+
+* Allow to stop/abort macro executing other hooked macros (#1603, #1608)
+
+### Deprecated
+
+* `MacroExecutor.clearRunningMacro()` in favor of `MacroExecutor.clearMacroStack()` (#1608)
+
 ## [3.1.0] 2021-05-17
 
 ### Added
@@ -1047,6 +1057,7 @@ Main improvements since sardana 1.5.0 (aka Jan15):
 
 
 [keepachangelog.com]: http://keepachangelog.com
+[3.1.1]: https://github.com/sardana-org/sardana/compare/3.1.1...3.1.0
 [3.1.0]: https://github.com/sardana-org/sardana/compare/3.1.0...3.0.3
 [3.0.3]: https://github.com/sardana-org/sardana/compare/3.0.3...2.8.6
 [2.8.6]: https://github.com/sardana-org/sardana/compare/2.8.6...2.8.5

--- a/doc/source/news.rst
+++ b/doc/source/news.rst
@@ -6,6 +6,21 @@ Below you will find the most relevant news that brings the Sardana releases.
 For a complete list of changes consult the Sardana `CHANGELOG.md \
 <https://github.com/sardana-org/sardana/blob/develop/CHANGELOG.md>`_ file.
 
+****************************
+What's new in Sardana 3.1.1?
+****************************
+
+Date: 2021-06-11
+
+Type: hotfix release
+
+Fixed
+=====
+
+- Correctly handle stop/abort of macros e.g. ``Ctrl+c`` in Spock in case
+  the macro was executing another hooked macros e.g. a scan executing a general
+  hook.
+
 **************************
 What's new in Sardana 3.1?
 **************************

--- a/src/sardana/macroserver/msmacromanager.py
+++ b/src/sardana/macroserver/msmacromanager.py
@@ -1602,8 +1602,8 @@ class MacroExecutor(Logger):
         except Exception:
             self.sendState(Macro.Exception)
         finally:
-            self._macro_stack = None
-            self._xml_stack = None
+            self._macro_stack = []
+            self._xml_stack = []
 
     def __runStatelessXML(self, xml=None):
         if xml is None:

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,7 +47,7 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '3.1.0'
+version = '3.1.1-alpha'
 
 description = "instrument control and data acquisition system"
 

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,7 +47,7 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '3.1.1-alpha'
+version = '3.1.1'
 
 description = "instrument control and data acquisition system"
 

--- a/src/sardana/tango/macroserver/Door.py
+++ b/src/sardana/tango/macroserver/Door.py
@@ -173,7 +173,7 @@ class Door(SardanaDevice):
         if self.getRunningMacro():
             self.debug("aborting running macro")
             self.macro_executor.abort()
-            self.macro_executor.clearRunningMacro()
+            self.macro_executor.clearMacroStack()
 
         for handler, filter, format in list(self._handler_dict.values()):
             handler.finish()


### PR DESCRIPTION
#1559 introduced a bug which does not allow to abort macros executing hooked macros. This is because a dedicated `_macro_pointer` is being wrongly invalidated at the end of the `runMacro()` method.

Refactor the concept of _macro_pointer_ - use a property which points to the macro at the `_macro_stack`. This avoids the problem of having to update the `_macro_pointer`.

Deprecate `clearRunningMacro()` in favor of `clearMacroStack()`.

Fixes #1603.

@HEnquist, @13bscsaamjad could you please review and test it? I put a release date for tomorrow. If you merge on another day, before the merge, please update the date of the release in the "What's new?" and in the CHANGELOG.md. Finally, please also continue the [hotfix release process](https://github.com/sardana-org/sardana/wiki/How-to-Hotfix-Sardana) by completing point 6. Thanks!

@teresanunez, also it would be nice if you crosscheck if this is not the same issue you mentioned today on the follow-up. Thanks!

