### PR TITLE
Fix #87  (error with duplicated pre-scan snapshots)

### DIFF
--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -301,6 +301,13 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
 
         for dd in self.preScanSnapShot:
             label = self.sanitizeName(dd.label)
+            if label in _snap:
+                self.warning(
+                    "PreScanSnapShot: skipping duplicated label'{}'".format(
+                        label
+                    )
+                )
+                continue
             dtype = dd.dtype
             pre_scan_value = dd.pre_scan_value
             if dd.dtype == 'bool':

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -427,7 +427,8 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
         conf = door.getExperimentConfiguration()
         self._originalConfiguration = copy.deepcopy(conf)
         self.setLocalConfig(conf)
-        self._setDirty(False)
+        # Flag as "dirty" if some config was changed during the set-up
+        self._setDirty(self._localConfig != self._originalConfiguration)
         self._dirtyMntGrps = set()
         # set a list of available channels
         avail_channels = {}

--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -671,7 +671,18 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
             else:
                 full_name = nfo.full_name
                 display = nfo.name
+            if full_name in [fn for fn, _ in preScanList]:
+                msg = ("'{}' defined more than once in snapshot.\n"
+                       + "Only one entry will be kept").format(display)
+                Qt.QMessageBox.warning(
+                    self, "Duplicated entry", msg, Qt.QMessageBox.Ok
+                )
+                continue
             preScanList.append((full_name, display))
+        if len(preScanList) != len(items):
+            # refresh the preScanList removing duplicated entries (if any)
+            self.ui.preScanList.clear()
+            self.ui.preScanList.addModels(preScanList)
         self._localConfig['PreScanSnapshot'] = preScanList
         self._setDirty(True)
 


### PR DESCRIPTION
- Nexus recorder: handle duplicated snapshot labels 
- Do not allow setting duplicated snapshots in Exponf 

Fixes #87 

(worked with @emiliojmorales )