### PR TITLE
runMacro executed twice does not work anymore

### DIFF
--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -2346,8 +2346,10 @@ class Macro(Logger):
         # Avoid repeating same information on subsequent events. If, in the
         # future, clients that connect in the middle of macro execution need
         # this information, just simply remove the lines below
-        del macro_status['name']
-        del macro_status['macro_line']
+        if 'name' in macro_status:
+            del macro_status['name']
+        if 'macro_line' in macro_status:
+            del macro_status['macro_line']
 
         # allow any macro to be paused at the beginning of its execution
         self.pausePoint()

--- a/src/sardana/macroserver/macro.py
+++ b/src/sardana/macroserver/macro.py
@@ -2346,10 +2346,8 @@ class Macro(Logger):
         # Avoid repeating same information on subsequent events. If, in the
         # future, clients that connect in the middle of macro execution need
         # this information, just simply remove the lines below
-        if 'name' in macro_status:
-            del macro_status['name']
-        if 'macro_line' in macro_status:
-            del macro_status['macro_line']
+        macro_status.pop('name', None)
+        macro_status.pop('macro_line', None)
 
         # allow any macro to be paused at the beginning of its execution
         self.pausePoint()

--- a/src/sardana/macroserver/test/res/macros/testmacros.py
+++ b/src/sardana/macroserver/test/res/macros/testmacros.py
@@ -71,6 +71,24 @@ class runMacro(Macro):
         msg = FAIL_MSG % (result, expected_params)
         assert expected_params == result, msg
 
+        params = "pt0_base"
+        macro, _ = self.prepareMacro(params)
+        expected_params = 1
+        self.runMacro(macro)
+        result = macro.data
+        msg = FAIL_MSG % (result, expected_params)
+        assert expected_params == result, msg
+        expected_params = 2
+        self.runMacro(macro)
+        result = macro.data
+        msg = FAIL_MSG % (result, expected_params)
+        assert expected_params == result, msg
+        expected_params = 3
+        self.runMacro(macro)
+        result = macro.data
+        msg = FAIL_MSG % (result, expected_params)
+        assert expected_params == result, msg
+
 
 class createMacro(Macro):
     """
@@ -136,6 +154,24 @@ class createMacro(Macro):
         params = "pt10_base 91 True"
         expected_params = ([91], True)
         macro, _ = self.createMacro(params)
+        self.runMacro(macro)
+        result = macro.data
+        msg = FAIL_MSG % (result, expected_params)
+        assert expected_params == result, msg
+
+        params = "pt0_base"
+        macro, _ = self.createMacro(params)
+        expected_params = 1
+        self.runMacro(macro)
+        result = macro.data
+        msg = FAIL_MSG % (result, expected_params)
+        assert expected_params == result, msg
+        expected_params = 2
+        self.runMacro(macro)
+        result = macro.data
+        msg = FAIL_MSG % (result, expected_params)
+        assert expected_params == result, msg
+        expected_params = 3
         self.runMacro(macro)
         result = macro.data
         msg = FAIL_MSG % (result, expected_params)
@@ -207,6 +243,21 @@ class execMacro(Macro):
         msg = FAIL_MSG % (result, expected_params)
         assert expected_params == result, msg
 
+        params = "pt0_base"
+        expected_params = 1
+        macro = self.execMacro(params)
+        result = macro.data
+        msg = FAIL_MSG % (result, expected_params)
+        assert expected_params == result, msg
+        macro = self.execMacro(params)
+        result = macro.data
+        msg = FAIL_MSG % (result, expected_params)
+        assert expected_params == result, msg
+        macro = self.execMacro(params)
+        result = macro.data
+        msg = FAIL_MSG % (result, expected_params)
+        assert expected_params == result, msg
+
 
 class pt6_base(Macro):
     """Macro with a number parameter followed by a list of numbers.
@@ -241,3 +292,13 @@ class pt10_base(Macro):
 
     def run(self, *args, **kwargs):
         self.data = args
+
+class pt0_base(Macro):
+    """Macro counter.
+    """
+
+    def run(self, *args, **kwargs):
+        try:
+            self.data += 1
+        except Exception as e:
+            self.data = 1

--- a/src/sardana/macroserver/test/res/macros/testmacros.py
+++ b/src/sardana/macroserver/test/res/macros/testmacros.py
@@ -294,7 +294,7 @@ class pt10_base(Macro):
         self.data = args
 
 class pt0_base(Macro):
-    """Macro counter.
+    """Test counter Macro.
     """
 
     def run(self, *args, **kwargs):


### PR DESCRIPTION
At DESY we execute runMacro() twice on the same object. 
However, after the change 

  https://github.com/sardana-org/sardana/pull/1476/files

it does not work anymore because you cannot delete an object from the macro_status dictionary which does not exist anymore.
Therefore if it is allowed to runMacro twice it would be good to check before deleting 'name' and  'macro_line' if they exist in the dictionary.
Otherwise if running macro twice it is forbidden (I hope not) It should be thrown an exception informing users that running macro twice is forbidden.  