### PR TITLE
Avoid QtWebEngineWidgets-related warning from taurus

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -30,6 +30,12 @@ __all__ = ["ExpDescriptionEditor"]
 
 
 import json
+
+try:
+    # import QtWebEngineWidgets before QApplication is instantiated
+    from taurus.external.qt import QtWebEngineWidgets  # noqa
+except ImportError:
+    pass
 from taurus.external.qt import Qt, QtCore, QtGui, compat
 import copy
 import taurus


### PR DESCRIPTION
Since [taurus MR !1213](https://gitlab.com/taurus-org/taurus/-/merge_requests/1213) , launching expconf triggers a warning in taurus due to `QCoreApplication` being already instantiated when attempting to import `QtWebEngineWidgets`. Avoid it by doing an early import of `QtWebEngineWidgets` in `expdescription.py`

