### PR TITLE
Allow reading Door Status when macros are stopping

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -2239,6 +2239,12 @@ class Macro(Logger):
         return self._parent_macro
 
     @property
+    def _command(self):
+        """**Unofficial Macro API**. Alternative to getCommand that does not
+        throw StopException in case of a Stop."""
+        return '%s %s' % (self._getName(), ' '.join([str(p) for p in self._in_pars]))
+
+    @property
     def description(self):
         """**Unofficial Macro API**. Alternative to :meth:`getDescription` that
         does not throw StopException in case of a Stop. This should be

--- a/src/sardana/tango/macroserver/Door.py
+++ b/src/sardana/tango/macroserver/Door.py
@@ -303,9 +303,9 @@ class Door(SardanaDevice):
         macro = self.getRunningMacro()
         mstack = ''
         while macro is not None:
-            mstate = macro.getMacroStatus()['state']
-            mstack = '\n    -[%s]\t%s' % (mstate, macro.getCommand()) + mstack
-            macro = macro.getParentMacro()
+            mstate = macro._getMacroStatus()['state']
+            mstack = '\n    -[%s]\t%s' % (mstate, macro._command) + mstack
+            macro = macro.parent_macro
         self._status += mstack
         return self._status
 


### PR DESCRIPTION
This fixes a deadlock that happens if someone happens to read Status of the Door exactly while a scan is stopping. 
The problem is that the Status command takes the TangoMonitor of the Door device server, and then dev_status calls methods that are decorated by mAPI. This makes it wait until the running macro has stopped. It's holding the Monitor for this entire time and that causes all kinds of trouble. For example the logging fails on `push_change_event()`, and there are change events on other attributes as well during the stopping procedure. Every such attempt will fail with:
```
PyTango.DevFailed: DevFailed[
DevError[
    desc = Not able to acquire serialization (dev, class or process) monitor
  origin = TangoMonitor::get_monitor
  reason = API_CommandTimedOut
severity = ERR]
]
``` 