### PR TITLE
Take scan starttime before snapshots

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -677,6 +677,9 @@ class GScan(Logger):
              'user': user,
              'title': self.macro.getCommand()})
 
+        env['startts'] = ts = time.time()
+        env['starttime'] = datetime.datetime.fromtimestamp(ts)
+
         # Initialize the data_desc list (and add the point number column)
         data_desc = [
             ColumnDesc(name='point_nb', label='#Pt No', dtype='int64')
@@ -993,8 +996,6 @@ class GScan(Logger):
     def start(self):
         self.do_backup()
         env = self._env
-        env['startts'] = ts = time.time()
-        env['starttime'] = datetime.datetime.fromtimestamp(ts)
         env['acqtime'] = 0
         env['motiontime'] = 0
         env['deadtime'] = 0


### PR DESCRIPTION
This pull request fixes #1321 
The fix is to take the start time already when creating the scan object, and not when starting the scan loop (after potentially slow things like taking snapshots).