### PR TITLE
Hotfix 3.1.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 3.1.2
+current_version = 3.1.3-alpha
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 3.1.3-alpha
+current_version = 3.1.3
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the formats and conventions from [keepachangelog.com]
 
-## [3.1.3] 2021-09-15
+## [3.1.3] 2021-09-17
 
 ### Fixed
 
-* Start record index in CTScan when executing waypoint with not homogeneous number of points introduced on 3.1.2
-
-* Bug in mv and scan macros with Pseudomotors (#1686)
+* Grouped move of pseudo motors proceeding from the same controller e.g. slit's gap and offset (#1686)
+* Filling missing records i.e. final padding in CTScan when executing waypoints with not homogeneous 
+  number of points, introduced on 3.1.2. (#1689)
 
 ## [3.1.2] 2021-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This file follows the formats and conventions from [keepachangelog.com]
 
 * Start record index in CTScan when executing waypoint with not homogeneous number of points introduced on 3.1.2
 
+* Bug in mv and scan macros with Pseudomotors (#1686)
+
 ## [3.1.2] 2021-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the formats and conventions from [keepachangelog.com]
 
+## [3.1.3] 2021-09-15
+
+### Fixed
+
+* Start record index in CTScan when executing waypoint with not homogeneous number of points introduced on 3.1.2
+
 ## [3.1.2] 2021-08-02
 
 ### Fixed
@@ -1063,6 +1069,7 @@ Main improvements since sardana 1.5.0 (aka Jan15):
 
 
 [keepachangelog.com]: http://keepachangelog.com
+[3.1.3]: https://github.com/sardana-org/sardana/compare/3.1.3...3.1.2
 [3.1.2]: https://github.com/sardana-org/sardana/compare/3.1.2...3.1.1
 [3.1.1]: https://github.com/sardana-org/sardana/compare/3.1.1...3.1.0
 [3.1.0]: https://github.com/sardana-org/sardana/compare/3.1.0...3.0.3

--- a/doc/source/news.rst
+++ b/doc/source/news.rst
@@ -7,6 +7,24 @@ For a complete list of changes consult the Sardana `CHANGELOG.md \
 <https://github.com/sardana-org/sardana/blob/develop/CHANGELOG.md>`_ file.
 
 ****************************
+What's new in Sardana 3.1.3?
+****************************
+
+Date: 2021-09-17
+
+Type: hotfix release
+
+Fixed
+=====
+
+- Regression introduced in Sardana 3.0.3 affecting grouped move/scan of pseudo
+  motors proceeding from the same controller e.g. slit's gap and offset, HKL pseudo motors.
+  Such a grouped move was only sending set possition to the first pseudo motor.
+* Regression introduced in Sardana 3.1.2 affecting custom continuous scans composed from
+  waypoints with non-homogeneous number of points. Such scans were producing erroneuous
+  number of points due to an error in the final padding logic.
+
+****************************
 What's new in Sardana 3.1.2?
 ****************************
 

--- a/src/sardana/macroserver/scan/gscan.py
+++ b/src/sardana/macroserver/scan/gscan.py
@@ -2372,6 +2372,7 @@ class CTScan(CScan, CAcquisition):
             "Motor positions and relative timestamp (dt) columns contains"
             " theoretical values"
         )
+        start_record = 0
         for i, waypoint in waypoints:
             self.macro.debug("Waypoint iteration...")
 
@@ -2426,7 +2427,7 @@ class CTScan(CScan, CAcquisition):
                 raise ScanException(msg)
 
             # Set the index offset used in CAcquisition class.
-            self._index_offset = i * self.macro.nb_points
+            self._index_offset = start_record
 
             startTimestamp = time.time()
 
@@ -2591,8 +2592,10 @@ class CTScan(CScan, CAcquisition):
             for hook in waypoint.get('post-move-hooks', []):
                 hook()
 
-            # fill record list with empty records for the final padding of waypoint
-            self._fill_missing_records(start_record=nb_points * i)
+            # fill record list with empty records for the final padding of
+            # waypoint
+            self._fill_missing_records(start_record=start_record)
+            start_record += nb_points
 
             if start_positions is None:
                 last_positions = positions

--- a/src/sardana/pool/poolmotorgroup.py
+++ b/src/sardana/pool/poolmotorgroup.py
@@ -268,8 +268,6 @@ class PoolMotorGroup(PoolGroupElement):
                 )
                 raise ValueError(msg) from e
 
-            element.calculate_motion(new_position, items=items,
-                                     calculated=calculated)
         for new_position, element in zip(new_positions, user_elements):
             element.calculate_motion(new_position, items=items,
                                      calculated=calculated)

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,7 +47,7 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '3.1.3-alpha'
+version = '3.1.3'
 
 description = "instrument control and data acquisition system"
 

--- a/src/sardana/release.py
+++ b/src/sardana/release.py
@@ -47,7 +47,7 @@ name = 'sardana'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '3.1.2'
+version = '3.1.3-alpha'
 
 description = "instrument control and data acquisition system"
 


### PR DESCRIPTION
The hotfix 3.1.2 introduced a bug on the fill_missing_records method. The system assumes a constant number of point on all waypoints (meshct macro). 

Here there is a macro to reproduce the problem, I used as energy motor "mot01"  
```
import numpy as np
from sardana.macroserver.macro import Type, Macro, Hookable
from sardana.macroserver.scan import CTScan, MoveableDesc
from sardana.macroserver.macros.scan import getCallable, UNCONSTRAINED
from sardana.util.tree import BranchNode
from tango import DevState

def _calculate_positions(moveable_node, start, end):
    '''Function to calculate starting and ending positions on the physical
    motors level.
    :param moveable_node: (BaseNode) node representing a moveable.
                          Can be a BranchNode representing a PseudoMotor,
                          or a LeafNode representing a PhysicalMotor).
    :param start: (float) starting position of the moveable
    :param end: (float) ending position of the moveable

    :return: (list<(float,float)>) a list of tuples comprising starting
             and ending positions. List order is important and preserved.'''
    start_positions = []
    end_positions = []
    if isinstance(moveable_node, BranchNode):
        pseudo_node = moveable_node
        moveable = pseudo_node.data
        moveable_nodes = moveable_node.children
        starts = moveable.calcPhysical(start)
        ends = moveable.calcPhysical(end)
        for moveable_node, start, end in zip(moveable_nodes, starts,
                                             ends):
            _start_positions, _end_positions = _calculate_positions(
                moveable_node,
                start, end)
            start_positions += _start_positions
            end_positions += _end_positions
    else:
        start_positions = [start]
        end_positions = [end]

    return start_positions, end_positions


class qExafsc(Macro, Hookable):
    """
    New version of the qExafs Macro
    """

    # TODO define final MG
    # env = ('ContScanMG',)

    energy_name = "mot01"

    hints = {}

    param_def = [["startPos", Type.Float, None, "Starting position"],
                 ["end_triggers", [
                     ["endPos", Type.Float, None, "Ending pos value"],
                     ["nrIntervals", Type.Integer, None, "Nr of triggers"],
                     {'min': 1}], None, 'List of [end_pos, triggers] for the '
                                        'region'],
                 ["intTime", Type.Float, None, "Integration time per point"],

                 ["waitFE", Type.Boolean, True, ("Active the waiting for "
                                                 "opening of Front End")],
                 ]

    def prepare(self, start_pos, ends_intervals_list, int_time, wait_fe,
                **opts):

        self.start_pos = start_pos
        self.ends_intervals_list = ends_intervals_list
        self.integ_time = int_time

         self._flg_cleanup = False


        self.nr_interv = ends_intervals_list[0][1]
        self.nb_points = self.nr_interv + 1

        self.waypoints = []
        self.starts_points = []
        self.intervals_list = []
        for end_pos, intervals in self.ends_intervals_list:
            self.starts_points.append(self.start_pos)
            self.waypoints.append(end_pos)
            self.intervals_list.append(intervals)
            self.start_pos = end_pos

        motor = self.getMoveable(self.energy_name)
        self.motors = [motor]

        moveables = [MoveableDesc(moveable=motor)]
        moveables[0].is_reference = True

        self.name = opts.get('name', 'qExafsc')
        env = opts.get('env', {})
        mg_name = self.getEnv('ActiveMntGrp')
        mg = self.getMeasurementGroup(mg_name)
        mg_latency_time = mg.getLatencyTime()

        self.latency_time = mg_latency_time

        constrains = [getCallable(cns) for cns in opts.get('constrains',
                                                           [UNCONSTRAINED])]

        extrainfodesc = opts.get('extrainfodesc', [])

        self._gScan = CTScan(self, self._generator, moveables, env, constrains,
                             extrainfodesc)

        self.setData(self._gScan.data)

    def _generator(self):

        moveables_trees = self._gScan.get_moveables_trees()
        step = {}

        step["pre-move-hooks"] = self.getHooks('pre-move')
        step["post-move-hooks"] = self.getHooks('post-move')
        step['pre-acq-hooks'] = self.getHooks('pre-acq')
        step["check_func"] = []

        for i, waypoint in enumerate(self.waypoints):
            self.nr_interv = self.intervals_list[i]
            self.nb_points = self.nr_interv + 1
            step["active_time"] = self.nb_points * (self.integ_time +
                                                    self.latency_time)

     
            step["waypoint_id"] = i
            self.starts = np.array([self.starts_points[i]])
            self.finals = np.array([waypoint])

            moveable_root = moveables_trees[0].root()
            start_positions, end_positions = _calculate_positions(
                    moveable_root, self.starts[0], self.finals[0])

            step["start_positions"] = start_positions
            step["positions"] = end_positions

            yield step

    def run(self, *args):
        try:
            for step in self._gScan.step_scan():
                yield step
        except Exception:
            pass
        finally:
            if not self._flg_cleanup:
                self._post_cleanup_hook()

    def getTimeEstimation(self):
        return 0.0

    def getIntervalEstimation(self):
        return self.nr_interv

    @property
    def nr_points(self):
        msg = ("nr_points is deprecated since version 3.0.3. "
               "Use nb_points instead.")
        self.warning(msg)
        return self.nb_points


```
To run %qExafsc 13000 [[13100 100] [13400 200] [13800 400]] 0.01
