### PR TITLE
fix: correctly extract taurus version

### DIFF
--- a/src/sardana/spock/ipython_01_00/genutils.py
+++ b/src/sardana/spock/ipython_01_00/genutils.py
@@ -502,8 +502,7 @@ def clean_up():
 
 def get_taurus_core_version():
     try:
-        import taurus
-        return taurus.core.release.version
+        return taurus.Release.version
     except:
         import traceback
         traceback.print_exc()

--- a/src/sardana/tango/pool/test/base_sartest.py
+++ b/src/sardana/tango/pool/test/base_sartest.py
@@ -93,13 +93,6 @@ class SarTestTestCase(BasePoolTestCase):
     def setUp(self, pool_properties=None):
         BasePoolTestCase.setUp(self, pool_properties)
 
-        # due to problems with factory cleanup in Taurus 3
-        # we must skip these tests temporarily, whenever Taurus 3 support will
-        # be dropped, re-enable them
-        if taurus.core.release.version_info[0] < 4:
-            self.skipTest("Taurus 3 has problems with factory cleanup")
-
-
         self.ctrl_list = []
         self.elem_list = []
         try:


### PR DESCRIPTION
taurus for many years was allowing to retrieve its version from the
taurus.core.release module directly, even if this was not a recommended way.
taurus!1199 does not allow it anymore.

Change the way of obtaining the version number. In the future it will be
possible to use `taurus.__version__` directly.