### PR TITLE
fix Python import error of sardana module using clr of Python.NET

### DIFF
--- a/src/sardana/sardanamodulemanager.py
+++ b/src/sardana/sardanamodulemanager.py
@@ -36,6 +36,7 @@ __docformat__ = 'restructuredtext'
 import imp
 import sys
 import threading
+import importlib
 
 from taurus.core import ManagerState
 from taurus.core.util.log import Logger
@@ -273,7 +274,7 @@ class ModuleManager(Singleton, Logger):
         with PathContext(path):
             self.info("loading module %s...", module_name)
             try:
-                module = __import__(module_name, globals(), locals(), -1)
+                module = importlib.import_module(module_name)
             except:
                 self.error("Error loading module %s", module_name)
                 self.debug("Details:", exc_info=1)


### PR DESCRIPTION
When loading a module that internally imports some libraries (i. e. clr of Python.NET) Python is unable to import the module using `__import__` but it works when using **importlib**. The documentation of `__import__` recommends using importlib outside of the interpreter.