### PR TITLE
fix: hang of IPython when macro input gives timeout

### DIFF
--- a/src/sardana/spock/inputhandler.py
+++ b/src/sardana/spock/inputhandler.py
@@ -29,6 +29,9 @@ __all__ = ['SpockInputHandler']
 
 __docformat__ = 'restructuredtext'
 
+import threading
+
+from sardana.util.thread import raise_in_thread
 from sardana.taurus.core.tango.sardana.macroserver import BaseInputHandler
 
 from sardana.spock import genutils
@@ -39,8 +42,10 @@ class SpockInputHandler(BaseInputHandler):
     def __init__(self):
         # don't call super __init__ on purpose
         self._input = genutils.spock_input
+        self._input_thread = None
 
     def input(self, input_data=None):
+        self._input_thread = threading.current_thread()
         if input_data is None:
             input_data = {}
         prompt = input_data.get('prompt')
@@ -58,4 +63,5 @@ class SpockInputHandler(BaseInputHandler):
         return ret
 
     def input_timeout(self, input_data):
-        print("SpockInputHandler input timeout")
+        raise_in_thread(KeyboardInterrupt, self._input_thread)
+        print("Input timeout reached!")

--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -64,6 +64,7 @@ from IPython.utils.io import ask_yes_no as _ask_yes_no
 from IPython.utils.process import arg_split
 from IPython.utils.coloransi import TermColors
 from IPython.terminal.ipapp import TerminalIPythonApp, launch_new_instance
+from prompt_toolkit import prompt as prompt_input
 
 try:
     # IPython 4.x
@@ -168,7 +169,7 @@ def ask_yes_no(prompt, default=None):
 
 
 def spock_input(prompt='',  ps2='... '):
-    return input(prompt)
+    return prompt_input(prompt)
 
 
 def translate_version_str2int(version_str):


### PR DESCRIPTION
When macro input gives timeout then the Spock (IPython) gets hung completely.
It seems to be a bug in IPython - see https://github.com/ipython/ipython/issues/12078.
Use [`prompt_toolkit.prompt()`](https://python-prompt-toolkit.readthedocs.io/en/master/pages/reference.html#prompt_toolkit.shortcuts.prompt) (a dependency of IPython) instead of `input()` and raise an exception in the thread waiting for input when the timeout was reached. This apparently works while `input()` does not react on exceptions sent in this way.

Also change the message in Spock when the timeout is reached so it appears this way:

```
Door/zreszela/1 [3]: question
Answer (y/n) [y] Input timeout reached!
User answered: y
```

instead of:

```
Door/zreszela/1 [4]: question
Answer (y/n) [y] SpockInputHandler input timeout
User answered: y
```
Fixes #1613.

@jairomoldes, could you please test it? Many thanks!