### PR TITLE
Fix: Avoid cycle reference between h5 recorder and macro

### DIFF
--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -35,6 +35,7 @@ __docformat__ = 'restructuredtext'
 import os
 import re
 import posixpath
+import weakref
 from datetime import datetime
 import numpy
 import h5py
@@ -84,7 +85,7 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
     def __init__(self, filename=None, macro=None, overwrite=False, **pars):
         BaseFileRecorder.__init__(self, **pars)
 
-        self.macro = macro
+        self.macro = weakref.ref(macro)
         self.overwrite = overwrite
         if filename:
             self.setFileName(filename)
@@ -628,7 +629,7 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
         except ValueError as e:
             msg = 'Error writing %s. Reason: %s' % (name, e)
             self.warning(msg)
-            self.macro.warning(msg)
+            self.macro().warning(msg)
 
         # flush
         self.fd.flush()

--- a/src/sardana/macroserver/recorders/h5storage.py
+++ b/src/sardana/macroserver/recorders/h5storage.py
@@ -85,7 +85,9 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
     def __init__(self, filename=None, macro=None, overwrite=False, **pars):
         BaseFileRecorder.__init__(self, **pars)
 
-        self.macro = weakref.ref(macro)
+        if macro is not None:
+            macro = weakref.ref(macro)
+        self.macro = macro
         self.overwrite = overwrite
         if filename:
             self.setFileName(filename)
@@ -629,7 +631,8 @@ class NXscanH5_FileRecorder(BaseFileRecorder):
         except ValueError as e:
             msg = 'Error writing %s. Reason: %s' % (name, e)
             self.warning(msg)
-            self.macro().warning(msg)
+            if self.macro is not None:
+                self.macro().warning(msg)
 
         # flush
         self.fd.flush()


### PR DESCRIPTION
h5 recorder creates hard reference to macro object in _startRecordList()
method. This closes the cycle reference between macro, GScan and recorder
since GScan has hard references to the recorders and macro has hard
references to the GScan.

Use weakref instead of hard references between recorder and macro.

![image](https://user-images.githubusercontent.com/73069754/127309365-4f01f72f-9dbc-415d-9dab-5c62a9d95b54.png)

This trend shows how memory stays stable during 10 scans with 2d channels

@dschick @felix92 

This PR should fix the issue you reported in https://github.com/sardana-org/sardana/issues/1095#issuecomment-875706639

