### PR TITLE
Step scan generator has now the possibility to not move motors. Fix #1159

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -1463,7 +1463,7 @@ class Macro(Logger):
 
         :param obj: object to be released from the control
         :rtype: object"""
-        self.executor.returnObj(obj)
+        self.executor.returnObj(obj, self)
 
     @mAPI
     def getObj(self, name, type_class=All, subtype=All, pool=All, reserve=True):

--- a/src/sardana/macroserver/macros/examples/scans.py
+++ b/src/sardana/macroserver/macros/examples/scans.py
@@ -145,7 +145,7 @@ class ascanr(Macro, Hookable):
         self.repeat = repeat
         self.opts = opts
 
-        self.nb_points = nr_interv + 1
+        self.nb_points = (nr_interv + 1) * repeat
         self.interv_sizes = (self.finals - self.starts) / nr_interv
         self.name = 'ascanr'
 
@@ -166,13 +166,15 @@ class ascanr(Macro, Hookable):
             "post-acq-hooks"] = self.getHooks('post-acq') + self.getHooks('_NOHINT_')
         step["post-step-hooks"] = self.getHooks('post-step')
         step["check_func"] = []
-        extrainfo = {"repetition": 0}  # !!!
-        step['extrainfo'] = extrainfo  # !!!
-        for point_no in range(self.nb_points):
+        for point_no in range(self.nb_points // self.repeat):
+            extrainfo = {"repetition": 0}  # !!!
+            step['extrainfo'] = extrainfo  # !!!
             step["positions"] = self.starts + point_no * self.interv_sizes
             step["point_id"] = point_no
-            for i in range(self.repeat):
+            yield step
+            for i in range(1, self.repeat):
                 extrainfo["repetition"] = i  # !!!
+                step["positions"] = [None]
                 yield step
 
     def run(self, *args):

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -199,8 +199,9 @@ class GScan(Logger):
     The generator must be a function yielding a dictionary with the following
     content (minimum) at each step of the scan:
 
-    - 'positions' : In a step scan, the position where the moveables
-      should go
+    - 'positions' : In a step scan, a sequence with position(s) where 
+      the moveable(s) should go. ``None`` or ``float("NaN")`` in the sequence
+      means do not move a given moveable.
     - 'integ_time' : In a step scan, a number representing the integration
       time for the step (in seconds)
     - 'integ_time' : In a continuous scan, the time between acquisitions

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -930,7 +930,7 @@ class GScan(Logger):
                             path = MotionPath(v_motor, start, stop)
                             max_path_duration = max(
                                 max_path_duration, path.duration)
-                            new_start_pos[i] = end_pos
+                            new_start_pos[i] = stop
                         integ_time = step.get("integ_time", 0.0)
                         acq_time += integ_time
                         motion_time += max_path_duration

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -921,18 +921,21 @@ class GScan(Logger):
                         step = next(iterator)
                         end_pos = step['positions']
                         max_path_duration = 0.0
-                        for v_motor, start, stop in zip(v_motors,
-                                                        start_pos,
-                                                        end_pos):
+                        new_start_pos = start_pos.copy()
+                        for i, (v_motor, start, stop) in enumerate(
+                                zip(v_motors, start_pos, end_pos)):
+                            if stop is None or np.isnan(stop):
+                                continue
                             path = MotionPath(v_motor, start, stop)
                             max_path_duration = max(
                                 max_path_duration, path.duration)
+                            new_start_pos[i] = end_pos
                         integ_time = step.get("integ_time", 0.0)
                         acq_time += integ_time
                         motion_time += max_path_duration
                         total_time += integ_time + max_path_duration
                         point_nb += 1
-                        start_pos = end_pos
+                        start_pos = new_start_pos
                 finally:
                     if with_interval:
                         interval_nb = self.macro.getIntervalEstimation()


### PR DESCRIPTION
Note that this also fixes a bug in returnObj() of macro.py

Please find attached 2 useless test macros to check the fix works fine.
[useless.txt](https://github.com/sardana-org/sardana/files/6870004/useless.txt)

It worked as expected in a test environment running:
ascan mot01 0 100 10 0.1
u2scan mot03 0 100 gap01 30 40 8 0.1
uscan mot01 0 10 9 0.1
uscan gap01 0 10 9 0.1

I also suggest that maybe it will be nice to adapt the aNscan family in order to allow a new "repeat" parameter