### PR TITLE
fix: consider events from not standard 0D channel attributes

### DIFF
--- a/src/sardana/tango/pool/ZeroDExpChannel.py
+++ b/src/sardana/tango/pool/ZeroDExpChannel.py
@@ -109,7 +109,7 @@ class ZeroDExpChannel(PoolExpChannelDevice):
             value = self.calculate_tango_status(event_value)
         elif name == "valuebuffer":
             value = self._encode_value_chunk(event_value)
-        elif name == "value":
+        else:
             if isinstance(event_value, SardanaAttribute):
                 if event_value.error:
                     error = Except.to_dev_failed(*event_value.exc_info)


### PR DESCRIPTION
0D Tango implementation only consider some attributes events e.g. value, valuebuffer, etc.
Consider other attributes' events e.g. shape.
Fixes #1618.

@dschick could you please test it? Many thanks!
Reading the shape attribute still gives None. The same is for counter/timer channels. But I think this is how PyTango deals with empty spectrums: https://gitlab.com/tango-controls/pytango/-/issues/271.