### PR TITLE
Fix: Remove unnecessary property overwrite

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -764,7 +764,6 @@ class BaseDoor(MacroServerDevice):
     def write(self, msg, stream=None):
         if self.isSilent():
             return
-        self._output_stream = sys.stdout
         out = self._output_stream
         if stream is not None:
             start, stop = self.log_start.get(stream), self.log_stop.get(stream)


### PR DESCRIPTION
(Related to https://github.com/sardana-org/sardana/issues/1665)

This PR remove an unnecessary property overwrite. It's unnecessary because it already assigns a value in the constructor:https://github.com/sardana-org/sardana/blob/3eb154ccc4b25001925c4a48ce060d7cfda7e496/src/sardana/taurus/core/tango/sardana/macroserver.py#L337
So, it makes it impossible to make a custom output. The solution is just to remove the line.

😄 Thanks