### PR TITLE
Refactor pool external object

### DIFF
--- a/src/sardana/pool/poolbasegroup.py
+++ b/src/sardana/pool/poolbasegroup.py
@@ -171,10 +171,7 @@ class PoolBaseGroup(PoolContainer):
             # a tango channel or non internal element (ex: ioregister or motor
             # in measurement group)
             if not internal:
-                validator = TangoAttributeNameValidator()
-                params = validator.getUriGroups(user_element_id)
-                params['pool'] = self._get_pool()
-                user_element = PoolExternalObject(**params)
+                user_element = PoolExternalObject(pool, user_element_id)
             self.add_user_element(user_element)
         self._pending = False
 

--- a/src/sardana/pool/poolexternal.py
+++ b/src/sardana/pool/poolexternal.py
@@ -53,35 +53,21 @@ class PoolBaseExternalObject(PoolBaseObject):
 class PoolTangoObject(PoolBaseExternalObject):
     """TODO"""
 
-    def __init__(self, **kwargs):
-        scheme = kwargs.pop('scheme', 'tango')
-        attribute_name = kwargs.pop('_shortattrname')
-        host, port = kwargs.pop('host', None), kwargs.pop('port', None)
-        devalias = kwargs.pop('_devalias', None)
-        device_name = kwargs.pop('devname', None)
-        if host is None:
-            db = PyTango.Database()
-            host, port = db.get_db_host(), db.get_db_port()
-        else:
-            db = PyTango.Database(host, port)
-        full_name = "<unknown>"
-        if device_name is None:
-            if devalias is not None:
-                try:
-                    device_name = db.get_device_alias(devalias)
-                    full_name = "tango://{0}:{1}/{2}/{3}".format(
-                        host, port, device_name, attribute_name)
-                except:
-                    full_name = "{0}/{1}".format(devalias, attribute_name)
-        else:
-            full_name = "tango://{0}:{1}/{2}/{3}".format(
-                host, port, device_name, attribute_name)
-        self._device_name = device_name
-        self._attribute_name = attribute_name
+    def __init__(self, pool, name):
+        validator = TangoAttributeNameValidator()
+        params = validator.getUriGroups(name)
+        full_name = "{}:{}{}".format(params['scheme'], params['authority'], params['path'])
+        name = "{}/{}".format(params['devname'], params['_shortattrname'])
+        self._device_name = params['devname']
+        self._attribute_name = params['_shortattrname']
         self._config = None
         self._device = None
+
         # TODO evaluate to use alias instead of device_name
-        kwargs['name'] = '{0}/{1}'.format(device_name, attribute_name)
+        kwargs = {}
+        kwargs['scheme'] = params['scheme']
+        kwargs['pool'] = pool
+        kwargs['name'] = name
         kwargs['full_name'] = full_name
         PoolBaseExternalObject.__init__(self, **kwargs)
 

--- a/src/sardana/pool/poolexternal.py
+++ b/src/sardana/pool/poolexternal.py
@@ -33,8 +33,9 @@ __docformat__ = 'restructuredtext'
 import PyTango
 
 from sardana import ElementType
+import sardana
 from sardana.pool.poolbaseobject import PoolBaseObject
-
+from taurus.core.tango.tangovalidator import TangoAttributeNameValidator
 
 class PoolBaseExternalObject(PoolBaseObject):
     """TODO"""
@@ -104,7 +105,19 @@ _SCHEME_CLASS = {'tango': PoolTangoObject,
                  None: PoolTangoObject}
 
 
-def PoolExternalObject(**kwargs):
-    scheme = kwargs.get('scheme', 'tango')
-    klass = _SCHEME_CLASS[scheme]
-    return klass(**kwargs)
+def PoolExternalObject(pool, name):
+    """
+    Factory of Pool external objects.
+
+    :param pool: The pool object.
+    :type pool: `sardana.pool.Pool`
+    :param name: The name of the external object (Any name accepted by Taurus
+        validators.).
+    :type name: `str`
+    :return: Pool external object.
+    :rtype: `sardana.pool.poolexternal.PoolBaseExternalObject`
+    """
+
+    scheme = name.split(":")[0]
+    klass = _SCHEME_CLASS.get(scheme, PoolTangoObject)
+    return klass(pool, name)

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -794,11 +794,8 @@ class MeasurementConfiguration(object):
                 user_config_ctrl['channels'] = user_config_channel = {}
             for ch_name, ch_data in list(ctrl_data['channels'].items()):
                 if external:
-                    validator = TangoAttributeNameValidator()
                     full_name = ch_data.get('full_name', ch_name)
-                    params = validator.getUriGroups(full_name)
-                    params['pool'] = pool
-                    channel = PoolExternalObject(**params)
+                    channel = PoolExternalObject(pool, full_name)
                 else:
                     channel = pool.get_element_by_full_name(ch_name)
                 ch_data = self._fill_channel_data(channel, ch_data)


### PR DESCRIPTION
Working on #1053 we found that full name of the Pool Tango object (External measurement group channel. i.e: /sys/tg_test/1/ampli) full name is wrongly discovered.

The ways of retrieving the tango database host between PyTango and TangoNameValidators are inconsistent. For instance, inside a docker container PyTango returns <docker_network>.<docker_container_name>:<port> while using a Taurus validator returns the host and port specified by the TANGO_HOST environment variable. Leading to names like: "tango://sardana_network. sardana_dev_databaseds:10000/sys/tg_test/1/ampli" instead of "tango://databaseds:10000/sys/tg_test/1/ampli".

The use of Taurus validators instead of accessing PyTango database host and port API for discovery the full name of a PoolTangoObject fixes the problem.

PoolExternalObject requires many kwargs describing the object identity, this forces the API users to discover those kwargs using Taurus validators. Since PoolTangoObject can do this discovery by itself, we decided to change the PoolExternalObject API and we adapted its usage in Sardana code base.