### PR TITLE
Add gitlab-ci pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,66 @@
+---
+stages:
+  - build
+  - test
+  - deploy
+
+build-pypi-package:
+  stage: build
+  image: python:3.9
+  script:
+    - python setup.py check sdist bdist_wheel
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - dist/
+
+run-test:
+  stage: test
+  image: reszelaz/sardana-test
+  before_script:
+    - python3 -m pip install dist/sardana-*.whl
+    - export TANGO_HOST=$(hostname):10000
+    - /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+    - sleep 10
+    - supervisorctl start Pool
+    - supervisorctl start MacroServer
+  script:
+    - xvfb-run -s '-screen 0 1920x1080x24' /bin/bash -c "pytest /usr/local/lib/python3.5/dist-packages/sardana"
+
+build-doc:
+  stage: test
+  image: reszelaz/sardana-test
+  script:
+    - xvfb-run sphinx-build -qW doc/source/ public
+    - echo "Documentation can be found at https://$CI_PROJECT_NAMESPACE.gitlab.io/-/$CI_PROJECT_NAME/-/jobs/$CI_JOB_ID/artifacts/public/index.html"
+  artifacts:
+    paths:
+      - public
+  environment:
+    name: Docs-dev
+    url: "https://$CI_PROJECT_NAMESPACE.gitlab.io/-/$CI_PROJECT_NAME/-/jobs/$CI_JOB_ID/artifacts/public/index.html"
+
+pages:
+  stage: deploy
+  image: alpine
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - echo "Deploying already-built docs"
+  artifacts:
+    paths:
+      - public
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+.*$/'
+
+release-pypi-package:
+  stage: deploy
+  image: python:3.9
+  variables:
+    GIT_STRATEGY: none
+  before_script:
+    - pip install twine
+  script:
+    - twine upload dist/*
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+.*$/'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,8 @@ build-pypi-package:
 run-test:
   stage: test
   image: reszelaz/sardana-test
+  variables:
+    GIT_STRATEGY: none
   before_script:
     - python3 -m pip install dist/sardana-*.whl
     - export TANGO_HOST=$(hostname):10000

--- a/doc/source/other_versions.rst
+++ b/doc/source/other_versions.rst
@@ -1,25 +1,20 @@
-
 ===============================
 Docs for other Sardana versions
 ===============================
 
-The `main Sardana docs <http://sardana-controls.org>`_ are generated for the
-most recent development version.
+The `default sardana docs <http://sardana-controls.org>`_ reflect the latest tagged
+version in the repository.
 
-You can still generate the docs for other versions of Sardana. In order to do that
-you first need to clone the `Sardana repository <https://github.com/sardana-org/sardana>`_,
-checkout the necessary version and build the docs (this may require you to install 
-some dependencies apart from the sardana ones, such as sphinx).
+Docs are also built as artifacts by the CI pipeline for each ref (branch or tag)
+pushed to the repository, and they can be browsed as well using the following
+URL change (REF) by the branch or tag name for which you want to see the docs:
 
-In continuation you can find an example of how to do it for version ``2.8.3``:
+`https://gitlab.com/sardana-org/sardana/-/jobs/artifacts/REF/file/public/index.html?job=doc`
 
-.. code-block:: console
+For example, to check the docs for the latest push to `develop`, visit:
 
-    git clone -b 2.8.3 https://github.com/sardana-org/sardana
-    cd sardana
-    python setup.py build_sphinx
-    firefox build/sphinx/html/index.html
+https://gitlab.com/sardana-org/sardana/-/jobs/artifacts/develop/file/public/index.html?job=doc
 
-.. note::
-   Sardana versions >= 3 work only with Python 3. Then you will need to build
-   the documentation with ``python3`` instead of ``python``.
+Note that the docs are also automatically built by the pipelines triggered by
+Merge Requests. They can be viewed using the "View App" button in the given
+Merge Request page.


### PR DESCRIPTION
Prepare migration to GitLab.

Pipeline was tested here: https://gitlab.com/beenje/sardana/-/pipelines/379922351
And here with a dummy tag: https://gitlab.com/beenje/sardana/-/pipelines/379934485
The release to PyPi of course failed because I didn't define any credentials. The variables `TWINE_USERNAME` and `TWINE_PASSWORD` shall be defined in the CI/CD settings of the project.