### PR TITLE
Hotfix 3.1.2 - fix memory leak in continuous scans

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 3.1.1
+current_version = 3.1.2-alpha
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 3.1.2-alpha
+current_version = 3.1.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the formats and conventions from [keepachangelog.com]
 
-## [3.1.2] 2021-07-16
+## [3.1.2] 2021-08-02
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the formats and conventions from [keepachangelog.com]
 
+## [3.1.2] 2021-07-16
+
+### Fixed
+
+* Memory leak in MacroServer when executing ascanct, meshct, etc. continuous scan macros (#1664)
+
 ## [3.1.1] 2021-06-11
 
 ### Fixed
@@ -1057,6 +1063,7 @@ Main improvements since sardana 1.5.0 (aka Jan15):
 
 
 [keepachangelog.com]: http://keepachangelog.com
+[3.1.2]: https://github.com/sardana-org/sardana/compare/3.1.2...3.1.1
 [3.1.1]: https://github.com/sardana-org/sardana/compare/3.1.1...3.1.0
 [3.1.0]: https://github.com/sardana-org/sardana/compare/3.1.0...3.0.3
 [3.0.3]: https://github.com/sardana-org/sardana/compare/3.0.3...2.8.6

--- a/doc/source/news.rst
+++ b/doc/source/news.rst
@@ -7,6 +7,21 @@ For a complete list of changes consult the Sardana `CHANGELOG.md \
 <https://github.com/sardana-org/sardana/blob/develop/CHANGELOG.md>`_ file.
 
 ****************************
+What's new in Sardana 3.1.2?
+****************************
+
+Date: 2021-08-02
+
+Type: hotfix release
+
+Fixed
+=====
+
+- Avoid *memory leak* in continuous scans (``ascanct``, ``meshct``, etc.).
+  The MacroServer process memory was growing on each scan execution by the
+  amount corresponding to storing in the memory the scan data.
+
+****************************
 What's new in Sardana 3.1.1?
 ****************************
 

--- a/src/sardana/macroserver/macros/scan.py
+++ b/src/sardana/macroserver/macros/scan.py
@@ -249,7 +249,7 @@ class aNscan(Hookable):
         step = {}
         step["pre-move-hooks"] = self.getHooks('pre-move')
         post_move_hooks = self.getHooks(
-            'post-move') + [self._fill_missing_records]
+            'post-move')
         step["post-move-hooks"] = post_move_hooks
         step["pre-acq-hooks"] = self.getHooks('pre-acq')
         step["post-acq-hooks"] = self.getHooks('post-acq') + self.getHooks(
@@ -326,14 +326,6 @@ class aNscan(Hookable):
             return self.nr_interv
         elif mode == ContinuousMode:
             return self.nr_waypoints
-
-    def _fill_missing_records(self):
-        # fill record list with dummy records for the final padding
-        nb_of_points = self.nb_points
-        scan = self._gScan
-        nb_of_records = len(scan.data.records)
-        missing_records = nb_of_points - nb_of_records
-        scan.data.initRecords(missing_records)
 
     def _get_nr_points(self):
         msg = ("nr_points is deprecated since version 3.0.3. "
@@ -1782,7 +1774,7 @@ class meshct(Macro, Hookable):
         step = {}
         step["pre-move-hooks"] = self.getHooks('pre-move')
         post_move_hooks = self.getHooks(
-            'post-move') + [self._fill_missing_records]
+            'post-move')
         step["post-move-hooks"] = post_move_hooks
         step["check_func"] = []
         step["active_time"] = self.nb_points * (self.integ_time
@@ -1816,15 +1808,6 @@ class meshct(Macro, Hookable):
 
     def getIntervalEstimation(self):
         return len(self.waypoints)
-
-    def _fill_missing_records(self):
-        # fill record list with dummy records for the final padding
-        nb_of_points = self.nb_points
-        scan = self._gScan
-        nb_of_total_records = len(scan.data.records)
-        nb_of_records = nb_of_total_records - self.point_id
-        missing_records = nb_of_points - nb_of_records
-        scan.data.initRecords(missing_records)
 
     def _get_nr_points(self):
         msg = ("nr_points is deprecated since version 3.0.3. "

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2125,6 +2125,22 @@ class CAcquisition(object):
                 non_compatible_channels.append(name)
         is_compatible = len(non_compatible_channels) == 0
         return is_compatible, non_compatible_channels
+    
+    def _fill_missing_records(self, start_record=0):
+        """Fill missing records in scan data.
+        
+        Usefull for final padding at the end of the waypoint/scan.
+
+        :param start_record: record number from which start calculating
+            missing records (usefull to multi-waypoints scans)
+        :type start_record: int
+        """
+        # in multi-waypoint scans e.g. meshct, nb_points is per waypoint
+        expected_records = self.macro.nb_points
+        total_records = len(self.data.records)
+        records = total_records - start_record
+        missing_records = expected_records - records
+        self.data.initRecords(missing_records)
 
 
 def generate_timestamps(synch_description, initial_timestamp=0):
@@ -2575,6 +2591,9 @@ class CTScan(CScan, CAcquisition):
             for hook in waypoint.get('post-move-hooks', []):
                 hook()
 
+            # fill record list with empty records for the final padding of waypoint
+            self._fill_missing_records(start_record=nb_points * i)
+
             if start_positions is None:
                 last_positions = positions
 
@@ -2854,13 +2873,6 @@ class TScan(GScan, CAcquisition):
         if hasattr(macro, 'getHooks'):
             for hook in macro.getHooks('post-acq'):
                 hook()
-
-    def _fill_missing_records(self):
-        # fill record list with dummy records for the final padding
-        nb_points = self.macro.nb_points
-        records = len(self.data.records)
-        missing_records = nb_points - records
-        self.data.initRecords(missing_records)
 
     def _estimate(self):
         with_time = hasattr(self.macro, "getTimeEstimation")

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,7 +47,7 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '3.1.1'
+version = '3.1.2-alpha'
 
 description = "instrument control and data acquisition system"
 

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,7 +47,7 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '3.1.2-alpha'
+version = '3.1.2'
 
 description = "instrument control and data acquisition system"
 


### PR DESCRIPTION
#1095 documents MacroServer memory growing problems when performing numerous long scans. The last investigation [demonstrated a significant improvement when using jemalloc](https://github.com/sardana-org/sardana/issues/1095#issuecomment-596144102). Those tests were done on timescan, and I assumed that the continuous scans should behave the same since these scans reuse the same implementation of the data handling. But this assumption turned out to be wrong, as demonstrated in this trends:

(All examples in this description use measurement group with 20 software synchronized dummy counter/timers)

- `repeat 10 "ascanct mot01 0 100 10000 0.001"`  - increas of 260 MB!
  ![10ascanct_10kpoints_20channels_develop](https://user-images.githubusercontent.com/6735649/125860238-e041daa8-9a31-4265-89e8-264983fc4daa.png)
- `repeat 10 "meshct mot01 0 50 5000 mot02 0 1 1 0.001"` - increase of 260 MB 
  ![10meshct_10kpoints_20channels_develop](https://user-images.githubusercontent.com/6735649/125860464-4d269d4e-b064-4dee-9bb5-9c139ae10685.png)

This PR provides a hotfix release 3.1.2 which solves the above-mentioned memory leak.

**Technical explanation**:

`aNscan`, which holds a hard reference to the `CTScan`, adds its bound method as hook in the waypoint generator.
The enumeration object created from the waypoint generator is then hard referenced in the `CTScan`. Hence, a cycle reference
is created between `CTScan` and `aNscan` objects (I imagine that the last yielded waypoint, which contains the bound method, must be kept in the enumeration object). Then due to unknown reasons, the scan memory can not be released if this cycle reference exists (even if I believe that at some point the GC should collect it). This cycle reference was demonstrated using [this reduced example](https://gist.github.com/reszelaz/389fa8d262b5206879e98b0518d4be10).

**Introduced change**:

Follow the example of the `timescan` macro and `TScan` class in order to not pass  `_fill_missing_records()` as hook. Refactor the code and define the `_fill_missing_record()` in the `CAcquisition` class (base class of both `CTScan` and `TScan`). This way the memory is correctly released for `ascanct`, `a2scanct`, `meshct`, etc. macros.

This PR solves the memory leak in the Sardana as demonstrate on this examples:

- `repeat 10 "ascanct mot01 0 100 10000 0.001"`
  ![10ascanct_10kpoints_20channels_hotifx-3 1 2](https://user-images.githubusercontent.com/6735649/125861577-ffecbc01-8178-4561-a79e-c63f4f53841e.png)
- `repeat 10 "meshct mot01 0 50 5000 mot02 0 1 1 0.001"`
  ![10meshct_10kpoints_20channels_hotifx-3 1 2](https://user-images.githubusercontent.com/6735649/125861715-96be04c5-7b9d-4abb-a0a5-55c97127b39d.png)


...but the following way of developing a macro could still trigger it:

```python
from sardana.macroserver.macro import Macro


class MyAscanct(Macro):

    def hook(self):
        self.print("In MyAscanct.hook()")

    def run(self):
        self.ascanct, _ = self.prepareMacro("ascanct", "mot01", 0, 100, 10000, 0.001)
        self.ascanct.appendHook((self.hook, ["post-move"]))
        self.runMacro(self.ascanct)
```

In order to avoid it I see the following two options:
1. make [`GScan.steps`](https://github.com/sardana-org/sardana/blob/f0ac950f1dddf14b625c410e515da1fbb6155248/src/sardana/macroserver/scan/gscan.py#L992) property do not keep a reference to the enumeration object 
2. make `Hookable` class keep weak references to the hooks

@tiagocoutinho, @rhomspuron, @jairomoldes I know you suffered these memory leaks, it would be nice if you could review the changes and make tests.
@13bscsaamjad, have you observed this at MAXIV?