### PR TITLE
Issue1321 scan start time taken too late, take 2

### DIFF
--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -1252,6 +1252,7 @@ class scanhist(Macro):
         start, end, total_time = start.ctime(), end.ctime(), str(total_time)
         scan_dir, scan_file = h['ScanDir'], h['ScanFile']
         deadtime = '%.1f%%' % h['deadtime']
+        setuptime = '%.1f%%' % h['setuptime']
 
         user = h['user']
         store = "Not stored!"
@@ -1263,8 +1264,8 @@ class scanhist(Macro):
 
         channels = ", ".join(h['channels'])
         cols = ["#", "Title", "Start time", "End time", "Took", "Dead time",
-                "User", "Stored", "Channels"]
-        data = [serialno, title, start, end, total_time, deadtime, user, store,
+                "Setup time", "User", "Stored", "Channels"]
+        data = [serialno, title, start, end, total_time, deadtime, setuptime, user, store,
                 channels]
 
         table = Table([data], row_head_str=cols, row_head_fmt='%*s',

--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -227,6 +227,7 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
                                     self.__class__.__name__)
         _pname = nxentry.create_dataset('program_name', data=program_name)
         _pname.attrs['version'] = sardana.release.version
+        # TODO check if this should be "starttime" or "scanstarttime"
         nxentry.create_dataset('start_time', data=env['starttime'].isoformat())
         timedelta = (env['starttime'] - datetime(1970, 1, 1))
         try:

--- a/src/sardana/macroserver/recorders/output.py
+++ b/src/sardana/macroserver/recorders/output.py
@@ -224,6 +224,7 @@ class OutputRecorder(DataRecorder):
         starttime = recordlist.getEnvironValue('starttime')
         endtime = recordlist.getEnvironValue('endtime')
         deadtime = recordlist.getEnvironValue('deadtime')
+        setuptime = recordlist.getEnvironValue('setuptime')
         motiontime = recordlist.getEnvironValue('motiontime')
         totaltime = endtime - starttime
         endtime = endtime.ctime()
@@ -239,11 +240,12 @@ class OutputRecorder(DataRecorder):
         startts = recordlist.getEnvironValue('startts')
         totaltimets = endts - startts
         deadtime_perc = deadtime * 100 / totaltimets
+        setuptime_perc = setuptime * 100 / totaltimets
         motiontime_perc = motiontime * 100 / totaltimets
         info_string = 'Scan #%s ended at %s, taking %s. ' + \
-                      'Dead time %.1f%% (motion dead time %.1f%%)'
+                      'Dead time %.1f%% (setup time %.1f%%, motion dead time %.1f%%)'
         self._stream().info(info_string % (serialno, endtime, totaltime,
-                                         deadtime_perc, motiontime_perc))
+                                         deadtime_perc, setuptime_perc, motiontime_perc))
 
     def _writeRecord(self, record):
         cells = []

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -996,25 +996,31 @@ class GScan(Logger):
     def start(self):
         self.do_backup()
         env = self._env
+        env['scanstartts'] = ts = time.time()
+        env['scanstarttime'] = datetime.datetime.fromtimestamp(ts)
         env['acqtime'] = 0
         env['motiontime'] = 0
         env['deadtime'] = 0
+        env['setuptime'] = ts - env['startts'] 
         self.data.start()
 
     def end(self):
         env = self._env
         env['endts'] = end_ts = time.time()
         env['endtime'] = datetime.datetime.fromtimestamp(end_ts)
-        total_time = end_ts - env['startts']
+        # total macro time, including snapshots
+        # total_time = end_ts - env['startts']
+        # time to run actual scan
+        total_scan_time = end_ts - env['scanstartts']
         # estimated = env['estimatedtime']
         acq_time = env['acqtime']
         # env['deadtime'] = 100.0 * (total_time - estimated) / total_time
 
-        env['deadtime'] = total_time - acq_time
+        env['deadtime'] = total_scan_time - acq_time
         if 'delaytime' in env:
-            env['motiontime'] = total_time - acq_time - env['delaytime']
+            env['motiontime'] = total_scan_time - acq_time - env['delaytime']
         elif 'motiontime' in env:
-            env['delaytime'] = total_time - acq_time - env['motiontime']
+            env['delaytime'] = total_scan_time - acq_time - env['motiontime']
 
         self.data.end()
         try:

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -677,6 +677,9 @@ class GScan(Logger):
              'user': user,
              'title': self.macro.getCommand()})
 
+        env['startts'] = ts = time.time()
+        env['starttime'] = datetime.datetime.fromtimestamp(ts)
+
         # Initialize the data_desc list (and add the point number column)
         data_desc = [
             ColumnDesc(name='point_nb', label='#Pt No', dtype='int64')
@@ -993,8 +996,6 @@ class GScan(Logger):
     def start(self):
         self.do_backup()
         env = self._env
-        env['startts'] = ts = time.time()
-        env['starttime'] = datetime.datetime.fromtimestamp(ts)
         env['acqtime'] = 0
         env['motiontime'] = 0
         env['deadtime'] = 0


### PR DESCRIPTION
This is an updated more elaborate version of https://github.com/sardana-org/sardana/pull/1632. It fixes https://github.com/sardana-org/sardana/issues/1321

After a scan, it reports the setup part of the deadtime (snapshots etc) separately like this:
```
Door_dummy_1 [5]: ascan mot01 0 1 4 0.1
Operation will be saved in /tmp/dummmy2.h5 (HDF5::NXscan from NXscanH5_FileRecorder)
Scan #24 started at Thu Jul  8 08:38:42 2021. It will take at least 0:00:01.348528
 #Pt No    mot01      ct01      ct02       dt   
   0         0        0.1       0.2     0.34582 
   1        0.25      0.1       0.2     0.660809
   2        0.5       0.1       0.2     0.969109
   3        0.75      0.1       0.2     1.28313 
   4         1        0.1       0.2      1.5818 
Operation saved in /tmp/dummmy2.h5 (HDF5::NXscan)
Scan #24 ended at Thu Jul  8 08:38:43 2021, taking 0:00:01.726501. Dead time 69.8% (setup time 1.2%, motion dead time 56.1%)
```