### PR TITLE
Fix udef elem expconf

### DIFF
--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -803,6 +803,9 @@ class MeasurementConfiguration(object):
                     try:
                         channel = pool.get_element_by_full_name(ch_name)
                     except KeyError:
+                        if not ch_data['enabled']:
+                            user_config_channel[ch_name] = ch_data            
+                            continue
                         raise ValueError(
                             '{} is not defined'.format(ch_data['name']))
 

--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -793,31 +793,37 @@ class MeasurementConfiguration(object):
             if 'channels' in ctrl_data:
                 user_config_ctrl['channels'] = user_config_channel = {}
             for ch_name, ch_data in list(ctrl_data['channels'].items()):
-                if ch_data.get('enabled', True):
+                if external:
+                    validator = TangoAttributeNameValidator()
+                    full_name = ch_data.get('full_name', ch_name)
+                    params = validator.getUriGroups(full_name)
+                    params['pool'] = pool
+                    channel = PoolExternalObject(**params)
+                else:
+                    try:
+                        channel = pool.get_element_by_full_name(ch_name)
+                    except KeyError:
+                        raise ValueError(
+                            '{} is not defined'.format(ch_data['name']))
+
+                ch_data = self._fill_channel_data(channel, ch_data)
+                user_config_channel[ch_name] = ch_data
+                ch_item = ChannelConfiguration(channel, ch_data)
+                ch_item.controller = ctrl_item
+                ctrl_item.add_channel(ch_item)
+                if ch_item.enabled:
                     if external:
-                        validator = TangoAttributeNameValidator()
-                        full_name = ch_data.get('full_name', ch_name)
-                        params = validator.getUriGroups(full_name)
-                        params['pool'] = pool
-                        channel = PoolExternalObject(**params)
                         id_ = channel.full_name
                     else:
-                        try:
-                            channel = pool.get_element_by_full_name(ch_name)
-                        except KeyError:
-                            raise ValueError(
-                                '{} is not defined'.format(ch_data['name']))
                         id_ = channel.id
-                    ch_data = self._fill_channel_data(channel, ch_data)
-                    ch_item = ChannelConfiguration(channel, ch_data)
-                    ch_item.controller = ctrl_item
-                    ctrl_item.add_channel(ch_item)                    
                     user_elem_ids[ch_item.index] = id_
+
+                if ch_item.enabled:
                     ctrl_enabled = True
-                    if acq_synch is not None:
-                        channel_acq_synch[channel] = acq_synch
-                user_config_channel[ch_name] = ch_data
-                
+
+                if acq_synch is not None:
+                    channel_acq_synch[channel] = acq_synch
+
             if not external and ctrl.is_timerable():
                 ctrl_item.update_timer()
                 ctrl_item.update_monitor()


### PR DESCRIPTION
This PR fixes expconf issues introduced by #1615 and reported by @yimli in https://github.com/sardana-org/sardana/pull/1615#issuecomment-885535432 - see 3d146b6
One idea to improve it would be to somehow mark the row corresponding to a disabled and undefined channel in the expconf e.g. red background. Does someone know how to do it?

This PR also fixes one more issue with restoring the memorized value of the measurement group's configuration attribute containing disabled but undefined channels - see 244b5f2.

@yimli it would be great if you could test if it fixes the issues you observed. Many thanks!

