### PR TITLE
Udef checks dependencies

### DIFF
--- a/src/sardana/macroserver/macros/test/test_scanct.py
+++ b/src/sardana/macroserver/macros/test/test_scanct.py
@@ -24,6 +24,7 @@
 ##############################################################################
 
 """Tests for continuous scans (ct-like)"""
+import json
 import time
 import PyTango
 import unittest
@@ -333,6 +334,8 @@ class A2scanctTest(ScanctTest, unittest.TestCase):
         ScanctTest.check_stopped(self)
 
     def tearDown(self):
+        for mg in self.pool.MotorGroupList:
+            self.pool.DeleteElement(json.loads(mg)['name'])
         ScanctTest.tearDown(self)
         unittest.TestCase.tearDown(self)
 
@@ -388,5 +391,7 @@ class MeshctTest(ScanctTest, unittest.TestCase):
         ScanctTest.check_stopped(self)
 
     def tearDown(self):
+        for mg in self.pool.MotorGroupList:
+            self.pool.DeleteElement(json.loads(mg)['name'])
         ScanctTest.tearDown(self)
         unittest.TestCase.tearDown(self)

--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -32,6 +32,7 @@ __all__ = ["Pool"]
 
 __docformat__ = 'restructuredtext'
 
+import gc
 import os.path
 import logging.handlers
 
@@ -557,7 +558,9 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
                 raise Exception("There is no element with name '%s'" % name)
 
         elem_type = elem.get_type()
-
+        dependent_elements = elem.get_dependent_elements()
+        if len(dependent_elements) > 0:
+            gc.collect()
         dependent_elements = elem.get_dependent_elements()
         if len(dependent_elements) > 0:
             raise Exception(

--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -562,9 +562,10 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
         if len(dependent_elements) > 0:
             raise Exception(
                 "The element {} can't be deleted because {} depend on it."
-                "\n\nIf the name of the dependent element starts with" 
-                "'_mg_ms_*' it means that are motor groups, use any tango " 
-                "client (e.g. Jive) to delete them and restart the server."
+                "\n\nIf the name of the dependent element starts with " 
+                "'_mg_ms_*' it means that are motor groups, execute "
+                "DeleteElement(<motor_group_name>) command on the Pool e.g. "
+                "Pool_demo1_1.DeleteElement('_mg_ms_20671_1') in Spock."
                 .format(name, ", ".join(dependent_elements)))
             
         if elem_type == ElementType.Controller:

--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -558,11 +558,13 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
                 raise Exception("There is no element with name '%s'" % name)
 
         elem_type = elem.get_type()
-        
+
         dependent_elements = elem.get_dependent_elements()
         if len(dependent_elements) > 0:
             raise Exception("The element {} can't be deleted because {} depend"
-                " on it.".format(name, ", ".join(dependent_elements)))
+                " on it. '_mg_ms_*' are motor groups, use any tango client"
+                " (e.g. Jive) to delete them and restart server."
+                    .format(name, ", ".join(dependent_elements)))
             
         if elem_type == ElementType.Controller:
             if len(elem.get_elements()) > 0:
@@ -589,6 +591,7 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
         self.fire_event(EventType("ElementDeleted"), elem)
         if hasattr(elem, "get_controller"):
             elem.set_deleted(True)
+
 
     def create_instrument(self, full_name, klass_name, id=None):
         is_root = full_name.count('/') == 1

--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -40,7 +40,6 @@ from taurus.core.util.containers import CaselessDict
 
 from sardana import InvalidId, ElementType, TYPE_ACQUIRABLE_ELEMENTS, \
     TYPE_PSEUDO_ELEMENTS, TYPE_PHYSICAL_ELEMENTS, TYPE_MOVEABLE_ELEMENTS
-from sardana.pool.poolbaseelement import PoolBaseElement
 from sardana.sardanamanager import SardanaElementManager, SardanaIDManager
 from sardana.sardanamodulemanager import ModuleManager
 from sardana.sardanaevent import EventType
@@ -561,11 +560,12 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
 
         dependent_elements = elem.get_dependent_elements()
         if len(dependent_elements) > 0:
-            raise Exception("The element {} can't be deleted because {} depend"
-                " on it. \n\nIf the name of the dependent element starts with" 
+            raise Exception(
+                "The element {} can't be deleted because {} depend on it."
+                "\n\nIf the name of the dependent element starts with" 
                 "'_mg_ms_*' it means that are motor groups, use any tango " 
                 "client (e.g. Jive) to delete them and restart the server."
-                    .format(name, ", ".join(dependent_elements)))
+                .format(name, ", ".join(dependent_elements)))
             
         if elem_type == ElementType.Controller:
             if len(elem.get_elements()) > 0:
@@ -592,7 +592,6 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
         self.fire_event(EventType("ElementDeleted"), elem)
         if hasattr(elem, "get_controller"):
             elem.set_deleted(True)
-
 
     def create_instrument(self, full_name, klass_name, id=None):
         is_root = full_name.count('/') == 1

--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -562,8 +562,9 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
         dependent_elements = elem.get_dependent_elements()
         if len(dependent_elements) > 0:
             raise Exception("The element {} can't be deleted because {} depend"
-                " on it. '_mg_ms_*' are motor groups, use any tango client"
-                " (e.g. Jive) to delete them and restart server."
+                " on it. \n\nIf the name of the dependent element starts with" 
+                "'_mg_ms_*' it means that are motor groups, use any tango " 
+                "client (e.g. Jive) to delete them and restart the server."
                     .format(name, ", ".join(dependent_elements)))
             
         if elem_type == ElementType.Controller:

--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -40,6 +40,7 @@ from taurus.core.util.containers import CaselessDict
 
 from sardana import InvalidId, ElementType, TYPE_ACQUIRABLE_ELEMENTS, \
     TYPE_PSEUDO_ELEMENTS, TYPE_PHYSICAL_ELEMENTS, TYPE_MOVEABLE_ELEMENTS
+from sardana.pool.poolbaseelement import PoolBaseElement
 from sardana.sardanamanager import SardanaElementManager, SardanaIDManager
 from sardana.sardanamodulemanager import ModuleManager
 from sardana.sardanaevent import EventType
@@ -557,6 +558,12 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
                 raise Exception("There is no element with name '%s'" % name)
 
         elem_type = elem.get_type()
+        
+        dependent_elements = elem.get_dependent_elements()
+        if len(dependent_elements) > 0:
+            raise Exception("The element {} can't be deleted because {} depend"
+                " on it.".format(name, ", ".join(dependent_elements)))
+            
         if elem_type == ElementType.Controller:
             if len(elem.get_elements()) > 0:
                 raise Exception("Cannot delete controller with elements. "

--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -560,15 +560,12 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
                 elem = self.get_element(full_name=name)
             except:
                 raise Exception("There is no element with name '%s'" % name)
-
-        # TODO: most probably due to some cycle-reference the psuedo counter
-        #  objects are not being deleted when undefining them, as a workaround
-        #  try to delete them with gc.collect()
-        dependent_elements = elem.get_dependent_elements()
-        for dependent_element in dependent_elements:
-            if dependent_element.get_type() == ElementType.PseudoCounter:
-                gc.collect()
-                break
+        
+        # cycle-reference may exist between the element and a traceback
+        # stored in SardanaValue or SardanaAttribute as a consequence of
+        # getting sys.exc_info() - try to delete them with gc.collect()
+        if elem.has_dependent_elements():
+            gc.collect()
 
         dependent_elements = elem.get_dependent_elements()
         if len(dependent_elements) > 0:

--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -563,13 +563,14 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
             gc.collect()
         dependent_elements = elem.get_dependent_elements()
         if len(dependent_elements) > 0:
+            names = [elem.name for elem in dependent_elements]
             raise Exception(
                 "The element {} can't be deleted because {} depend on it."
                 "\n\nIf the name of the dependent element starts with " 
                 "'_mg_ms_*' it means that are motor groups, execute "
                 "DeleteElement(<motor_group_name>) command on the Pool e.g. "
                 "Pool_demo1_1.DeleteElement('_mg_ms_20671_1') in Spock."
-                .format(name, ", ".join(dependent_elements)))
+                .format(name, ", ".join(names)))
             
         if elem_type == ElementType.Controller:
             if len(elem.get_elements()) > 0:

--- a/src/sardana/pool/poolacquisition.py
+++ b/src/sardana/pool/poolacquisition.py
@@ -561,7 +561,7 @@ class PoolAcquisition(PoolAction):
             # clean also the pseudo counters, even the ones that do not
             # participate directly in the acquisition
             for pseudo_elem in elem.get_pseudo_elements():
-                pseudo_elem.clear_value_buffer()
+                pseudo_elem().clear_value_buffer()
 
         if self._hw_acq_args is not None:
             self._hw_acq._wait()

--- a/src/sardana/pool/poolbasechannel.py
+++ b/src/sardana/pool/poolbasechannel.py
@@ -165,7 +165,7 @@ class PoolBaseChannel(PoolElement):
         """
         for pseudo_element in self._pseudo_elements:
             if pseudo_element() == element:
-                self._pseudo_elements.remove(element)
+                self._pseudo_elements.remove(pseudo_element)
                 if not self.has_pseudo_elements():
                     self.get_value_buffer().persistent = False
                 break

--- a/src/sardana/pool/poolbasechannel.py
+++ b/src/sardana/pool/poolbasechannel.py
@@ -30,6 +30,8 @@ __all__ = ["Value", "PoolBaseChannel"]
 
 __docformat__ = 'restructuredtext'
 
+import weakref
+
 from sardana.sardanadefs import AttrQuality, ElementType
 from sardana.sardanaattribute import SardanaAttribute
 from sardana.sardanabuffer import SardanaBuffer
@@ -40,7 +42,7 @@ from sardana.pool.poolmeasurementgroup import ChannelConfiguration,\
     ControllerConfiguration
 from sardana.sardanaevent import EventType
 from sardana.pool import AcqSynch, AcqMode
-import weakref
+
 
 class ValueBuffer(SardanaBuffer):
 
@@ -107,7 +109,6 @@ class PoolBaseChannel(PoolElement):
 
     def __init__(self, **kwargs):
         PoolElement.__init__(self, **kwargs)
-                
         self._value = self.ValueAttributeClass(self, listeners=self.on_change)
         self._value_buffer = self.ValueBufferClass(self,
                                                    listeners=self.on_change)

--- a/src/sardana/pool/poolbasechannel.py
+++ b/src/sardana/pool/poolbasechannel.py
@@ -40,6 +40,7 @@ from sardana.pool.poolmeasurementgroup import ChannelConfiguration,\
     ControllerConfiguration
 from sardana.sardanaevent import EventType
 from sardana.pool import AcqSynch, AcqMode
+import weakref
 
 class ValueBuffer(SardanaBuffer):
 
@@ -106,6 +107,7 @@ class PoolBaseChannel(PoolElement):
 
     def __init__(self, **kwargs):
         PoolElement.__init__(self, **kwargs)
+                
         self._value = self.ValueAttributeClass(self, listeners=self.on_change)
         self._value_buffer = self.ValueBufferClass(self,
                                                    listeners=self.on_change)
@@ -150,7 +152,7 @@ class PoolBaseChannel(PoolElement):
         """
         if not self.has_pseudo_elements():
             self.get_value_buffer().persistent = True
-        self._pseudo_elements.append(element)
+        self._pseudo_elements.append(weakref.ref(element))
 
     def remove_pseudo_element(self, element):
         """Removes pseudo element e.g. pseudo counters that this channel

--- a/src/sardana/pool/poolbaseelement.py
+++ b/src/sardana/pool/poolbaseelement.py
@@ -99,6 +99,9 @@ class PoolBaseElement(PoolObject):
         ret = PoolObject.serialize(self, *args, **kwargs)
         return ret
 
+    def get_dependent_elements(self):
+        return []
+
     # --------------------------------------------------------------------------
     # simulation mode
     # --------------------------------------------------------------------------

--- a/src/sardana/pool/poolbaseelement.py
+++ b/src/sardana/pool/poolbaseelement.py
@@ -103,6 +103,9 @@ class PoolBaseElement(PoolObject):
     def get_dependent_elements(self):
         return []
 
+    def has_dependent_elements(self):
+        return False
+
     # --------------------------------------------------------------------------
     # simulation mode
     # --------------------------------------------------------------------------

--- a/src/sardana/pool/poolcontroller.py
+++ b/src/sardana/pool/poolcontroller.py
@@ -442,10 +442,10 @@ class PoolController(PoolBaseController):
 
            :param operator: the new operator object
            :type operator: object"""
-        self._operator = operator
+        self._operator = weakref.ref(operator)
 
     def get_operator(self):
-        return self._operator
+        return self._operator()
 
     operator = property(fget=get_operator, fset=set_operator,
                         doc="current controller operator")

--- a/src/sardana/pool/poolelement.py
+++ b/src/sardana/pool/poolelement.py
@@ -89,6 +89,14 @@ class PoolElement(PoolBaseElement):
         return "{0}/{1}".format(self.full_name, self.get_default_acquisition_channel())
 
     def get_dependent_elements(self):
+        """Get elements which depend on this element.
+        
+        Get elements e.g. pseudo elements or groups, which depend on this
+        element.
+        
+        :return: dependent elements
+        :rtype: seq<sardana.pool.poolbaseelement.PoolBaseElement>
+        """
         dependent_elements = []
         for listener in self.get_listeners():
             try:
@@ -96,7 +104,7 @@ class PoolElement(PoolBaseElement):
             except AttributeError:
                 continue
             if isinstance(elem, PoolBaseElement):
-                dependent_elements.append(elem.name)
+                dependent_elements.append(elem)
         
         return dependent_elements
 

--- a/src/sardana/pool/poolelement.py
+++ b/src/sardana/pool/poolelement.py
@@ -91,9 +91,12 @@ class PoolElement(PoolBaseElement):
     def get_dependent_elements(self):
         pool_base_elements = []
         for listener in self.get_listeners():
-            listener = listener()
-            if isinstance(listener.__self__, PoolBaseElement):
-                pool_base_elements.append(listener.__self__.get_name())
+            try:
+                dependent_elem = listener().__self__
+            except AttributeError:
+                continue
+            if isinstance(dependent_elem, PoolBaseElement):
+                pool_base_elements.append(dependent_elem.name)
         
         return pool_base_elements
 

--- a/src/sardana/pool/poolelement.py
+++ b/src/sardana/pool/poolelement.py
@@ -88,6 +88,18 @@ class PoolElement(PoolBaseElement):
     def get_source(self):
         return "{0}/{1}".format(self.full_name, self.get_default_acquisition_channel())
 
+    def get_dependent_elements(self):
+        pool_base_elements = []
+        for listener in self.get_listeners():
+            listener = listener()
+            if isinstance(listener.__self__, PoolBaseElement):
+                pool_base_elements.append(listener.__self__.get_name())
+        
+        return pool_base_elements
+
+    def has_dependent_elements(self):
+        return len(self.get_dependent_elements()) > 0
+
     # --------------------------------------------------------------------------
     # instrument
     # --------------------------------------------------------------------------

--- a/src/sardana/pool/poolelement.py
+++ b/src/sardana/pool/poolelement.py
@@ -89,16 +89,16 @@ class PoolElement(PoolBaseElement):
         return "{0}/{1}".format(self.full_name, self.get_default_acquisition_channel())
 
     def get_dependent_elements(self):
-        pool_base_elements = []
+        dependent_elements = []
         for listener in self.get_listeners():
             try:
-                dependent_elem = listener().__self__
+                elem = listener().__self__
             except AttributeError:
                 continue
-            if isinstance(dependent_elem, PoolBaseElement):
-                pool_base_elements.append(dependent_elem.name)
+            if isinstance(elem, PoolBaseElement):
+                dependent_elements.append(elem.name)
         
-        return pool_base_elements
+        return dependent_elements
 
     def has_dependent_elements(self):
         return len(self.get_dependent_elements()) > 0

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -1345,16 +1345,13 @@ class PoolMeasurementGroup(PoolGroupElement):
         value = self._get_value()
         self._pending_starts = self.nb_starts
 
-        kwargs = {'head': self}
-
         self.acquisition.prepare(self.configuration,
                                  self.acquisition_mode,
                                  value,
                                  self._synch_description,
                                  self._moveable_obj,
                                  self.sw_synch_initial_domain,
-                                 self.nb_starts,
-                                 **kwargs)
+                                 self.nb_starts)
 
     def start_acquisition(self, value=None):
         """Start measurement.

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -800,7 +800,12 @@ class MeasurementConfiguration(object):
                     params['pool'] = pool
                     channel = PoolExternalObject(**params)
                 else:
-                    channel = pool.get_element_by_full_name(ch_name)
+                    try:
+                        channel = pool.get_element_by_full_name(ch_name)
+                    except KeyError:
+                        raise ValueError(
+                            '{} is not defined'.format(ch_data['name']))
+
                 ch_data = self._fill_channel_data(channel, ch_data)
                 user_config_channel[ch_name] = ch_data
                 ch_item = ChannelConfiguration(channel, ch_data)
@@ -958,7 +963,11 @@ class MeasurementConfiguration(object):
             for conf_synch in conf_synch_ctrl.get_channels(enabled=True):
                 user_elem_ids_list.append(conf_synch.id)
         self._parent.set_user_element_ids(user_elem_ids_list)
-
+        # force assignment of user elements to the measurement group
+        # in order to update the list of dependent elements (listeners)
+        # of the element e.g. to prevent undefinition of an element added
+        # to the measurement group.
+        self._parent.get_user_elements()
         self.changed = True
 
     def _fill_channel_data(self, channel, channel_data):

--- a/src/sardana/sardanaevent.py
+++ b/src/sardana/sardanaevent.py
@@ -105,6 +105,9 @@ class EventGenerator(object):
             return False
         return len(self._listeners) > 0
 
+    def get_listeners(self):
+        return self._listeners
+
     def fire_event(self, event_type, event_value, listeners=None):
         self.flush_queue()
         self._fire_event(event_type, event_value, listeners=listeners)

--- a/src/sardana/tango/pool/Controller.py
+++ b/src/sardana/tango/pool/Controller.py
@@ -72,6 +72,7 @@ class Controller(PoolDevice):
     @DebugIt()
     def delete_device(self):
         PoolDevice.delete_device(self)
+        self.ctrl = None
 
     @DebugIt()
     def init_device(self):

--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -68,6 +68,7 @@ class MeasurementGroup(PoolGroupDevice):
         mg = self.measurement_group
         if mg is not None:
             mg.remove_listener(self.on_measurement_group_changed)
+        self.measurement_group = None
 
     @DebugIt()
     def init_device(self):

--- a/src/sardana/tango/pool/MotorGroup.py
+++ b/src/sardana/tango/pool/MotorGroup.py
@@ -70,6 +70,7 @@ class MotorGroup(PoolGroupDevice):
         motor_group = self.motor_group
         if motor_group is not None:
             motor_group.remove_listener(self.on_motor_group_changed)
+        self.motor_group = None
 
     @DebugIt()
     def init_device(self):

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -538,8 +538,6 @@ class Pool(PyTango.LatestDeviceImpl, Logger):
         self._check_element(name, full_name)
 
         util = PyTango.Util.instance()
-        import pydevd
-        pydevd.settrace(suspend=False, trace_only_current_thread=True)
         def create_element_cb(device_name):
             try:
                 db = util.get_database()

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -538,7 +538,8 @@ class Pool(PyTango.LatestDeviceImpl, Logger):
         self._check_element(name, full_name)
 
         util = PyTango.Util.instance()
-
+        import pydevd
+        pydevd.settrace(suspend=False, trace_only_current_thread=True)
         def create_element_cb(device_name):
             try:
                 db = util.get_database()

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -538,6 +538,7 @@ class Pool(PyTango.LatestDeviceImpl, Logger):
         self._check_element(name, full_name)
 
         util = PyTango.Util.instance()
+
         def create_element_cb(device_name):
             try:
                 db = util.get_database()

--- a/src/sardana/tango/pool/PseudoCounter.py
+++ b/src/sardana/tango/pool/PseudoCounter.py
@@ -51,6 +51,9 @@ class PseudoCounter(PoolExpChannelDevice):
         PoolExpChannelDevice.__init__(self, dclass, name)
         self._first_read_cache = False
 
+    def __del__(self):
+        print("PseudoCounter.__del__")
+
     def init(self, name):
         PoolExpChannelDevice.init(self, name)
 
@@ -71,9 +74,7 @@ class PseudoCounter(PoolExpChannelDevice):
         pseudo_counter = self.pseudo_counter
         if pseudo_counter is not None:
             pseudo_counter.remove_listener(self.on_pseudo_counter_changed)
-        self.element = None
         self.pseudo_counter = None
-        self.ctrl = None
 
     @DebugIt()
     def init_device(self):

--- a/src/sardana/tango/pool/PseudoCounter.py
+++ b/src/sardana/tango/pool/PseudoCounter.py
@@ -51,9 +51,6 @@ class PseudoCounter(PoolExpChannelDevice):
         PoolExpChannelDevice.__init__(self, dclass, name)
         self._first_read_cache = False
 
-    def __del__(self):
-        print("PseudoCounter.__del__")
-
     def init(self, name):
         PoolExpChannelDevice.init(self, name)
 

--- a/src/sardana/tango/pool/PseudoCounter.py
+++ b/src/sardana/tango/pool/PseudoCounter.py
@@ -71,6 +71,9 @@ class PseudoCounter(PoolExpChannelDevice):
         pseudo_counter = self.pseudo_counter
         if pseudo_counter is not None:
             pseudo_counter.remove_listener(self.on_pseudo_counter_changed)
+        self.element = None
+        self.pseudo_counter = None
+        self.ctrl = None
 
     @DebugIt()
     def init_device(self):

--- a/src/sardana/tango/pool/PseudoMotor.py
+++ b/src/sardana/tango/pool/PseudoMotor.py
@@ -73,6 +73,7 @@ class PseudoMotor(PoolElementDevice):
         pseudo_motor = self.pseudo_motor
         if pseudo_motor is not None:
             pseudo_motor.remove_listener(self.on_pseudo_motor_changed)
+        self.pseudo_motor = None
 
     @DebugIt()
     def init_device(self):

--- a/src/sardana/tango/pool/test/base_sartest.py
+++ b/src/sardana/tango/pool/test/base_sartest.py
@@ -102,6 +102,8 @@ class SarTestTestCase(BasePoolTestCase):
 
         self.ctrl_list = []
         self.elem_list = []
+        self.pseudo_ctrl_list = []
+        self.pseudo_elem_list = []
         try:
             # physical controllers and elements
             for sar_type, lib, cls, prefix, postfix, nelem in self.cls_list:
@@ -145,58 +147,68 @@ class SarTestTestCase(BasePoolTestCase):
                     print(e)
                     msg = 'Impossible to create ctrl: "%s"' % (ctrl_name)
                     raise Exception('Aborting SartestTestCase: %s' % (msg))
-                self.ctrl_list.append(ctrl_name)
+                self.pseudo_ctrl_list.append(ctrl_name)
                 for role in roles:
                     elem = role.split("=")[1]
                     if elem not in self.elem_list:
-                        self.elem_list.append(elem)
+                        self.pseudo_elem_list.append(elem)
         except Exception as e:
             # force tearDown in order to eliminate the Pool
             BasePoolTestCase.tearDown(self)
             print(e)
 
+    def _delete_elem(self, elem_name):
+        # Cleanup eventual taurus devices. This is especially important
+        # if the sardana-taurus extensions are in use since this
+        # devices are created and destroyed within the testsuite.
+        # Persisting taurus device may react on API_EventTimeouts, enabled
+        # polling, etc.
+        if elem_name in self.f.tango_alias_devs:
+            _cleanup_device(elem_name)
+        try:
+            if os.name != "nt":
+                self.pool.DeleteElement(elem_name)
+                print(elem_name)
+        except Exception as e:
+            print(e)
+            self.dirty_elems.append(elem_name)
+
+    def _delete_ctrl(self, ctrl_name):
+        # Cleanup eventual taurus devices. This is especially important
+        # if the sardana-taurus extensions are in use since this
+        # devices are created and destroyed within the testsuite.
+        # Persisting taurus device may react on API_EventTimeouts, enabled
+        # polling, etc.
+        if ctrl_name in self.f.tango_alias_devs:
+            _cleanup_device(ctrl_name)
+        try:
+            if os.name != "nt":
+                self.pool.DeleteElement(ctrl_name)
+                print(ctrl_name)
+        except:
+            self.dirty_ctrls.append(ctrl_name)
+
     def tearDown(self):
         """Remove the elements and the controllers
         """
-        dirty_elems = []
-        dirty_ctrls = []
-        f = taurus.Factory()
+        self.dirty_elems = []
+        self.dirty_ctrls = []
+        self.f = taurus.Factory()
+        for elem_name in self.pseudo_elem_list:
+            self._delete_elem(elem_name)
+        for ctrl_name in self.pseudo_ctrl_list:
+            self._delete_ctrl(ctrl_name)
         for elem_name in self.elem_list:
-            # Cleanup eventual taurus devices. This is especially important
-            # if the sardana-taurus extensions are in use since this
-            # devices are created and destroyed within the testsuite.
-            # Persisting taurus device may react on API_EventTimeouts, enabled
-            # polling, etc.
-            if elem_name in f.tango_alias_devs:
-                _cleanup_device(elem_name)
-            try:
-                if os.name != "nt":
-                    self.pool.DeleteElement(elem_name)
-            except Exception as e:
-                print(e)
-                dirty_elems.append(elem_name)
-
+            self._delete_elem(elem_name)
         for ctrl_name in self.ctrl_list:
-            # Cleanup eventual taurus devices. This is especially important
-            # if the sardana-taurus extensions are in use since this
-            # devices are created and destroyed within the testsuite.
-            # Persisting taurus device may react on API_EventTimeouts, enabled
-            # polling, etc.
-            if ctrl_name in f.tango_alias_devs:
-                _cleanup_device(ctrl_name)
-            try:
-                if os.name != "nt":
-                    self.pool.DeleteElement(ctrl_name)
-            except:
-                dirty_ctrls.append(ctrl_name)
-
+            self._delete_ctrl(ctrl_name)
         _cleanup_device(self.pool_name)
 
         BasePoolTestCase.tearDown(self)
 
-        if dirty_elems or dirty_ctrls:
+        if self.dirty_elems or self.dirty_ctrls:
             msg = "Cleanup failed. Database may be left dirty." + \
-                "\n\tCtrls : %s\n\tElems : %s" % (dirty_ctrls, dirty_elems)
+                "\n\tCtrls : %s\n\tElems : %s" % (self.dirty_ctrls, self.dirty_elems)
             raise Exception(msg)
 
 

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -1525,6 +1525,8 @@ class MGConfiguration(object):
         tg_attr_validator = TangoAttributeNameValidator()
         for channel_name, channel_data in list(self.channels.items()):
             cache[channel_name] = None
+            if not channel_data.get("enabled", True):
+                continue
             data_source = channel_data['source']
             params = tg_attr_validator.getUriGroups(data_source)
             if params is None:


### PR DESCRIPTION
This pull request resolves #1586. Now a check for dependent elements is performed when an element is going to be undefined. 

So far we tested it for Pseudocounters, Motorgroups, Pseudomotors and, Measurement Groups.

The remaining tests could be testing for Pseudomotors that have as dependent elements another Pseudomotors.

----

IMPORTANT: This PR introduces usage of `gc.collect()` in Sardana. cycle-reference may exist between an element and a traceback stored in `SardanaValue` or `SardanaAttribute` as a consequence of getting `sys.exc_info()` and storing a reference to it. Since _dependent elements_ are determined by introspecting the listeners we need to attempt garbage collection of these cycled-referenced objects. 