### PR TITLE
fix: `not DevFailed` exception catching

### DIFF
--- a/src/sardana/tango/pool/CTExpChannel.py
+++ b/src/sardana/tango/pool/CTExpChannel.py
@@ -93,7 +93,9 @@ class CTExpChannel(PoolTimerableDevice):
     def on_ct_changed(self, event_source, event_type, event_value):
         try:
             self._on_ct_changed(event_source, event_type, event_value)
-        except not DevFailed:
+        except DevFailed:
+            raise
+        except:
             msg = 'Error occurred "on_ct_changed(%s.%s): %s"'
             exc_info = sys.exc_info()
             self.error(msg, self.motor.name, event_type.name,

--- a/src/sardana/tango/pool/IORegister.py
+++ b/src/sardana/tango/pool/IORegister.py
@@ -120,7 +120,9 @@ class IORegister(PoolElementDevice):
     def on_ior_changed(self, event_source, event_type, event_value):
         try:
             self._on_ior_changed(event_source, event_type, event_value)
-        except not DevFailed:
+        except DevFailed:
+            raise
+        except:
             msg = 'Error occurred "on_ior_changed(%s.%s): %s"'
             exc_info = sys.exc_info()
             self.error(msg, self.ior.name, event_type.name,

--- a/src/sardana/tango/pool/Motor.py
+++ b/src/sardana/tango/pool/Motor.py
@@ -356,7 +356,9 @@ with this value is sent to clients using events.
     def on_motor_changed(self, event_source, event_type, event_value):
         try:
             self._on_motor_changed(event_source, event_type, event_value)
-        except not DevFailed:
+        except DevFailed:
+            raise
+        except:
             msg = 'Error occurred "on_motor_changed(%s.%s): %s"'
             exc_info = sys.exc_info()
             self.error(msg, self.motor.name, event_type.name,

--- a/src/sardana/tango/pool/OneDExpChannel.py
+++ b/src/sardana/tango/pool/OneDExpChannel.py
@@ -92,7 +92,9 @@ class OneDExpChannel(PoolTimerableDevice):
     def on_oned_changed(self, event_source, event_type, event_value):
         try:
             self._on_oned_changed(event_source, event_type, event_value)
-        except not DevFailed:
+        except DevFailed:
+            raise
+        except:
             msg = 'Error occurred "on_oned_changed(%s.%s): %s"'
             exc_info = sys.exc_info()
             self.error(msg, self.motor.name, event_type.name,

--- a/src/sardana/tango/pool/TriggerGate.py
+++ b/src/sardana/tango/pool/TriggerGate.py
@@ -91,7 +91,9 @@ class TriggerGate(PoolElementDevice):
     def on_tg_changed(self, event_source, event_type, event_value):
         try:
             self._on_tg_changed(event_source, event_type, event_value)
-        except not DevFailed:
+        except DevFailed:
+            raise
+        except:
             msg = 'Error occurred "on_tg_changed(%s.%s): %s"'
             exc_info = sys.exc_info()
             self.error(msg, event_type.name,

--- a/src/sardana/tango/pool/TwoDExpChannel.py
+++ b/src/sardana/tango/pool/TwoDExpChannel.py
@@ -93,7 +93,9 @@ class TwoDExpChannel(PoolTimerableDevice):
     def on_twod_changed(self, event_source, event_type, event_value):
         try:
             self._on_twod_changed(event_source, event_type, event_value)
-        except not DevFailed:
+        except DevFailed:
+            raise
+        except:
             msg = 'Error occurred "on_twod_changed(%s.%s): %s"'
             exc_info = sys.exc_info()
             self.error(msg, self.motor.name, event_type.name,


### PR DESCRIPTION
`not DevFailed` evaluates to False and can not be used to catch
exceptions. Otherwise we get "TypeError: catching classes that do
not inherit from BaseException is not allowed"

I will auto-merge since this is a trivial change.