### PR TITLE
raise exception in relmaclib and relmac methods if any is detected

### DIFF
--- a/src/sardana/macroserver/macroserver.py
+++ b/src/sardana/macroserver/macroserver.py
@@ -447,8 +447,10 @@ class MacroServer(MSContainer, MSObject, SardanaElementManager, SardanaIDManager
         new_elements, changed_elements, deleted_elements = [], [], []
 
         new_lib = manager.reloadMacroLib(lib_name)
+        
         if new_lib.has_errors():
-            return new_lib
+            exc_type, exc_value, exc_traceback = new_lib.get_error()
+            raise exc_type(exc_value).with_traceback(exc_traceback)
 
         if old_lib is None:
             new_elements.extend(new_lib.get_macros())


### PR DESCRIPTION
This suggestion comes from Manu Taurel from ESRF.

Tango commands: ReloadMacro and ReloadMacroLib does not report problems with reloading macros or macro libraries. If the module being reloaded contains bugs it gets silently "reloaded". Maybe raising an exception could a good way of communicating it?

Reported by: reszelaz ( http://sf.net/u/zreszela )

Original Ticket: sardana/tickets/118

Fix: #75 

-----------------------------

Description of the argout says: "[OK] if successfull or a traceback if there was a error (one string with complete traceback of each error". However even if the error occurs the [OK] string is returned.

Reported by: reszelaz ( http://sf.net/u/zreszela )

Original Ticket: sardana/tickets/119

Fix: #76 
