### PR TITLE
Update MeasurementGroup's Elements property when Configuration attr is written

### DIFF
--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -243,6 +243,10 @@ class MeasurementGroup(PoolGroupDevice):
         else:
             self.measurement_group._config._value_ref_compat = False
         self.measurement_group.set_configuration_from_user(cfg)
+        db = util.get_database()
+        elem_ids = self.measurement_group.user_element_ids
+        data = {"elements": elem_ids}
+        db.put_device_property(self.get_name(), data)
 
     def read_NbStarts(self, attr):
         nb_starts = self.measurement_group.nb_starts


### PR DESCRIPTION
MeasurementGroup's persistent information about elements is stored in two places:
1. Elements property
2. Configuration memorized attribute

The first one is set only once, at the MeasurementGroup creation time. The subsequent
changes of the configuration does not update the Elements property. Update it on the
successful write of the Configurtion attribute in order to maintain them in sync.