### PR TITLE
[docs] Small fix on spock's `lsmac`/`lsdef` usage 

### DIFF
--- a/doc/source/users/spock.rst
+++ b/doc/source/users/spock.rst
@@ -149,7 +149,7 @@ A similar macro exists that only shows the desired motor positions
      Low            5.0     -100.0
 
 To get the list of all existing macros use
-:class:`~sardana.macroserver.macros.expert.lsmac`:
+:class:`~sardana.macroserver.macros.expert.lsdef`:
 
 .. sourcecode:: spock
 
@@ -169,6 +169,8 @@ To get the list of all existing macros use
                      wa      standard                                     Show all motor position.
                      wm      standard                   Show the position of the specified motors.
     <...>
+
+You can also use :class:`~sardana.macroserver.macros.expert.lsmac` if you want to know a macro's location.
 
 Miscellaneous
 ~~~~~~~~~~~~~


### PR DESCRIPTION
I fixed a small typo on [Spock's docs](https://sardana-controls.org/users/spock.html#executing-macros) where it says to use `lsmac` but then `lsdef`:

![image](https://user-images.githubusercontent.com/38158676/122723087-d06f6c80-d272-11eb-83ad-108fff3a35a0.png)

I replaced `lsmac` with `lsdef` and added a small suggestion:

![image](https://user-images.githubusercontent.com/38158676/122724113-eaf61580-d273-11eb-87be-041c2b239849.png)

👍🏻 
