### PR TITLE
Fix post_mortem Spock's magic command

### DIFF
--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -527,10 +527,12 @@ class BaseDoor(MacroServerDevice):
         finally:
             evt_wait.unlock()
             evt_wait.disconnect()
+    
+
+    def _clearLogBuffer(self):
+        list(map(LogAttr.clearLogBuffer, list(self._log_attr.values())))
 
     def _clearRunMacro(self):
-        # Clear the log buffer
-        list(map(LogAttr.clearLogBuffer, list(self._log_attr.values())))
         self._running_macros = None
         self._running_macro = None
         self._user_xml = None
@@ -551,6 +553,7 @@ class BaseDoor(MacroServerDevice):
         return macro_node.toXml()
 
     def preRunMacro(self, obj, parameters):
+        self._clearLogBuffer()
         self._clearRunMacro()
 
         xml_root = None

--- a/src/sardana/taurus/core/tango/sardana/macroserver.py
+++ b/src/sardana/taurus/core/tango/sardana/macroserver.py
@@ -104,6 +104,9 @@ class Attr(Logger, EventGenerator):
 
     def getTaurusAttribute(self):
         return self._attr
+    
+    def read(self, cache=False):
+        return self._attr.read(cache)
 
     def __getattr__(self, name):
         return getattr(self._attr, name)


### PR DESCRIPTION
post_mortem magic command has two problems:
- is unable to read Door stream attributes and always fallback to the buffered logs. Fix it by making the Attr class capable to read, from cache or from the device, attribute values.
- door stream buffer is cleared when macro finishes and in case of server crash these needs to be kept. Fix it by clearing buffer at the next macro startup

@cmft could you please test it? Many thanks!