### PR TITLE
fix: provide back compat for external ctrls meas conf

### DIFF
--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -719,15 +719,13 @@ class MeasurementConfiguration(object):
             # The external controllers should not have synchronizer
 
             if external:
-                if 'synchronizer' in ctrl_data:
-                    raise ValueError('External controller does not allow '
-                                     'to have synchronizer')
-                if 'monitor' in ctrl_data:
-                    raise ValueError('External controller does not allow '
-                                     'to have monitor')
-                if 'timer' in ctrl_data:
-                    raise ValueError('External controller does not allow '
-                                     'to have timer')
+                for parameter in ['synchronizer', 'timer', 'monitor']:
+                    if parameter in ctrl_data:
+                        msg = (
+                            '{} is deprecated for external controllers '
+                            'e.g. Tango, since 3.0.3. Re-apply configuration '
+                            'in order to upgrade.').format(parameter)
+                    self._parent.warning(msg)
             else:
                 synchronizer = ctrl_data.get('synchronizer', 'software')
                 if synchronizer is None or synchronizer == 'software':

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -490,6 +490,9 @@ class MeasurementConfiguration(object):
         # provide back. compatibility for value_ref_{enabled,pattern}
         # config parameters created with Sardana < 3.
         self._value_ref_compat = False
+        # provide back. compatibility for synchronizer, timer and monitor
+        # config parameters set on external channels created with Sardana < 3.
+        self._external_ctrl_compat = False
 
     def get_acq_synch_by_channel(self, channel):
         """Return acquisition synchronization configured for this element.
@@ -721,12 +724,17 @@ class MeasurementConfiguration(object):
             if external:
                 for parameter in ['synchronizer', 'timer', 'monitor']:
                     if parameter in ctrl_data:
-                        msg = (
-                            '{} is deprecated for external controllers '
-                            'e.g. Tango, since 3.0.3. Re-apply configuration '
-                            'in order to upgrade.'
-                        ).format(parameter)
-                        self._parent.warning(msg)
+                        if self._external_ctrl_compat:
+                            msg = (
+                                '{} is deprecated for external controllers '
+                                'e.g. Tango, since 3.0.3. Re-apply configuration '
+                                'in order to upgrade.'
+                            ).format(parameter)
+                            self._parent.warning(msg)
+                        else:
+                            raise ValueError(
+                                'External controller does not allow '
+                                'to have {}'.format(parameter))
             else:
                 synchronizer = ctrl_data.get('synchronizer', 'software')
                 if synchronizer is None or synchronizer == 'software':

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -724,8 +724,9 @@ class MeasurementConfiguration(object):
                         msg = (
                             '{} is deprecated for external controllers '
                             'e.g. Tango, since 3.0.3. Re-apply configuration '
-                            'in order to upgrade.').format(parameter)
-                    self._parent.warning(msg)
+                            'in order to upgrade.'
+                        ).format(parameter)
+                        self._parent.warning(msg)
             else:
                 synchronizer = ctrl_data.get('synchronizer', 'software')
                 if synchronizer is None or synchronizer == 'software':

--- a/src/sardana/tango/pool/MeasurementGroup.py
+++ b/src/sardana/tango/pool/MeasurementGroup.py
@@ -240,8 +240,10 @@ class MeasurementGroup(PoolGroupDevice):
         util = Util.instance()
         if util.is_svr_starting():
             self.measurement_group._config._value_ref_compat = True
+            self.measurement_group._config._external_ctrl_compat = True
         else:
             self.measurement_group._config._value_ref_compat = False
+            self.measurement_group._config._external_ctrl_compat = False
         self.measurement_group.set_configuration_from_user(cfg)
         db = util.get_database()
         elem_ids = self.measurement_group.user_element_ids


### PR DESCRIPTION
#867 accidentally introduced backward-incompatible changes
which break the measurement groups which external controllers e.g. Tango
have synchronizer/timer/monitor configured. Relax validation and print
a deprecation warning instead of raising an exception.

This was discovered at ALBA by @jairomoldes and @tiagocoutinho. @jordiandreu could you test if it avoids the problem?
I would expect that with this change, if you read the configuration back, the synchronizer/timer/monitor parameters should not be there anymore, could you check this as well, please?