### PR TITLE
Allow to disable global timer/monitor channel

### DIFF
--- a/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
+++ b/src/sardana/taurus/qt/qtgui/extra_sardana/expdescription.py
@@ -539,6 +539,13 @@ class ExpDescriptionEditor(Qt.QWidget, TaurusBaseWidget):
         if self.ui.channelEditor.getQModel().isDataChanged():
             self._dirtyMntGrps.add(self._localConfig['ActiveMntGrp'])
 
+        mgconfs = conf.get('MntGrpConfigs', {})
+        
+        for mgname in self._dirtyMntGrps:
+            mgconf = mgconfs[mgname]
+            mgconf.pop('timer', None)
+            mgconf.pop('monitor', None)
+            
         door = self.getModelObj()
         try:
             door.setExperimentConfiguration(conf, mnt_grps=self._dirtyMntGrps)


### PR DESCRIPTION
ExpConf gui does not allow to disable a channel if it was designed as global timer or monitor.

Fix #1700