### PR TITLE
revert control_exceptions arg to waitForEvent

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -518,8 +518,7 @@ class PoolElement(BaseElement, TangoDevice):
         evt_wait = self._getEventWait()
         try:
             evt_wait.waitForEvent((DevState.MOVING, ), after=id, equal=False,
-                                  timeout=timeout, reactivity=0.1,
-                                  control_exceptions=[AbortException])
+                                  timeout=timeout, reactivity=0.1)
         finally:
             self.__go_end_time = time.time()
             self.__go_time = self.__go_end_time - self.__go_start_time


### PR DESCRIPTION
Different types of exceptions are not possible here so there is no need for the control_exceptions argument to Taurus' waitforEvent. Ref to [PR](https://gitlab.com/taurus-org/taurus/-/merge_requests/1204) in Taurus. Reverting here as well.