### PR TITLE
Allow user to control MS and pool log files size & number

### DIFF
--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -39,7 +39,8 @@ from taurus.core.tango.tangovalidator import TangoAttributeNameValidator
 from taurus.core.util.containers import CaselessDict
 
 from sardana import InvalidId, ElementType, TYPE_ACQUIRABLE_ELEMENTS, \
-    TYPE_PSEUDO_ELEMENTS, TYPE_PHYSICAL_ELEMENTS, TYPE_MOVEABLE_ELEMENTS
+    TYPE_PSEUDO_ELEMENTS, TYPE_PHYSICAL_ELEMENTS, TYPE_MOVEABLE_ELEMENTS, \
+    sardanacustomsettings
 from sardana.sardanamanager import SardanaElementManager, SardanaIDManager
 from sardana.sardanamodulemanager import ModuleManager
 from sardana.sardanaevent import EventType
@@ -138,6 +139,7 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
         PoolObject.__init__(self, full_name=full_name, name=name, id=InvalidId,
                             pool=self, elem_type=ElementType.Pool)
         self._monitor = PoolMonitor(self, "PMonitor", auto_start=False)
+        # To be used if the user wants to use sardana without tango.
         # self.init_local_logging()
         ControllerManager().set_pool(self)
 
@@ -148,12 +150,14 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
         log.propagate = 0
         path = os.path.join(os.sep, "tmp", "tango")
         log_file_name = os.path.join(path, 'controller.log.txt')
+        maxBytes = getattr(sardanacustomsettings, 'POOL_LOG_FILES_SIZE', 1E7)
+        backupCount = getattr(sardanacustomsettings, 'POOL_LOG_BCK_COUNT', 5)
         try:
             if not os.path.exists(path):
                 os.makedirs(path, 0o777)
             f_h = logging.handlers.RotatingFileHandler(log_file_name,
-                                                       maxBytes=1E7,
-                                                       backupCount=5)
+                                                       maxBytes=maxBytes,
+                                                       backupCount=backupCount)
 
             f_h.setFormatter(self.getLogFormat())
             log.addHandler(f_h)

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -40,16 +40,20 @@ UNITTEST_POOL_NAME = "pool/demo1/1"
 #: Size of rotating backups of the log files.
 #: The Pool device server will use these values for its logs.
 POOL_LOG_FILES_SIZE = 1e7
+#: Size of rotating backups of the log files.
 #: The MacroServer device server will use these values for its logs.
 MS_LOG_FILES_SIZE = 1e7
+#: Size of rotating backups of the log files.
 #: The Sardana device server will use these values for its logs.
 SARDANA_LOG_FILES_SIZE = 1e7
 
 #: Number of rotating backups of the log files.
 #: The Pool device server will use these values for its logs.
 POOL_LOG_BCK_COUNT = 5
+#: Number of rotating backups of the log files.
 #: The MacroServer device server will use these values for its logs.
 MS_LOG_BCK_COUNT = 5
+#: Number of rotating backups of the log files.
 #: The Sardana device server will use these values for its logs.
 SARDANA_LOG_BCK_COUNT = 5
 

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -38,11 +38,6 @@ UNITTEST_POOL_DS_NAME = "unittest1"
 UNITTEST_POOL_NAME = "pool/demo1/1"
 
 #: Size of rotating backups of the log files.
-#: The Pool, MacroServer and Sardana device servers will use these values
-#: for their logs.
-#LOG_FILES_SIZE = 1e7
-
-#: Size of rotating backups of the log files.
 #: The Pool device server will use these values for its logs.
 POOL_LOG_FILES_SIZE = 1e7
 #: The MacroServer device server will use these values for its logs.
@@ -50,7 +45,6 @@ MS_LOG_FILES_SIZE = 1e7
 
 #: Number of rotating backups of the log files.
 #: The Pool device server will use these values for its logs.
-#LOG_BCK_COUNT = 5
 POOL_LOG_BCK_COUNT = 5
 #: The MacroServer device server will use these values for its logs.
 MS_LOG_BCK_COUNT = 5

--- a/src/sardana/sardanacustomsettings.py
+++ b/src/sardana/sardanacustomsettings.py
@@ -40,11 +40,20 @@ UNITTEST_POOL_NAME = "pool/demo1/1"
 #: Size of rotating backups of the log files.
 #: The Pool, MacroServer and Sardana device servers will use these values
 #: for their logs.
-LOG_FILES_SIZE = 1e7
+#LOG_FILES_SIZE = 1e7
+
+#: Size of rotating backups of the log files.
+#: The Pool device server will use these values for its logs.
+POOL_LOG_FILES_SIZE = 1e7
+#: The MacroServer device server will use these values for its logs.
+MS_LOG_FILES_SIZE = 1e7
+
 #: Number of rotating backups of the log files.
-#: The Pool, MacroServer and Sardana device servers will use these values
-#: for their logs.
-LOG_BCK_COUNT = 5
+#: The Pool device server will use these values for its logs.
+#LOG_BCK_COUNT = 5
+POOL_LOG_BCK_COUNT = 5
+#: The MacroServer device server will use these values for its logs.
+MS_LOG_BCK_COUNT = 5
 
 #: Input handler for spock interactive macros. Accepted values are:
 #:

--- a/src/sardana/tango/core/util.py
+++ b/src/sardana/tango/core/util.py
@@ -1156,9 +1156,16 @@ def prepare_logging(options, args, tango_args, start_time=None,
                 os.makedirs(path, 0o777)
 
             from sardana import sardanacustomsettings
-            maxBytes = getattr(sardanacustomsettings, 'LOG_FILES_SIZE', 1E7)
-            backupCount = getattr(sardanacustomsettings, 'LOG_BCK_COUNT', 5)
 
+            tangods = args[0]
+            
+            if tangods == "Pool":
+                maxBytes = getattr(sardanacustomsettings, 'POOL_LOG_FILES_SIZE', 1E7)
+                backupCount = getattr(sardanacustomsettings, 'POOL_LOG_BCK_COUNT', 5)
+            elif tangods == "MacroServer":
+                maxBytes = getattr(sardanacustomsettings, 'MS_LOG_FILES_SIZE', 1E7)
+                backupCount = getattr(sardanacustomsettings, 'MS_LOG_BCK_COUNT', 5)
+                
             fmt = Logger.getLogFormat()
             f_h = logging.handlers.RotatingFileHandler(log_file_name,
                                                        maxBytes=maxBytes,


### PR DESCRIPTION
Currently the log files size and number of backups used by loggers in sardana (e.g. by Pool and MacroServer DSs) is hardcoded to 10M and 5 respectively. Make this a variable that can be controlled via sardanacustomsettings.py.

Fix: #141 