### PR TITLE
Advance output of last points in continuous scan

### DIFF
--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2637,7 +2637,7 @@ class CTScan(CScan, CAcquisition):
                   instead of _motion or in both cases: CSScan and CTScan
                   coordinate the physical motors' velocit.
         """
-        self.macro.debug("on_waypoints_end() entering...")
+        self.debug("on_waypoints_end() entering...")
         self.set_all_waypoints_finished(True)
         if restore_positions is not None:
             self._restore_motors()  # first restore motors backup

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2674,7 +2674,6 @@ class CTScan(CScan, CAcquisition):
         if restore_positions is not None:
             self._restore_motors()  # first restore motors backup
             self._setFastMotions()  # then try to go even faster (limits)
-            self.macro.info("Correcting overshoot...")
             self._physical_motion.move(restore_positions)
         self.motion_end_event.set()
         self.cleanup()
@@ -2683,6 +2682,10 @@ class CTScan(CScan, CAcquisition):
         self.join_thread_pool()
         self.debug("All data events are processed")
         self.data.endRecords()
+        if restore_positions is not None:
+            self.macro.info("Overshoot was corrected")
+        else:
+            self.macro.info("Overshoot was not corrected")
 
         # Note: The commented out code below works, but due to an issue with
         # output of the last measurement point, it should not be enabled yet.

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2646,10 +2646,10 @@ class CTScan(CScan, CAcquisition):
             self._physical_motion.move(restore_positions)
         self.motion_end_event.set()
         self.cleanup()
-        self.macro.debug("Waiting for data events to be processed")
+        self.debug("Waiting for data events to be processed")
         self.wait_value_buffer()
         self.join_thread_pool()
-        self.macro.debug("All data events are processed")
+        self.debug("All data events are processed")
 
         # Note: The commented out code below works, but due to an issue with
         # output of the last measurement point, it should not be enabled yet.
@@ -2913,7 +2913,7 @@ class TScan(GScan, CAcquisition):
         self.debug("Waiting for value buffer events to be processed")
         self.wait_value_buffer()
         self.join_thread_pool()
-        self.macro.checkPoint()
+        self.debug("All data events are processed")
         self._fill_missing_records()
         yield 100
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2650,6 +2650,7 @@ class CTScan(CScan, CAcquisition):
         self.wait_value_buffer()
         self.join_thread_pool()
         self.debug("All data events are processed")
+        self.data.endRecords()
 
         # Note: The commented out code below works, but due to an issue with
         # output of the last measurement point, it should not be enabled yet.
@@ -2915,6 +2916,7 @@ class TScan(GScan, CAcquisition):
         self.join_thread_pool()
         self.debug("All data events are processed")
         self._fill_missing_records()
+        self.data.endRecords()
         yield 100
 
         if hasattr(macro, 'getHooks'):

--- a/src/sardana/macroserver/scan/scandata.py
+++ b/src/sardana/macroserver/scan/scandata.py
@@ -492,8 +492,13 @@ class RecordList(dict):
 
     def addRecords(self, records):
         list(map(self.addRecord, records))
-
-    def end(self):
+    
+    def endRecords(self):
+        """Complete and add *initilized* records
+        
+        Complete (eventually apply interpolation) initilized
+        records and add them to the *data handler*.
+        """
         start = self.currentIndex
         for i in range(start, len(self.records)):
             rc = self.records[i]
@@ -502,6 +507,8 @@ class RecordList(dict):
                 self.applyZeroOrderInterpolation(rc)
             self.datahandler.addRecord(self, rc)
             self.currentIndex += 1
+
+    def end(self):
         self.datahandler.endRecordList(self)
 
     def getDataHandler(self):


### PR DESCRIPTION
#1651 points that output of last points in continuous scan often comes too late.

- [x] Change logger for data events processing messages to GSF classes level (CTScan and TScan) instead of the macro level. These messages may be confusing if macro is run in debug mode (the messages are interleaved with the output fo the scan records)
- [x] Delay overshoot correction until after ending all records. 

Fixes #1651.