### PR TITLE
Add ascanct parameter output

### DIFF
--- a/src/sardana/macroserver/recorders/output.py
+++ b/src/sardana/macroserver/recorders/output.py
@@ -141,6 +141,7 @@ class OutputRecorder(DataRecorder):
             cols = None
         self._columns = cols
         self._output_block = output_block
+        self._header_shown = False
 
     def _startRecordList(self, recordlist):
         starttime = recordlist.getEnvironValue('starttime').ctime()
@@ -215,9 +216,7 @@ class OutputRecorder(DataRecorder):
         self._scan_line_t = [(col_names[0], '%%(%s)8d' % col_names[0])]
         self._scan_line_t += [(name, cell_t_number % name)
                               for name in col_names[1:]]
-
-        self._stream()._output(header)
-        self._stream()._flushOutput()
+        self._header = header
 
     def _endRecordList(self, recordlist):
         self._stream()._flushOutput()
@@ -243,9 +242,14 @@ class OutputRecorder(DataRecorder):
         info_string = 'Scan #%s ended at %s, taking %s. ' + \
                       'Dead time %.1f%% (motion dead time %.1f%%)'
         self._stream().info(info_string % (serialno, endtime, totaltime,
-                                         deadtime_perc, motiontime_perc))
+                                           deadtime_perc, motiontime_perc))
 
     def _writeRecord(self, record):
+        if not self._header_shown:
+            # show column headers
+            self._stream()._output(self._header)
+            self._stream()._flushOutput()
+            self._header_shown = True
         cells = []
         for i, (name, cell) in enumerate(self._scan_line_t):
             cell_data = record.data[name]

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2623,6 +2623,25 @@ class CTScan(CScan, CAcquisition):
         self.join_thread_pool()
         self.macro.debug("All data events are processed")
 
+        # Note: The commented out code below works, but due to an issue with
+        # output of the last measurement point, it should not be enabled yet.
+        # See https://github.com/sardana-org/sardana/issues/1651
+
+        # # Output the restored motor settings
+        # out = List(["Motor", "Velocity", "Acceleration", "Deceleration"],
+        #            header_separator=None,
+        #            text_alignment=[Alignment.HCenter] * 4,
+        #            max_col_width=[-1] * 4)
+        # cell_format = "%g"
+        # for motor_backup in self._backup:
+        #     out.appendRow([motor_backup["moveable"].getName(),
+        #                    cell_format % motor_backup["velocity"],
+        #                    cell_format % motor_backup["acceleration"],
+        #                    cell_format % motor_backup["deceleration"]])
+        # self.macro.output("")
+        # for line in out.genOutput():
+        #     self.macro.output(line)
+
     def scan_loop(self):
         macro = self.macro
         # manager = macro.getManager()

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2474,7 +2474,7 @@ class CTScan(CScan, CAcquisition):
 
             # Output some helpful info about the settings that are to be used
             Left, Right, HCenter = Alignment.Left, Alignment.Right, Alignment.HCenter
-            out = List(cols=["Motor", "Velocity", "Acceleration", "Deceleration", "Start", "End"],
+            out = List(["Motor", "Velocity", "Acceleration", "Deceleration", "Start", "End"],
                        text_alignment=[Left, Right, Right, Right, Right, Right],
                        max_col_width=[-1, -1, -1, -1, -1, -1])
 
@@ -2508,7 +2508,7 @@ class CTScan(CScan, CAcquisition):
                     raise ScanException(msg)
 
             for line in out.genOutput():
-                self.output(line)
+                self.macro.output(line)
 
             if macro.isStopped():
                 self.on_waypoints_end()

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2473,8 +2473,9 @@ class CTScan(CScan, CAcquisition):
                 return
 
             # a table of motor settings
-            motor_table = List(["Motor", "Velocity", "Acceleration",
-                                "Deceleration", "Start", "End"],
+            # ("u" is short for "unit", to save space)
+            motor_table = List(["Motor", "Velocity[u/s]", "Acceleration[s]",
+                                "Deceleration[s]", "Start[u]", "End[u]"],
                                header_separator=None,
                                text_alignment=[Alignment.HCenter] * 6,
                                max_col_width=[-1] * 6)
@@ -2509,6 +2510,7 @@ class CTScan(CScan, CAcquisition):
                     msg = "Error when configuring scan motion (%s)" % e
                     raise ScanException(msg)
 
+            self.macro.output("")
             for line in motor_table.genOutput():
                 self.macro.output(line)
             self.macro.output("")

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2472,11 +2472,12 @@ class CTScan(CScan, CAcquisition):
                 self.on_waypoints_end()
                 return
 
-            # Output some helpful info about the settings that are to be used
-            Left, Right, HCenter = Alignment.Left, Alignment.Right, Alignment.HCenter
-            out = List(["Motor", "Velocity", "Acceleration", "Deceleration", "Start", "End"],
-                       text_alignment=[Left, Right, Right, Right, Right, Right],
-                       max_col_width=[-1, -1, -1, -1, -1, -1])
+            # a table of motor settings
+            motor_table = List(["Motor", "Velocity", "Acceleration",
+                                "Deceleration", "Start", "End"],
+                               header_separator=None,
+                               text_alignment=[Alignment.HCenter] * 6,
+                               max_col_width=[-1] * 6)
 
             # prepare motor(s) to move with their maximum velocity
             for path in motion_paths:
@@ -2488,12 +2489,13 @@ class CTScan(CScan, CAcquisition):
                                  'end: %f; ' % path.final_pos +
                                  'ds: %f' % (path.final_pos -
                                              path.initial_pos))
-                out.appendRow([motor.getName(),
-                               path.max_vel,
-                               path.max_vel_time,
-                               path.min_vel_time,
-                               path.initial_pos,
-                               path.final_pos])
+                cell_format = "%g"  # TODO is this the proper format to use?
+                motor_table.appendRow([motor.getName(),
+                                       cell_format % path.max_vel,
+                                       cell_format % path.max_vel_time,
+                                       cell_format % path.min_vel_time,
+                                       cell_format % path.initial_pos,
+                                       cell_format % path.final_pos])
                 attributes = OrderedDict(velocity=path.max_vel,
                                          acceleration=path.max_vel_time,
                                          deceleration=path.min_vel_time)
@@ -2507,8 +2509,9 @@ class CTScan(CScan, CAcquisition):
                     msg = "Error when configuring scan motion (%s)" % e
                     raise ScanException(msg)
 
-            for line in out.genOutput():
+            for line in motor_table.genOutput():
                 self.macro.output(line)
+            self.macro.output("")
 
             if macro.isStopped():
                 self.on_waypoints_end()


### PR DESCRIPTION
Adds a table with some helpful output of the motor settings that are about to be used in a continuous scan. 

In order to implement this, we had to change how the header of the scan table is output; it is now printed when the first point arrives, and not immediately. This also prevents some issues with info/debug messages appearing after the header.

The original issue #692 also suggests showing the restored settings after the scan but for similar reasons (see issue #1651) it is currently commented out. It can be added in whenever that issue is solved.

Example:
```
Door_2_1 [5]: ascanct mot10  0 10 10 0.1 0.1
ScanDir is not defined. This operation will not be stored persistently. Use "expconf" or "newfile" to configure data storage (or eventually "senv ScanDir <abs directory>")
Scan #31 started at Thu Jul  8 13:05:35 2021. It will take at least 0:00:00
Motor positions and relative timestamp (dt) columns contains theoretical values
 Motor    Velocity   Acceleration   Deceleration  Start   End  
 mot10       5            2              2          -5     16  

 #Pt No    mot10      ct09      ct10      ct11      ct12       dt   
   0         0        0.1       0.2       0.3       0.4        2    
...
```
Opinions on how the output should be formatted are very welcome.

Fixes #692 