### PR TITLE
Avoid errors in edctrlcls and edctrllib macros

### DIFF
--- a/src/sardana/macroserver/macros/expert.py
+++ b/src/sardana/macroserver/macros/expert.py
@@ -248,14 +248,15 @@ class edctrlcls(Macro):
     hints = {'commit_cmd': 'commit_ctrllib'}
 
     def run(self, ctrlclass):
-        f_name = ctrlclass.file
-        pool = ctrlclass.getPool()
+        f_name = ctrlclass.f_name
+        pool = ctrlclass.getPoolObj()
         data = pool.GetFile(f_name)
-        data = array.array('B', data).tostring()
+        data = data[0] + data[1]
         line_nb = 1
+        ctrlname = " " +  ctrlclass.name + "("
         for line in data.splitlines():
             line = line.strip(' \t')
-            if line.startswith('class') and line.find(ctrlclass.name) > 0 and \
+            if line.startswith('class') and line.find(ctrlname) > 0 and \
                     line.endswith(":"):
                 break
             line_nb = line_nb + 1
@@ -277,9 +278,10 @@ class edctrllib(Macro):
     hints = {'commit_cmd': 'commit_ctrllib'}
 
     def run(self, filename):
-        pool = self.getManager().getPool()
+        pool = self.getPools()[0]
         data = pool.GetFile(filename)
-        return [filename, array.array('B', data).tostring(), 0]
+        data = data[0] + data[1]
+        return [filename, data, 0]
 
 
 class commit_ctrllib(Macro):

--- a/src/sardana/tango/pool/Pool.py
+++ b/src/sardana/tango/pool/Pool.py
@@ -989,7 +989,7 @@ class Pool(PyTango.LatestDeviceImpl, Logger):
         lib = manager.getControllerLib(name)
         if lib is None:
             raise Exception("Unknown controller file '%s'", name)
-        return lib.f_path, "".join(lib.getCode())
+        return lib.path, "".join(lib.get_code())
 
     def PutFile(self, file_data):
         p = self.pool


### PR DESCRIPTION
This PR avoid errors coming up when running edctrlcls and edctrllib macros. The macros are still not
functional, since they have to be moved to magic commands (like edmac and edmaclib is done), but
this PR solves bugs in the code of the macros and of the sardana core. Now the code is ready for
further implementation (not done now since it has very low priority and it has to be discussed if it
is worth to implement it). Issue #317 is closed with this PR.