### PR TITLE
fix: prevent showscan online startup when door does not exist

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/showscanonline.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/showscanonline.py
@@ -36,6 +36,8 @@ __all__ = [
 import click
 import pkg_resources
 
+import taurus
+from taurus.core.taurusbasetypes import TaurusDevState
 from taurus.external.qt import Qt, uic
 from taurus.qt.qtgui.base import TaurusBaseWidget
 from taurus.qt.qtgui.taurusgui import TaurusGui
@@ -234,6 +236,9 @@ class ScanWindow(Qt.QMainWindow):
         self.plot_widget.manager.newShortMessage.connect(sbar.showMessage)
 
     def setModel(self, model):
+        door = taurus.Device(model)
+        if door.state == TaurusDevState.NotReady:
+            raise RuntimeError("{} is not defined".format(model))
         self.plot_widget.setModel(model)
         self.info_form.setModel(model)
         self.point_form.setModel(model)


### PR DESCRIPTION
`ScanWindow.setModel()` set models of its subwidgets which then try
to connect to Sardana-Taurus model extensions e.g. `recordDataUpdated`
which raises not self-explanatory AttributeError.
Early recognize this situation and raise a self-explanatory RuntimeError.

Fixes #1674. @cmft could you test and review this one?


I asked this related [question](https://gitlab.com/taurus-org/taurus/-/issues/1223) to taurus project.