### PR TITLE
fix: backward compatibility for meas grp conf value_ref_*

### DIFF
--- a/src/sardana/pool/poolmeasurementgroup.py
+++ b/src/sardana/pool/poolmeasurementgroup.py
@@ -1006,8 +1006,8 @@ class MeasurementConfiguration(object):
                       'for non-referable channels since 3.0.3. Re-apply ' \
                       'configuration in order to upgrade.'
                 self._parent.warning(msg)
-                channel_data.pop('value_ref_enabled')
-                channel_data.pop('value_ref_pattern')
+                channel_data.pop('value_ref_enabled', None)
+                channel_data.pop('value_ref_pattern', None)
             else:
                 msg = ('The channel {} is not referable. You can not set '
                        'the enabled and/or the pattern parameters.').format(


### PR DESCRIPTION
#867 introduced backward compatibility layer for measurement group
configurations with non-referable channels containing value_ref_*
parameters. This compatibility layer assumes that in this case both
parameters: value_ref_enabled and value_ref_pattern are present, which is
not always true.
Fix it by considering also the case when only one of these parameters is
present.

@ByRellex could you please confirm this fixes the issue you have discovered? As soon as you confirm and the CI is green I will auto-merge. Thanks!