### PR TITLE
fix: spock prompt informs when the Door is offline

### DIFF
--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -1117,8 +1117,12 @@ object?   -> Details about 'object'. ?object also works, ?? prints more.
         class SpockPrompts(Prompts):
 
             def in_prompt_tokens(self, cli=None):
+                door_state = self.shell.user_ns.get("DOOR_STATE")
+                door_state_suffix = ""
+                if door_state is not None:
+                    door_state_suffix += door_state
                 return [
-                    (Token.Prompt, door_alias),
+                    (Token.Prompt, door_alias + door_state_suffix),
                     (Token.Prompt, ' ['),
                     (Token.PromptNum, str(self.shell.execution_count)),
                     (Token.Prompt, ']: '),


### PR DESCRIPTION
It is not possible to distinguish in Spock if the Door (MacroServer server) is running.
Previous genutilis (IPython 0.10) offered this information.
Fix it for IPython >= 5 by appending "(OFFLINE)" suffix to the prompt.

Fixes #1621.

This is what I get now when the Door is offline on the Spock startup:

```
╰─>$ spock
MainThread     INFO     2021-07-01 00:13:09,032 TaurusRootLogger: Using PyQt5 (v5.12.3 with Qt 5.12.9 and Python 3.9.1)
MainThread     WARNING  2021-07-01 00:13:09,246 TaurusRootLogger: epics scheme not available: ModuleNotFoundError("No module named 'epics'")
[TerminalIPythonApp] WARNING | Config option `deep_reload` not recognized by `TerminalInteractiveShell`.
Spock 3.1.2-alpha -- An interactive laboratory application.

help      -> Spock's help system.
object?   -> Details about 'object'. ?object also works, ?? prints more.

IPython profile: spockdoor

Connected to Door/zreszela/1
MainThread     INFO     2021-07-01 00:13:09,821 TaurusRootLogger: Plugin "taurus_pyqtgraph" lazy-loaded as "taurus.qt.qtgui.tpg"

Door/zreszela/1 (OFFLINE) [1]: exit
```

And this is what I get now when the Door is shut down after the Spock startup (after receiving API_EventTimout warnings I had to press return):
```
╰─>$ spock
MainThread     INFO     2021-07-01 00:13:30,136 TaurusRootLogger: Using PyQt5 (v5.12.3 with Qt 5.12.9 and Python 3.9.1)
MainThread     WARNING  2021-07-01 00:13:30,361 TaurusRootLogger: epics scheme not available: ModuleNotFoundError("No module named 'epics'")
[TerminalIPythonApp] WARNING | Config option `deep_reload` not recognized by `TerminalInteractiveShell`.
Spock 3.1.2-alpha -- An interactive laboratory application.

help      -> Spock's help system.
object?   -> Details about 'object'. ?object also works, ?? prints more.

IPython profile: spockdoor

Connected to Door/zreszela/1
MainThread     INFO     2021-07-01 00:13:30,896 TaurusRootLogger: Plugin "taurus_pyqtgraph" lazy-loaded as "taurus.qt.qtgui.tpg"

Door/zreszela/1 [1]: 

Door/zreszela/1 [1]: Dummy-29       INFO     2021-07-01 00:13:43,038 pt222.cells.es:10000.Door/zreszela/1.Debug: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,039 pt222.cells.es:10000.Door/zreszela/1.Error: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,039 pt222.cells.es:10000.Door/zreszela/1.Info: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,039 pt222.cells.es:10000.Door/zreszela/1.Input: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,039 pt222.cells.es:10000.Door/zreszela/1.MacroStatus: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,039 pt222.cells.es:10000.Door/zreszela/1.Output: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,039 pt222.cells.es:10000.Door/zreszela/1.RecordData: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,040 pt222.cells.es:10000.Door/zreszela/1.Result: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,041 pt222.cells.es:10000.Door/zreszela/1.state: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,041 pt222.cells.es:10000.Door/zreszela/1.Warning: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,043 pt222.cells.es:10000.macroserver/zreszela/1.Elements: Activating polling. Reason: API_EventTimeout
Dummy-29       INFO     2021-07-01 00:13:43,043 pt222.cells.es:10000.macroserver/zreszela/1.Environment: Activating polling. Reason: API_EventTimeout
Door/zreszela/1 [1]: 

Door/zreszela/1 (OFFLINE) [1]:
```

@doctordesh could you please test and review this! Many thanks!