### PR TITLE
Improve devcontainer configurations

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,3 +1,0 @@
-DOCKER_REGISTRY_HOST=nexus.engageska-portugal.pt
-DOCKER_REGISTRY_USER=ska-docker
-CONTAINER_NAME_PREFIX=sardana_dev_

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     hostname: sardana
     environment:
       TANGO_HOST: databaseds:10000
-      DISPLAY: "unix:0"
+      DISPLAY: "unix:0" # for osx: host.docker.internal:0
     build:
       context: ./sardana_dev
       args: 
@@ -36,8 +36,8 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
     command: /bin/sh -c "while sleep 1000; do :; done"
   tangodb:
-    image: ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/tango-db:latest
-    container_name: ${CONTAINER_NAME_PREFIX}tangodb
+    image: nexus.engageska-portugal.pt/ska-docker/tango-db:latest
+    container_name: sardana_dev_tangodb
     networks:
       - sardana
     environment:
@@ -50,8 +50,8 @@ services:
     restart: on-failure
 
   databaseds:
-    image: ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/tango-cpp:latest
-    container_name: ${CONTAINER_NAME_PREFIX}databaseds
+    image: nexus.engageska-portugal.pt/ska-docker/tango-cpp:latest
+    container_name: sardana_dev_databaseds
     networks:
       - sardana
     depends_on:
@@ -74,8 +74,8 @@ services:
     restart: on-failure
   
   tangotest:
-    image: ${DOCKER_REGISTRY_HOST}/${DOCKER_REGISTRY_USER}/tango-java:latest
-    container_name: ${CONTAINER_NAME_PREFIX}tangotest
+    image: nexus.engageska-portugal.pt/ska-docker/tango-java:latest
+    container_name: sardana_dev_tangotest
     networks:
       - sardana
     environment:

--- a/.devcontainer/sardana_dev/Dockerfile
+++ b/.devcontainer/sardana_dev/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.155.1/containers/python-3-miniconda/.devcontainer/base.Dockerfile
 
-FROM mambaorg/micromamba:0.13.1
+FROM condaforge/mambaforge
 
 # RUN conda install mamba -n base -c conda-forge --yes
 
@@ -10,11 +10,22 @@ FROM mambaorg/micromamba:0.13.1
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends pkg-config make build-essential \
-    iputils-ping git libgl1-mesa-glx ssh
+    iputils-ping git libgl1-mesa-glx libgl1-mesa-dev libxi6 libnvidia-egl-wayland-dev \
+    mesa-utils libxft-dev libglew-dev libglfw3-dev \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD environment.yml /root/
 # RUN micromamba env update -n base -f /root/environment.yml && rm /root/environment.yml
-RUN micromamba install -y -n base -f /root/environment.yml && micromamba clean --all --yes
+RUN mamba env update -n base -f /root/environment.yml && mamba clean --all --yes
+
+# Install jive and its dependencies
+RUN mamba install -c beenje jive
+RUN mamba install xorg-libxtst
+
+# Create XDG_RUNTIME_DIR
+RUN mkdir -p /tmp/runtime-root && chmod -R 700 /tmp/runtime-root
+
 # [Optional] Uncomment to install a different version of Python than the default
 # RUN conda install -y python=3.6 \
 #     && pip install --no-cache-dir pipx \

--- a/.devcontainer/sardana_dev/Dockerfile
+++ b/.devcontainer/sardana_dev/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && rm -rf /var/lib/apt/lists/*
 
 ADD environment.yml /root/
-# RUN micromamba env update -n base -f /root/environment.yml && rm /root/environment.yml
 RUN mamba env update -n base -f /root/environment.yml && mamba clean --all --yes
 
 # Install jive and its dependencies

--- a/.devcontainer/sardana_dev/environment.yml
+++ b/.devcontainer/sardana_dev/environment.yml
@@ -11,6 +11,8 @@ dependencies:
   - pyqtgraph
   - matplotlib
   - h5py
+  - autopep8
+  - flake8
   - qt
   - pyqt
   - libxcb

--- a/.devcontainer/sardana_dev/environment.yml
+++ b/.devcontainer/sardana_dev/environment.yml
@@ -11,8 +11,14 @@ dependencies:
   - pyqtgraph
   - matplotlib
   - h5py
-  - autopep8
-  - flake8
+  - qt
+  - pyqt
+  - libxcb
+  - pytest
+  - libxkbcommon
+  - spyder
+  - guiqwt
+  - lxml
   - pip:
     # Temporarily install taurus from repo to include MR!1191
     - git+https://gitlab.com/taurus-org/taurus.git@9a3043ad


### PR DESCRIPTION
- removed .env for .devcontainer as it does not work for all docker versions
- use mambaforge to easily intall packages from conda-forge using mamba
- installed system packages in the sardana image to be able to use X apps like jive, expconf
- installed jive in the sardana image which is really handy for dev when multiple clients are required
- updated the environment file for .devcontainer to install pyqt related stuff required for expconf etc.