### PR TITLE
Improove error handling for state read

### DIFF
--- a/src/sardana/macroserver/macros/standard.py
+++ b/src/sardana/macroserver/macros/standard.py
@@ -529,17 +529,26 @@ class mv(Macro, Hookable):
             self.debug("Starting %s movement to %s", m.getName(), p)
 
         motion = self.getMotion(self.motors)
-        state, pos = motion.move(positions)
+        try:
+            state, pos = motion.move(positions)
+        except Exception as e:
+            self.warning("Motion failed due to: {}".format(e))
+            self._log_information()
+            raise e
         if state != DevState.ON:
             self.warning("Motion ended in %s", state.name)
-            msg = []
-            for motor in self.motors:
-                msg.append(motor.information())
-            self.info("\n".join(msg))
+            self._log_information()
 
         if enable_hooks:
             for postMoveHook in self.getHooks('post-move'):
                 postMoveHook()
+
+    def _log_information(self):
+        msg = []
+        for motor in self.motors:
+            msg.append(motor.information())
+        self.info("\n".join(msg))
+
 
 
 class mstate(Macro):

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -1196,7 +1196,7 @@ class SScan(GScan):
         except InterruptException:
             raise
         except Exception:
-            self.dump_information(n, step, self.motion.moveable_list)
+            self.dump_information(n, step, self.macro.motors)
             raise
         self.debug("[ END ] motion")
 

--- a/src/sardana/pool/poolcontroller.py
+++ b/src/sardana/pool/poolcontroller.py
@@ -42,6 +42,7 @@ from taurus.core.util.containers import CaselessDict
 from sardana import State, ElementType, TYPE_TIMERABLE_ELEMENTS,\
     TYPE_PSEUDO_ELEMENTS
 from sardana.sardanaevent import EventType
+from sardana.sardanaexception import clear_exception_context
 from sardana.sardanavalue import SardanaValue
 from sardana.sardanautils import is_non_str_seq, is_number
 
@@ -555,6 +556,9 @@ class PoolController(PoolBaseController):
 
     @staticmethod
     def _format_exception(exc_info):
+        exc = exc_info[1]
+        clear_exception_context(exc)
+        exc_info = exc_info[0], exc, exc_info[2]
         fmt_exc = traceback.format_exception(*exc_info)
         fmt_exc = "".join(fmt_exc)
         if fmt_exc.endswith("\n"):

--- a/src/sardana/pool/poolcontroller.py
+++ b/src/sardana/pool/poolcontroller.py
@@ -555,7 +555,7 @@ class PoolController(PoolBaseController):
 
     @staticmethod
     def _format_exception(exc_info):
-        fmt_exc = traceback.format_exception_only(*exc_info[:2])
+        fmt_exc = traceback.format_exception(*exc_info)
         fmt_exc = "".join(fmt_exc)
         if fmt_exc.endswith("\n"):
             fmt_exc = fmt_exc[:-1]

--- a/src/sardana/sardanaexception.py
+++ b/src/sardana/sardanaexception.py
@@ -30,12 +30,25 @@ for sardana exceptions"""
 
 __all__ = ["AbortException", "SardanaException", "SardanaExceptionList",
            "UnknownCode", "UnknownLibrary", "LibraryError",
-           "format_exception_only", "format_exception_only_str"]
+           "format_exception_only", "format_exception_only_str",
+           "clear_exception_context"]
 
 __docformat__ = 'restructuredtext'
 
 import sys
 import traceback
+
+
+def clear_exception_context(exc):
+    """Clear expcetion __context__
+    
+    When exception's __cause__ is filled, then clear the
+    __context__ also for the causing exception, and so on
+    recursivelly. """
+    if exc.__cause__ == None:
+        exc.__context__ = None
+    else:
+        clear_exception_context(exc.__cause__)
 
 
 def format_exception_only(etype, value):

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -487,9 +487,8 @@ class PoolElement(BaseElement, TangoDevice):
         try:
             if not evt_wait.waitForEvent((DevState.ON, DevState.ALARM),
                                          timeout=3, reactivity=.1):
-                info = self.information()
                 raise RuntimeError(
-                    "{} state is different than ON or ALARM. Can not proceed to start. Full information:\n{}".format(self.name, info))
+                    "{} state is different than ON or ALARM. Can not proceed to start.".format(self.name))
             # Clear event set to not confuse the value coming from the
             # connection with the event of of end of the operation
             # in the next wait event. This was observed on Windows where

--- a/src/sardana/taurus/core/tango/sardana/pool.py
+++ b/src/sardana/taurus/core/tango/sardana/pool.py
@@ -487,8 +487,9 @@ class PoolElement(BaseElement, TangoDevice):
         try:
             if not evt_wait.waitForEvent((DevState.ON, DevState.ALARM),
                                          timeout=3, reactivity=.1):
+                info = self.information()
                 raise RuntimeError(
-                    "{} is Moving, can not proceed to start".format(self.name))
+                    "{} state is different than ON or ALARM. Can not proceed to start. Full information:\n{}".format(self.name, info))
             # Clear event set to not confuse the value coming from the
             # connection with the event of of end of the operation
             # in the next wait event. This was observed on Windows where
@@ -499,9 +500,9 @@ class PoolElement(BaseElement, TangoDevice):
             self._start(*args, **kwargs)
             ts2 = time.time()
             evt_wait.waitForEvent((DevState.MOVING, ), after=ts1)
-        except:
+        except Exception as e:
             evt_wait.disconnect()
-            raise
+            raise e
         ts2 = evt_wait.getRecordedEvents().get(DevState.MOVING, ts2)
         return (ts2,)
 


### PR DESCRIPTION
Addressing this MAX-IV ticket: https://agile.maxiv.lu.se/project/vinhar-max-iv-machine-cs/us/4056 

Error in the controller layer need to be handled in the way that points to the actual error.

Now, when reading the state of an axis causes an error (eg. exception in StateOne) it will get printed to spock console, showing traceback with line of the error.

![Screenshot from 2021-09-01 18-16-12](https://user-images.githubusercontent.com/41666803/131709682-473df2e1-cac8-4e54-97b1-8f7b0427c0d2.png)

Please let me know if this is a sardana-friendly way.
