### PR TITLE
fix: rename_elem: update name of elem before other methods that depends on it get called.

### DIFF
--- a/src/sardana/pool/pool.py
+++ b/src/sardana/pool/pool.py
@@ -538,12 +538,13 @@ class Pool(PoolContainer, PoolObject, SardanaElementManager, SardanaIDManager):
         return ret
 
     def rename_element(self, old_name, new_name):
+        PoolContainer.rename_element(self, old_name, new_name)
+
         elem = self.get_element_by_name(old_name)
         if type(elem) == PoolMeasurementGroup:
             elem.rename_element(old_name, new_name)
         else:
             elem.controller.rename_element(old_name, new_name)
-        PoolContainer.rename_element(self, old_name, new_name)
         elem = self.get_element_by_name(new_name)
         self.fire_event(EventType("ElementChanged"), elem)
 


### PR DESCRIPTION
The property name of the elem is used in the rename_element method to
assign the new name of the element, however,
it is not updated in the moment the method
is executed.

We changed the order of these events in order to
have the name updated in the following calls to
rename_element.