### PR TITLE
Sequencer action buttons

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -580,7 +580,7 @@ class TaurusSequencerWidget(TaurusWidget):
                                    Qt.QMessageBox.No) == Qt.QMessageBox.Yes:
             self.onSaveSequence()
         self.tree.clearTree()
-        self.newSequenceAction.setEnabled(False)
+        self.playSequenceAction.setEnabled(False)
         self.saveSequenceAction.setEnabled(False)
         self.currentMacroChanged.emit(None)
 

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -368,7 +368,7 @@ class TaurusSequencerWidget(TaurusWidget):
             Qt.QIcon.fromTheme("document-new"), "New", self)
         self.newSequenceAction.triggered.connect(self.onNewSequence)
         self.newSequenceAction.setToolTip("New sequence")
-        self.newSequenceAction.setEnabled(False)
+        self.newSequenceAction.setEnabled(True)
         newSequenceButton = Qt.QToolButton()
         newSequenceButton.setDefaultAction(self.newSequenceAction)
         actionsLayout.addWidget(newSequenceButton)

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -85,6 +85,7 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
 
     macroNameChanged = Qt.pyqtSignal('QString')
     macroChanged = Qt.pyqtSignal(compat.PY_OBJECT)
+    macroListEmpty = Qt.pyqtSignal()
 
     def __init__(self, parent=None):
         Qt.QTreeView.__init__(self, parent)
@@ -233,6 +234,8 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
 #        self._idIndexDict.pop(node.id())
         self.expandAll()
         self.expanded()
+        if len(self.model().root()) == 0:
+            self.macroListEmpty.emit()
 
     def upMacro(self):
         node, proxyIndex = self.selectedNodeAndIndex()
@@ -499,6 +502,7 @@ class TaurusSequencerWidget(TaurusWidget):
         self.macroComboBox.currentIndexChanged.connect(
             self.onMacroComboBoxChanged)
         self.tree.macroChanged.connect(self.setMacroParametersRootIndex)
+        self.tree.macroListEmpty.connect(self.onEmptyList)
 
     def contextMenuEvent(self, event):
         menu = Qt.QMenu()
@@ -808,6 +812,10 @@ class TaurusSequencerWidget(TaurusWidget):
             self.playSequenceAction.setEnabled(True)
             self.pauseSequenceAction.setEnabled(False)
             self.stopSequenceAction.setEnabled(True)
+
+    def onEmptyList(self):
+        self.saveSequenceAction.setEnabled(False)
+        self.playSequenceAction.setEnabled(False)
 
     def setMacroParametersRootIndex(self, sourceIndex):
         parametersModel = self.standardMacroParametersEditor.tree.model()

--- a/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
+++ b/src/sardana/taurus/qt/qtgui/extra_macroexecutor/sequenceeditor/sequenceeditor.py
@@ -85,7 +85,7 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
 
     macroNameChanged = Qt.pyqtSignal('QString')
     macroChanged = Qt.pyqtSignal(compat.PY_OBJECT)
-    macroListEmpty = Qt.pyqtSignal()
+    macroTreeChanged = Qt.pyqtSignal()
 
     def __init__(self, parent=None):
         Qt.QTreeView.__init__(self, parent)
@@ -190,6 +190,7 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
 
     def clearTree(self):
         self.model().clearSequence()
+        self.macroTreeChanged.emit()
 
     def toXmlString(self, pretty=False, withId=True):
         return self.model().toXmlString(pretty=pretty, withId=withId)
@@ -226,6 +227,7 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
         self.setCurrentIndex(newProxyIndex)
         self.expandAll()
         self.expanded()
+        self.macroTreeChanged.emit()
 
     def deleteMacro(self):
         node, proxyIndex = self.selectedNodeAndIndex()
@@ -234,8 +236,7 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
 #        self._idIndexDict.pop(node.id())
         self.expandAll()
         self.expanded()
-        if len(self.model().root()) == 0:
-            self.macroListEmpty.emit()
+        self.macroTreeChanged.emit()
 
     def upMacro(self):
         node, proxyIndex = self.selectedNodeAndIndex()
@@ -247,6 +248,7 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
         self.setCurrentIndex(newProxyIndex)
         self.expandAll()
 #        self.expanded()
+        self.macroTreeChanged.emit()
 
     def downMacro(self):
         node, proxyIndex = self.selectedNodeAndIndex()
@@ -258,6 +260,7 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
         self.setCurrentIndex(newProxyIndex)
         self.expandAll()
 #        self.expanded()
+        self.macroTreeChanged.emit()
 
     def leftMacro(self):
         node, proxyIndex = self.selectedNodeAndIndex()
@@ -269,6 +272,7 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
         self.setCurrentIndex(newProxyIndex)
         self.expandAll()
         self.expanded()
+        self.macroTreeChanged.emit()
 
     def rightMacro(self):
         node, proxyIndex = self.selectedNodeAndIndex()
@@ -280,6 +284,7 @@ class MacroSequenceTree(Qt.QTreeView, BaseConfigurableClass):
         self.setCurrentIndex(newProxyIndex)
         self.expandAll()
         self.expanded()
+        self.macroTreeChanged.emit()
 
     def prepareMacroIds(self):
         model = self.model()
@@ -502,7 +507,7 @@ class TaurusSequencerWidget(TaurusWidget):
         self.macroComboBox.currentIndexChanged.connect(
             self.onMacroComboBoxChanged)
         self.tree.macroChanged.connect(self.setMacroParametersRootIndex)
-        self.tree.macroListEmpty.connect(self.onEmptyList)
+        self.tree.macroTreeChanged.connect(self.onMacroTreeChanged)
 
     def contextMenuEvent(self, event):
         menu = Qt.QMenu()
@@ -813,9 +818,10 @@ class TaurusSequencerWidget(TaurusWidget):
             self.pauseSequenceAction.setEnabled(False)
             self.stopSequenceAction.setEnabled(True)
 
-    def onEmptyList(self):
-        self.saveSequenceAction.setEnabled(False)
-        self.playSequenceAction.setEnabled(False)
+    def onMacroTreeChanged(self):
+        if self.isEmptySequence():
+            self.saveSequenceAction.setEnabled(False)
+            self.playSequenceAction.setEnabled(False)
 
     def setMacroParametersRootIndex(self, sourceIndex):
         parametersModel = self.standardMacroParametersEditor.tree.model()


### PR DESCRIPTION
Fixes #305 

Couple action buttons bug fixes:

- When a macro is added to the sequence, now the "New sequence"  button remains enabled.
- When no macros remain in the sequence tree after deleting them, the "Save sequence" and "Play sequence" buttons now remain disabled,
- When new sequence is created "new sequence" remain enabled and "play" button remain disabled